### PR TITLE
Mayerj/optimize duplicate code

### DIFF
--- a/Philips.CodeAnalysis.Benchmark/Philips.CodeAnalysis.Benchmark.csproj
+++ b/Philips.CodeAnalysis.Benchmark/Philips.CodeAnalysis.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Philips.CodeAnalysis.Benchmark/Philips.CodeAnalysis.Benchmark.csproj
+++ b/Philips.CodeAnalysis.Benchmark/Philips.CodeAnalysis.Benchmark.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Philips.CodeAnalysis.DuplicateCodeAnalyzer\Philips.CodeAnalysis.DuplicateCodeAnalyzer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Philips.CodeAnalysis.Benchmark/Program.cs
+++ b/Philips.CodeAnalysis.Benchmark/Program.cs
@@ -14,7 +14,7 @@ namespace Philips.CodeAnalysis.Benchmark
 	{
 		public static void Main(string[] args)
 		{
-			var summary = BenchmarkRunner.Run<DuplicationDetectorBenchmark>();
+			_ = BenchmarkRunner.Run<DuplicationDetectorBenchmark>();
 		}
 	}
 
@@ -80,7 +80,7 @@ namespace Philips.CodeAnalysis.Benchmark
 
 					if (rollingTokenSet.IsFull())
 					{
-						Evidence existingEvidence = _library.TryAdd(hash, evidence);
+						_ = _library.TryAdd(hash, evidence);
 					}
 				}
 			});

--- a/Philips.CodeAnalysis.Benchmark/Program.cs
+++ b/Philips.CodeAnalysis.Benchmark/Program.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
@@ -69,11 +68,11 @@ namespace Philips.CodeAnalysis.Benchmark
 				}
 			}
 		}
