### PR TITLE
Fix the TestCategory analyzer

### DIFF
--- a/Philips.CodeAnalysis.MsTestAnalyzers/Philips.CodeAnalysis.MsTestAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/Philips.CodeAnalysis.MsTestAnalyzers.csproj
@@ -24,9 +24,9 @@
     <PackageTags>CSharp MsTest Roslyn CodeAnalysis analyzers Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <AssemblyVersion>1.0.1.0</AssemblyVersion>
-    <FileVersion>1.1.2</FileVersion>
+    <FileVersion>1.1.3</FileVersion>
   </PropertyGroup>
   
   <ItemGroup>

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestHasCategoryAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestHasCategoryAnalyzer.cs
@@ -51,15 +51,20 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 				return;
 			}
 
-			Optional<object> argument = context.SemanticModel.GetConstantValue(argumentSyntax.Expression);
-
-			if (!argument.HasValue)
+			string value;
+			switch (argumentSyntax.Expression)
 			{
-				//this should not be possible.  Attribute values must by compile time constants
-				return;
+				case MemberAccessExpressionSyntax mae:
+					value = mae.ToString();
+					break;
+				case LiteralExpressionSyntax literal:
+					value = literal.ToString();
+					break;
+				default:
+					return;
 			}
 
-			if (!_allowedCategories.Contains((string)argument.Value))
+			if (!_allowedCategories.Contains(value))
 			{
 				Diagnostic diagnostic = Diagnostic.Create(Rule, categoryLocation);
 				context.ReportDiagnostic(diagnostic);

--- a/Philips.CodeAnalysis.Test/TestHasCategoryTest.cs
+++ b/Philips.CodeAnalysis.Test/TestHasCategoryTest.cs
@@ -63,6 +63,32 @@ class Foo
 			VerifyError(baseline, category, isError);
 		}
 
+		[DataTestMethod]
+		[DataRow(@"UnitTest", false)]
+		[DataRow(@"ManualTest", false)]
+		[DataRow(@"NightlyTest", true)]
+		[DataRow(@"", true)]
+		public void TestHasCategoryAttributeIndirectionTest(string category, bool isError)
+		{
+			string baseline = @"
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+public class TestDefinitions
+{{
+  public const string {0} = ""blah"";
+}}
+
+class Foo
+{{
+  [TestMethod, TestCategory(TestDefinitions.{0})]
+  public void Foo()
+  {{
+  }}
+}}
+";
+			VerifyError(baseline, category, isError);
+		}
+
 
 		[DataTestMethod]
 		[DataRow(@"Foo1", false)]
@@ -95,7 +121,7 @@ class Foo
 						Severity = DiagnosticSeverity.Error,
 						Locations = new[]
 						{
-							new DiagnosticResultLocation("Test0.cs", 5, 16)
+							new DiagnosticResultLocation("Test0.cs", null, null)
 						}
 					}
 				};
@@ -122,7 +148,7 @@ class Foo
 		{
 			var options = new Dictionary<string, string>
 			{
-				{ $@"dotnet_code_quality.{Helper.ToDiagnosticId(DiagnosticIds.TestHasCategoryAttribute)}.allowed_test_categories", @"UnitTest,ManualTest" }
+				{ $@"dotnet_code_quality.{Helper.ToDiagnosticId(DiagnosticIds.TestHasCategoryAttribute)}.allowed_test_categories", @"""UnitTest"",""ManualTest"",TestDefinitions.UnitTest,TestDefinitions.ManualTest" }
 			};
 			return options;
 		}


### PR DESCRIPTION
It was changed to look at the literal value in the attribute, which isn't actually what we want.

Go back to looking at the MemberAccessExpressionSyntax.