### PR TITLE
mayerj add support for default, and handle Assert.AreEqual<string>(x, y)

### DIFF
--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertMethodCallDiagnosticAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertMethodCallDiagnosticAnalyzer.cs
@@ -63,6 +63,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			});
 		}
 
+
 		#endregion
 	}
 }

--- a/Philips.CodeAnalysis.MsTestAnalyzers/Philips.CodeAnalysis.MsTestAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/Philips.CodeAnalysis.MsTestAnalyzers.csproj
@@ -24,9 +24,9 @@
     <PackageTags>CSharp MsTest Roslyn CodeAnalysis analyzers Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <AssemblyVersion>1.0.1.0</AssemblyVersion>
-    <FileVersion>1.1.0</FileVersion>
+    <FileVersion>1.1.1</FileVersion>
   </PropertyGroup>
   
   <ItemGroup>

--- a/Philips.CodeAnalysis.Test/AssertAreEqualAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/AssertAreEqualAnalyzerTest.cs
@@ -1,0 +1,72 @@
+// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Philips.CodeAnalysis.Common;
+using Philips.CodeAnalysis.MsTestAnalyzers;
+
+namespace Philips.CodeAnalysis.Test
+{
+	[TestClass]
+	public class AssertAreEquaAnalyzerTest : AssertCodeFixVerifier
+	{
+		#region Non-Public Data Members
+
+		#endregion
+
+		#region Non-Public Properties/Methods
+
+		protected override DiagnosticResult GetExpectedDiagnostic(int expectedLineNumberErrorOffset = 0, int expectedColumnErrorOffset = 0)
+		{
+			return new DiagnosticResult()
+			{
+				Id = Helper.ToDiagnosticId(DiagnosticIds.AssertAreEqual),
+				Location = new DiagnosticResultLocation("Test0.cs", null, null),
+				Severity = Microsoft.CodeAnalysis.DiagnosticSeverity.Error,
+			};
+		}
+
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		{
+			return new AssertAreEqualAnalyzer();
+		}
+
+		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		{
+			return new AssertAreEqualCodeFixProvider();
+		}
+
+		#endregion
+
+		#region Public Interface
+
+		[TestMethod]
+		public void CheckDefaultBehavior()
+		{
+			VerifyNoError(@"
+string GetValue()
+{
+	return string.Empty;
+}
+
+Assert.AreEqual(default, GetValue());
+");
+		}
+
+		[TestMethod]
+		public void CheckWillIgnoreTypeArgument()
+		{
+			VerifyError(@"
+string GetValue()
+{
+	return string.Empty;
+}
+
+Assert.AreEqual<string>(GetValue(), null);
+");
+		}
+
+		#endregion
+	}
+}

--- a/Philips.CodeAnalysis.Test/Verifiers/AssertCodeFixVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/AssertCodeFixVerifier.cs
@@ -66,6 +66,13 @@ namespace Philips.CodeAnalysis.Test
 			VerifyError(methodBody, string.Empty, expectedErrorLineOffset, expectedErrorColumnOffset, error);
 		}
 
+		protected void VerifyNoError(string methodBody)
+		{
+			var test = _helper.GetText(methodBody, OtherClassSyntax, string.Empty);
+
+			VerifyCSharpDiagnostic(test);
+		}
+
 		protected override MetadataReference[] GetMetadataReferences()
 		{
 			return _helper.GetMetaDataReferences();


### PR DESCRIPTION
Closes #31 