-		private void TestDictionary(DuplicateDetectorDictionary _library, Func<RollingHashCalculator<TokenInfo>> calc = null)
+		private void TestDictionary(DuplicateDetectorDictionary _library, int baseModulus, int modulus)
 		{
 			A.Data.AsParallel().ForAll(kvp =>
 			{
-				var rollingTokenSet = calc == null ? new RollingTokenSet(100) : new RollingTokenSet(calc());
+				var rollingTokenSet = new RollingTokenSet(new RollingHashCalculator<TokenInfo>(100, baseModulus, modulus));
 
 				foreach (var list in kvp.Value)
 				{
@@ -88,52 +87,19 @@ namespace Philips.CodeAnalysis.Benchmark
 		}
 
 		[Benchmark]
-		public void Existing()
+		public void OriginalHashParameters()
 		{
-			DuplicateDetectorDictionary _library = new OriginalDuplicateDetectorDictionary();
+			DuplicateDetectorDictionary _library = new DuplicateDetectorDictionary();
 
-			TestDictionary(_library);
+			TestDictionary(_library, 2048, 1723);
 		}
 
 		[Benchmark]
 		public void ExistingBiggerPrimes()
 		{
-			DuplicateDetectorDictionary _library = new OriginalDuplicateDetectorDictionary();
+			DuplicateDetectorDictionary _library = new DuplicateDetectorDictionary();
 
-			TestDictionary(_library, () => new RollingHashCalculator<TokenInfo>(100, 227, 1000005));
-		}
-
-
-		[Benchmark]
-		public void NestedHash()
-		{
-			DuplicateDetectorDictionary _library = new NestedHashDuplicateDetectorDictionary();
-
-			TestDictionary(_library);
-		}
-
-		[Benchmark]
-		public void NestedHashLockingFix()
-		{
-			DuplicateDetectorDictionary _library = new NestedHashDuplicateDetectorDictionary();
-
-			TestDictionary(_library);
-		}
-
-		[Benchmark]
-		public void NestedHashBiggerPrimes()
-		{
-			DuplicateDetectorDictionary _library = new NestedHashDuplicateDetectorDictionary();
-
-			TestDictionary(_library, () => new RollingHashCalculator<TokenInfo>(100, 227, 1000005));
-		}
-
-		[Benchmark]
-		public void NestedHashLockingFixBiggerPrimes()
-		{
-			DuplicateDetectorDictionary _library = new NestedHashDuplicateDetectorDictionary();
-
-			TestDictionary(_library, () => new RollingHashCalculator<TokenInfo>(100, 227, 1000005));
+			TestDictionary(_library, 227, 1000005);
 		}
 	}
 }

--- a/Philips.CodeAnalysis.Benchmark/Program.cs
+++ b/Philips.CodeAnalysis.Benchmark/Program.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Philips.CodeAnalysis.DuplicateCodeAnalyzer;
+
+namespace Philips.CodeAnalysis.Benchmark
+{
+	public class Program
+	{
+		public static void Main(string[] args)
+		{
+			var summary = BenchmarkRunner.Run<DuplicationDetectorBenchmark>();
+		}
+	}
+
+	public class Input
+	{
+		public string Folder { get; set; }
+		public Dictionary<MethodDeclarationSyntax, IEnumerable<SyntaxToken>> Data { get; set; }
+
+		public override string ToString()
+		{
+			return Folder;
+		}
+	}
+
+	[SimpleJob(launchCount: 3, warmupCount: 2, targetCount: 5)]
+	public class DuplicationDetectorBenchmark
+	{
+		[ParamsSource(nameof(ValuesForA))]
+		public Input A { get; set; }
+
+		// public property
+		public IEnumerable<Input> ValuesForA
+		{
+			get
+			{
+				foreach (var dir in new string[] { })
+				{
+					Dictionary<MethodDeclarationSyntax, IEnumerable<SyntaxToken>> tokens = new Dictionary<MethodDeclarationSyntax, IEnumerable<SyntaxToken>>();
+
+					foreach (var file in Directory.EnumerateFiles(dir, "*.cs", SearchOption.AllDirectories))
+					{
+						if (!file.EndsWith(".cs"))
+						{
+							continue;
+						}
+
+						var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(file), new CSharpParseOptions(LanguageVersion.Latest));
+
+						foreach (var method in tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>())
+						{
+							if (method.Body is null)
+							{
+								continue;
+							}
+
+							tokens[method] = method.Body.DescendantTokens();
+						}
+					}
+
+					yield return new Input { Data = tokens, Folder = dir };
+				}
+			}
+		}
+		private void TestDictionary(DuplicateDetectorDictionary _library, Func<RollingHashCalculator<TokenInfo>> calc = null)
+		{
+			A.Data.AsParallel().ForAll(kvp =>
+			{
+				var rollingTokenSet = calc == null ? new RollingTokenSet(100) : new RollingTokenSet(calc());
+
+				foreach (var list in kvp.Value)
+				{
+					(int hash, Evidence evidence) = rollingTokenSet.Add(new TokenInfo(list));
+
+					if (rollingTokenSet.IsFull())
+					{
+						Evidence existingEvidence = _library.TryAdd(hash, evidence);
+					}
+				}
+			});
+		}
+
+		[Benchmark]
+		public void Existing()
+		{
+			DuplicateDetectorDictionary _library = new OriginalDuplicateDetectorDictionary();
+
+			TestDictionary(_library);
+		}
+
+		[Benchmark]
+		public void ExistingBiggerPrimes()
+		{
+			DuplicateDetectorDictionary _library = new OriginalDuplicateDetectorDictionary();
+
+			TestDictionary(_library, () => new RollingHashCalculator<TokenInfo>(100, 227, 1000005));
+		}
+
+
+		[Benchmark]
+		public void NestedHash()
+		{
+			DuplicateDetectorDictionary _library = new NestedHashDuplicateDetectorDictionary();
+
+			TestDictionary(_library);
+		}
+
+		[Benchmark]
+		public void NestedHashLockingFix()
+		{
+			DuplicateDetectorDictionary _library = new NestedHashDuplicateDetectorDictionary();
+
+			TestDictionary(_library);
+		}
+
+		[Benchmark]
+		public void NestedHashBiggerPrimes()
+		{
+			DuplicateDetectorDictionary _library = new NestedHashDuplicateDetectorDictionary();
+
+			TestDictionary(_library, () => new RollingHashCalculator<TokenInfo>(100, 227, 1000005));
+		}
+
+		[Benchmark]
+		public void NestedHashLockingFixBiggerPrimes()
+		{
+			DuplicateDetectorDictionary _library = new NestedHashDuplicateDetectorDictionary();
+
+			TestDictionary(_library, () => new RollingHashCalculator<TokenInfo>(100, 227, 1000005));
+		}
+	}
+}

