### PR TITLE
Handle -1 and other trivial constants so that the analyzer correctly reports that it should be expected, then actual for Assert.AreEqual

### DIFF
--- a/Philips.CodeAnalysis.Common/Helper.cs
+++ b/Philips.CodeAnalysis.Common/Helper.cs
@@ -342,9 +342,7 @@ namespace Philips.CodeAnalysis.Common
 		public static bool IsConstantExpression(ExpressionSyntax expression, SemanticModel semanticModel)
 		{
 			// this assumes you've already checked for literals
-
-			MemberAccessExpressionSyntax memberAccess = expression as MemberAccessExpressionSyntax;
-			if (memberAccess != null)
+			if (expression is MemberAccessExpressionSyntax memberAccess)
 			{
 				// return true for member accesses that resolve to a constant e.g. SurveillanceConstants.TrendWidth
 				Optional<object> constValue = semanticModel.GetConstantValue(expression);
@@ -352,14 +350,10 @@ namespace Philips.CodeAnalysis.Common
 			}
 			else
 			{
-				TypeOfExpressionSyntax typeOfExpression = expression as TypeOfExpressionSyntax;
-				if (typeOfExpression != null)
+				if (expression is TypeOfExpressionSyntax typeOfExpression && typeOfExpression.Type is PredefinedTypeSyntax)
 				{
-					if (typeOfExpression.Type is PredefinedTypeSyntax)
-					{
-						// return true for typeof(<static type>)
-						return true;
-					}
+					// return true for typeof(<static type>)
+					return true;
 				}
 			}
 

--- a/Philips.CodeAnalysis.Common/Helper.cs
+++ b/Philips.CodeAnalysis.Common/Helper.cs
@@ -342,7 +342,7 @@ namespace Philips.CodeAnalysis.Common
 		public static bool IsConstantExpression(ExpressionSyntax expression, SemanticModel semanticModel)
 		{
 			// this assumes you've already checked for literals
-			if (expression is MemberAccessExpressionSyntax memberAccess)
+			if (expression is MemberAccessExpressionSyntax)
 			{
 				// return true for member accesses that resolve to a constant e.g. SurveillanceConstants.TrendWidth
 				Optional<object> constValue = semanticModel.GetConstantValue(expression);

--- a/Philips.CodeAnalysis.Test/AssertAreEqualAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/AssertAreEqualAnalyzerTest.cs
@@ -54,6 +54,68 @@ Assert.AreEqual(default, GetValue());
 ");
 		}
 
+		[DataRow(true, null, "-1", true)]
+		[DataRow(true, null, "1", true)]
+		[DataRow(true, null, "0", true)]
+		[DataRow(true, null, "-1u", true)]
+		[DataRow(true, null, "1u", true)]
+		[DataRow(true, null, "0u", true)]
+		[DataRow(true, "-1", null, false)]
+		[DataRow(true, "1", null, false)]
+		[DataRow(true, "0", null, false)]
+		[DataRow(true, "-1u", null, false)]
+		[DataRow(true, "1u", null, false)]
+		[DataRow(true, "0u", null, false)]
+		[DataRow(false, null, "-1", true)]
+		[DataRow(false, null, "1", true)]
+		[DataRow(false, null, "0", true)]
+		[DataRow(false, null, "-1u", true)]
+		[DataRow(false, null, "1u", true)]
+		[DataRow(false, null, "0u", true)]
+		[DataRow(false, "-1", null, false)]
+		[DataRow(false, "1", null, false)]
+		[DataRow(false, "0", null, false)]
+		[DataRow(false, "-1u", null, false)]
+		[DataRow(false, "1u", null, false)]
+		[DataRow(false, "0u", null, false)]
+		[DataTestMethod]
+		public void CheckNegativeInteger(bool shouldWrapArgument, string arg0, string arg1, bool isError)
+		{
+			string expectedParameter = arg0 ?? "GetValue()";
+			string actualParameter = arg1 ?? "GetValue()";
+
+			if (shouldWrapArgument)
+			{
+				if (arg0 is null)
+				{
+					expectedParameter = $"({expectedParameter})";
+				}
+
+				if (arg1 is null)
+				{
+					actualParameter = $"({actualParameter})";
+				}
+			}
+
+			string template = @$"
+int GetValue()
+{{
+	return 0;
+}}
+
+Assert.AreEqual({expectedParameter}, {actualParameter});
+";
+
+			if (isError)
+			{
+				VerifyError(template);
+			}
+			else
+			{
+				VerifyNoError(template);
+			}
+		}
+
 		[TestMethod]
 		public void CheckWillIgnoreTypeArgument()
 		{


### PR DESCRIPTION
Handle more cases in the <actual> -> <expected> Assert.AreEqual analyzer.  Handle -1, as a constant.

Closes #36 