### PR TITLE
Add developmentDependency flag

### DIFF
--- a/Philips.CodeAnalysis.DuplicateCodeAnalyzer/Philips.CodeAnalysis.DuplicateCodeAnalyzer.csproj
+++ b/Philips.CodeAnalysis.DuplicateCodeAnalyzer/Philips.CodeAnalysis.DuplicateCodeAnalyzer.csproj
@@ -8,7 +8,6 @@
 
   <PropertyGroup>
     <PackageId>Philips.CodeAnalysis.DuplicateCodeAnalyzer</PackageId>
-    <PackageVersion>1.0.0</PackageVersion>
     <Authors>Brian Collamore, Jean-Paul Mayer</Authors>
     <PackageLicenseUrl>https://github.com/philips-software/roslyn-analyzers/blob/master/LICENSE.md</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/philips-software/roslyn-analyzers</RepositoryUrl>
@@ -22,6 +21,9 @@
     <Copyright>© 2020 Koninklijke Philips N.V.</Copyright>
     <PackageTags>CSharp MsTest Roslyn CodeAnalysis analyzers cpd duplicate Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
+    <DevelopmentDependency>true</DevelopmentDependency>
+    <Version>1.0.1</Version>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -8,7 +8,6 @@
 
   <PropertyGroup>
     <PackageId>Philips.CodeAnalysis.MaintainabilityAnalyzers</PackageId>
-    <PackageVersion>1.0.3</PackageVersion>
     <Authors>Brian Collamore, Jean-Paul Mayer</Authors>
     <Company>Philips</Company>
     <PackageLicenseUrl>https://github.com/philips-software/roslyn-analyzers/blob/master/LICENSE.md</PackageLicenseUrl>
@@ -23,7 +22,9 @@
     <Copyright>© 2019 Koninklijke Philips N.V.</Copyright>
     <PackageTags>CSharp MsTest Roslyn CodeAnalysis analyzers Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
-    <Version>1.0.3</Version>
+    <DevelopmentDependency>true</DevelopmentDependency>
+    <Version>1.0.4</Version>
+    <AssemblyVersion>1.0.3.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Philips.CodeAnalysis.MoqAnalyzers/Philips.CodeAnalysis.MoqAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MoqAnalyzers/Philips.CodeAnalysis.MoqAnalyzers.csproj
@@ -8,7 +8,6 @@
 
   <PropertyGroup>
     <PackageId>Philips.CodeAnalysis.MoqAnalyzers</PackageId>
-    <PackageVersion>1.0.0</PackageVersion>
     <Authors>Brian Collamore, Jean-Paul Mayer</Authors>
     <Company>Philips</Company>
     <PackageLicenseUrl>https://github.com/philips-software/roslyn-analyzers/blob/master/LICENSE.md</PackageLicenseUrl>
@@ -23,6 +22,9 @@
     <Copyright>© 2019 Koninklijke Philips N.V.</Copyright>
     <PackageTags>CSharp MsTest Roslyn CodeAnalysis analyzers moq Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
+    <DevelopmentDependency>true</DevelopmentDependency>
+    <Version>1.0.1</Version>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Philips.CodeAnalysis.MsTestAnalyzers/Philips.CodeAnalysis.MsTestAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/Philips.CodeAnalysis.MsTestAnalyzers.csproj
@@ -23,7 +23,9 @@
     <Copyright>© 2019 Koninklijke Philips N.V.</Copyright>
     <PackageTags>CSharp MsTest Roslyn CodeAnalysis analyzers Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
-    <Version>1.0.1</Version>
+    <DevelopmentDependency>true</DevelopmentDependency>
+    <Version>1.0.2</Version>
+    <AssemblyVersion>1.0.1.0</AssemblyVersion>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
 such that PrivateAssets is set and the analyzer does not transitively flow to clients' deployments
https://docs.microsoft.com/en-us/dotnet/core/tools/csproj