--- a/Philips.CodeAnalysis.Benchmark/Program.cs
+++ b/Philips.CodeAnalysis.Benchmark/Program.cs
@@ -95,7 +95,7 @@ namespace Philips.CodeAnalysis.Benchmark
 		}
 
 		[Benchmark]
-		public void ExistingBiggerPrimes()
+		public void BiggerPrimes()
 		{
 			DuplicateDetectorDictionary _library = new DuplicateDetectorDictionary();
 

--- a/Philips.CodeAnalysis.DuplicateCodeAnalyzer/Philips.CodeAnalysis.DuplicateCodeAnalyzer.csproj
+++ b/Philips.CodeAnalysis.DuplicateCodeAnalyzer/Philips.CodeAnalysis.DuplicateCodeAnalyzer.csproj
@@ -23,9 +23,9 @@
     <PackageTags>CSharp MsTest Roslyn CodeAnalysis analyzers cpd duplicate Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <Version>1.1.1</Version>
+    <Version>1.1.2</Version>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.1.1.0</FileVersion>
+    <FileVersion>1.1.2.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Philips.CodeAnalysis.Test/AvoidDuplicateCodeTest.cs
+++ b/Philips.CodeAnalysis.Test/AvoidDuplicateCodeTest.cs
@@ -241,28 +241,26 @@ namespace Philips.CodeAnalysis.Test
 		[TestMethod]
 		public void DuplicateDictionaryTest()
 		{
-			foreach (var dictionary in new DuplicateDetectorDictionary[] { new OriginalDuplicateDetectorDictionary(), new NestedHashDuplicateDetectorDictionary(), new NestedHashLockingFixDuplicateDetectorDictionary() })
-			{
-				var e1 = new Evidence(null, new List<int>() { 10 }, 10);
+			var dictionary = new DuplicateDetectorDictionary();
+			var e1 = new Evidence(null, new List<int>() { 10 }, 10);
 
-				Evidence existing = dictionary.TryAdd(1, e1);
-				Assert.IsNull(existing);
+			Evidence existing = dictionary.TryAdd(1, e1);
+			Assert.IsNull(existing);
 
-				var e2 = new Evidence(null, new List<int>() { 20 }, 20);
+			var e2 = new Evidence(null, new List<int>() { 20 }, 20);
 
-				existing = dictionary.TryAdd(2, e2);
-				Assert.IsNull(existing);
+			existing = dictionary.TryAdd(2, e2);
+			Assert.IsNull(existing);
 
-				var e3 = new Evidence(null, new List<int>() { 30 }, 30);
+			var e3 = new Evidence(null, new List<int>() { 30 }, 30);
 
-				existing = dictionary.TryAdd(2, e3);
-				Assert.IsNull(existing);
+			existing = dictionary.TryAdd(2, e3);
+			Assert.IsNull(existing);
 
-				var e4 = new Evidence(null, new List<int>() { 30 }, 30);
+			var e4 = new Evidence(null, new List<int>() { 30 }, 30);
 
-				existing = dictionary.TryAdd(2, e4);
-				Assert.IsNotNull(existing);
-			}
+			existing = dictionary.TryAdd(2, e4);
+			Assert.IsNotNull(existing);
 		}
 
 		[DataTestMethod]

--- a/Philips.CodeAnalysis.Test/AvoidDuplicateCodeTest.cs
+++ b/Philips.CodeAnalysis.Test/AvoidDuplicateCodeTest.cs
@@ -241,30 +241,28 @@ namespace Philips.CodeAnalysis.Test
 		[TestMethod]
 		public void DuplicateDictionaryTest()
 		{
-			var dictionary = new DuplicateDetectorDictionary();
-			var e1 = new Evidence();
-			e1.Components = new List<int>();
-			e1.Components.Add(10);
-			Evidence existing = dictionary.TryAdd(1, e1);
-			Assert.IsNull(existing);
+			foreach (var dictionary in new DuplicateDetectorDictionary[] { new OriginalDuplicateDetectorDictionary(), new NestedHashDuplicateDetectorDictionary(), new NestedHashLockingFixDuplicateDetectorDictionary() })
+			{
+				var e1 = new Evidence(null, new List<int>() { 10 }, 10);
 
-			var e2 = new Evidence();
-			e2.Components = new List<int>();
-			e2.Components.Add(20);
-			existing = dictionary.TryAdd(2, e2);
-			Assert.IsNull(existing);
+				Evidence existing = dictionary.TryAdd(1, e1);
+				Assert.IsNull(existing);
 
-			var e3 = new Evidence();
-			e3.Components = new List<int>();
-			e3.Components.Add(30);
-			existing = dictionary.TryAdd(2, e3);
-			Assert.IsNull(existing);
+				var e2 = new Evidence(null, new List<int>() { 20 }, 20);
 
-			var e4 = new Evidence();
-			e4.Components = new List<int>();
-			e4.Components.Add(30);
-			existing = dictionary.TryAdd(2, e4);
-			Assert.IsNotNull(existing);
+				existing = dictionary.TryAdd(2, e2);
+				Assert.IsNull(existing);
+
+				var e3 = new Evidence(null, new List<int>() { 30 }, 30);
+
+				existing = dictionary.TryAdd(2, e3);
+				Assert.IsNull(existing);
+
+				var e4 = new Evidence(null, new List<int>() { 30 }, 30);
+
+				existing = dictionary.TryAdd(2, e4);
+				Assert.IsNotNull(existing);
+			}
 		}
 
 		[DataTestMethod]

--- a/Philips.CodeAnalysis.sln
+++ b/Philips.CodeAnalysis.sln
@@ -20,6 +20,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Philips.CodeAnalysis.Mainta
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Philips.CodeAnalysis.DuplicateCodeAnalyzer", "Philips.CodeAnalysis.DuplicateCodeAnalyzer\Philips.CodeAnalysis.DuplicateCodeAnalyzer.csproj", "{378CCB57-00DA-4782-A238-ADC134827B93}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Philips.CodeAnalysis.Benchmark", "Philips.CodeAnalysis.Benchmark\Philips.CodeAnalysis.Benchmark.csproj", "{D9B847FB-E395-4875-86E9-C69B47B8D77C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -50,6 +52,10 @@ Global
 		{378CCB57-00DA-4782-A238-ADC134827B93}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{378CCB57-00DA-4782-A238-ADC134827B93}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{378CCB57-00DA-4782-A238-ADC134827B93}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D9B847FB-E395-4875-86E9-C69B47B8D77C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9B847FB-E395-4875-86E9-C69B47B8D77C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9B847FB-E395-4875-86E9-C69B47B8D77C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9B847FB-E395-4875-86E9-C69B47B8D77C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This has several (small) performance improvements to the duplicate code analyzer.  Things like pre-allocating a list if we know the intended length, not creating the LocationEnvelopes until they are necessary, etc.

It also includes a change to the rolling hash algorithm, increasing the bucket count enormously.  On large projects the small bucket count was causing large numbers of collisions, which are extremely slow to resolve.

From the benchmarking: (2 input projects, one a "small" amount of code, one "large").

|                           Method |                    A |     Mean |    Error |   StdDev |
|--------------------------------- |--------------------- |---------:|---------:|---------:|
|                         OriginalHashParameters | C:\Ph(...)vices [56] |  4.545 s | 0.2088 s | 0.1630 s |
|             BiggerPrimes | C:\Ph(...)vices [56] |  1.122 s | 0.1357 s | 0.1203 s |
|                         OriginalHashParameters | C:\Ph(...).Auto [62] | 26.736 s | 0.8556 s | 0.7144 s |
|             BiggerPrimes | C:\Ph(...).Auto [62] |  3.344 s | 0.7255 s | 0.6432 s |

See [mayerj/performance-test](https://github.com/philips-software/roslyn-analyzers/tree/mayerj/performance-test) for more performance tests