### PR TITLE
Support VS2017

### DIFF
--- a/Philips.CodeAnalysis.Common/Philips.CodeAnalysis.Common.csproj
+++ b/Philips.CodeAnalysis.Common/Philips.CodeAnalysis.Common.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.10.0" />
   </ItemGroup>
 
 </Project>

--- a/Philips.CodeAnalysis.DuplicateCodeAnalyzer/Philips.CodeAnalysis.DuplicateCodeAnalyzer.csproj
+++ b/Philips.CodeAnalysis.DuplicateCodeAnalyzer/Philips.CodeAnalysis.DuplicateCodeAnalyzer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -18,14 +18,14 @@
     <PackageIconUrl>https://avatars3.githubusercontent.com/u/39734771</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Description>Detects Duplicate Code</Description>
-    <PackageReleaseNotes>1.1:  Depend on .NET Standard version 2.0 instead of 1.3</PackageReleaseNotes>
+    <PackageReleaseNotes>1.0.2:  Backwards-compatibility support for VS2017</PackageReleaseNotes>
     <Copyright>© 2020 Koninklijke Philips N.V.</Copyright>
     <PackageTags>CSharp MsTest Roslyn CodeAnalysis analyzers cpd duplicate Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <Version>1.1.2</Version>
+    <Version>1.0.2</Version>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.1.2.0</FileVersion>
+    <FileVersion>1.0.2.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -40,8 +40,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.8" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.10.0" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/AvoidStaticMethodAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/AvoidStaticMethodAnalyzer.cs
@@ -88,7 +88,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 				if (symbol.IsStatic && !symbol.IsExtern)
 				{
 					// We found a static thing being used in this method.  Is the thing ours?
-					if (SymbolEqualityComparer.Default.Equals(symbol.ContainingType, us))
+					if (Equals(symbol.ContainingType, us))
 					{
 						// This method must be static because it references something static of ours.  We are done.
 						return;
@@ -100,7 +100,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 			foreach (ObjectCreationExpressionSyntax objectCreationExpressionSyntax in methodDeclarationSyntax.DescendantNodesAndSelf().OfType<ObjectCreationExpressionSyntax>())
 			{
 				ISymbol objectCreationSymbol = context.SemanticModel.GetSymbolInfo(objectCreationExpressionSyntax).Symbol;
-				if (SymbolEqualityComparer.Default.Equals(objectCreationSymbol?.ContainingType, us))
+				if (Equals(objectCreationSymbol?.ContainingType, us))
 				{
 					return;
 				}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -19,18 +19,16 @@
     <PackageIconUrl>https://avatars3.githubusercontent.com/u/39734771</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Description>Roslyn Diagnostic Analyzers for helping maintainability or readability of C# code</Description>
-    <PackageReleaseNotes>1.1:  
-* Depend on .NET Standard version 2.0 instead of 1.3
-* Add "Avoid AssemblyVersion Change" Analyzer
-* Fix "Copyright Present Analyzer"
-</PackageReleaseNotes>
+    <PackageReleaseNotes>
+      1.0.5 Backwards-compatibility support for VS2017
+    </PackageReleaseNotes>
     <Copyright>© 2019 Koninklijke Philips N.V.</Copyright>
     <PackageTags>CSharp MsTest Roslyn CodeAnalysis analyzers Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <Version>1.2.0</Version>
+    <Version>1.0.5</Version>
     <AssemblyVersion>1.0.3.0</AssemblyVersion>
-    <FileVersion>1.2.0.0</FileVersion>
+    <FileVersion>1.0.5.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -45,11 +43,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.10.0" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
   

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/PreventUnnecessaryRangeChecksAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/PreventUnnecessaryRangeChecksAnalyzer.cs
@@ -165,7 +165,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 						return false;
 					}
 
-					if (!SymbolEqualityComparer.Default.Equals(leftSymbol.Symbol, rightSymbol.Symbol))
+					if (!Equals(leftSymbol.Symbol, rightSymbol.Symbol))
 					{
 						return false;
 					}

--- a/Philips.CodeAnalysis.MoqAnalyzers/Philips.CodeAnalysis.MoqAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MoqAnalyzers/Philips.CodeAnalysis.MoqAnalyzers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -19,14 +19,14 @@
     <PackageIconUrl>https://avatars3.githubusercontent.com/u/39734771</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Description>Roslyn Diagnostic Analyzers for Unit Testing with Moq</Description>
-    <PackageReleaseNotes>1.1:  Depend on .NET Standard version 2.0 instead of 1.3</PackageReleaseNotes>
+    <PackageReleaseNotes>1.0.2:  Backwards-compatibility support for VS2017</PackageReleaseNotes>
     <Copyright>© 2019 Koninklijke Philips N.V.</Copyright>
     <PackageTags>CSharp MsTest Roslyn CodeAnalysis analyzers moq Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <Version>1.1.0</Version>
+    <Version>1.0.2</Version>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.1.0.0</FileVersion>
+    <FileVersion>1.0.2.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -41,11 +41,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.10.0" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/Philips.CodeAnalysis.MsTestAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/Philips.CodeAnalysis.MsTestAnalyzers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -19,14 +19,14 @@
     <PackageIconUrl>https://avatars3.githubusercontent.com/u/39734771</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Description>Roslyn Diagnostic Analyzers for Unit Testing with MsTest</Description>
-    <PackageReleaseNotes>1.1:  Depend on .NET Standard version 2.0 instead of 1.3</PackageReleaseNotes>
+    <PackageReleaseNotes>1.0.4:  Backwards-compatibility support for VS2017</PackageReleaseNotes>
     <Copyright>© 2019 Koninklijke Philips N.V.</Copyright>
     <PackageTags>CSharp MsTest Roslyn CodeAnalysis analyzers Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <Version>1.1.1</Version>
-    <AssemblyVersion>1.0.1.0</AssemblyVersion>
-    <FileVersion>1.1.1</FileVersion>
+    <Version>1.0.4</Version>
+    <AssemblyVersion>1.0.4.0</AssemblyVersion>
+    <FileVersion>1.0.4</FileVersion>
   </PropertyGroup>
   
   <ItemGroup>
@@ -41,11 +41,11 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.10.0" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
   

--- a/Philips.CodeAnalysis.Test/AvoidDuplicateCodeTest.cs
+++ b/Philips.CodeAnalysis.Test/AvoidDuplicateCodeTest.cs
@@ -19,16 +19,6 @@ namespace Philips.CodeAnalysis.Test
 			return new AvoidDuplicateCodeAnalyzer() { DefaultDuplicateTokenThreshold = 100 };
 		}
 
-		protected override Dictionary<string, string> GetAdditionalAnalyzerConfigOptions()
-		{
-			var options = new Dictionary<string, string>
-			{
-				{ $@"dotnet_code_quality.{ AvoidDuplicateCodeAnalyzer.Rule.Id }.token_count", @"20" }
-			};
-			return options;
-		}
-
-
 		public class SumHashCalculator : RollingHashCalculator<TokenInfo>
 		{
 			public SumHashCalculator(int maxItems)

--- a/Philips.CodeAnalysis.Test/Philips.CodeAnalysis.Test.csproj
+++ b/Philips.CodeAnalysis.Test/Philips.CodeAnalysis.Test.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />

--- a/Philips.CodeAnalysis.Test/TestHasCategoryTest.cs
+++ b/Philips.CodeAnalysis.Test/TestHasCategoryTest.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -116,15 +115,6 @@ class Foo
 		protected override (string name, string content)[] GetAdditionalTexts()
 		{
 			return new[] { (@"TestsWithUnsupportedCategory.Allowed.txt", "Foo.Foo1") };
-		}
-
-		protected override Dictionary<string, string> GetAdditionalAnalyzerConfigOptions()
-		{
-			var options = new Dictionary<string, string>
-			{
-				{ $@"dotnet_code_quality.{Helper.ToDiagnosticId(DiagnosticIds.TestHasCategoryAttribute)}.allowed_test_categories", @"UnitTest,ManualTest" }
-			};
-			return options;
 		}
 	}
 }

--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ Add the rules using Visual Studio's Package Manager, locating these packages on 
 
 Enabling a new rule on a legacy codebase can be daunting.  Some rules (e.g., Avoid Duplicate Code, Avoid Static Classes) support configuration and whitelisting - again via the .editorconfig.
 
+# Visual Studio 2017 Support
+
+The latest versions are designed for Visual Studio 2019.  Support for legacy Visual Studio 2017, with a slightly reduced feature set, is maintained in the 1.0.x versions of the packages.
+


### PR DESCRIPTION
Rollback to older versions of libraries, APIs, and to .netstandard1.3, so as to work with Visual Studio 2017.

https://github.com/WalkerCodeRanger/ExhaustiveMatching/issues/33#issuecomment-673724966
https://docs.microsoft.com/en-us/visualstudio/code-quality/install-fxcop-analyzers?view=vs-2019#fxcopanalyzers-package-versions
