### PR TITLE
updated nonnestedstringformat analyzer (PR1115)

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -23,7 +23,7 @@
     <Copyright>© 2019 Koninklijke Philips N.V.</Copyright>
     <PackageTags>CSharp MsTest Roslyn CodeAnalysis analyzers Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Philips.CodeAnalysis.Test/NoNestedStringFormatsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/NoNestedStringFormatsAnalyzerTest.cs
@@ -1,6 +1,4 @@
-﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
-
-using System;
+﻿using System;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Philips.CodeAnalysis.Common;
@@ -96,21 +94,53 @@ class Foo
 			const string template = @"
 using System;
 
-static class StringHelper
+namespace Philips.Platform
+{
+public static class StringHelper
 {
 	public static string Format(string format, params object[] args)
 	{
 		return string.Empty;
 	}
 }
+}
 
 class Foo
 {
 	public void Test()
 	{
-		string t = StringHelper.Format(""test"");
+		string t = Philips.Platform.StringHelper.Format(""test"");
 	}
 }
+";
+
+			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
+		}
+
+		[DataRow("{0}")]
+		[DataRow("{1}")]
+		[DataTestMethod]
+		public void DontStringFormatUselessly2a(string arg)
+		{
+			string template = $@"
+using System;
+
+class Log
+{{
+	public void Err(string format, params object[] args)
+	{{
+	}}
+
+	public Log Platform {{ get; }}
+}}
+
+class Foo
+{{
+	public void Test()
+	{{
+		Log.Platform.Err(""{arg}"");
+	}}
+}}
 ";
 
 			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));


### PR DESCRIPTION
Prevent crashes in analyzer due to the assumption that Format("{0}") will have at least 1 argument