### PR TITLE
Analyzer to check absolute paths

### DIFF
--- a/Philips.CodeAnalysis.Common/DiagnosticIds.cs
+++ b/Philips.CodeAnalysis.Common/DiagnosticIds.cs
@@ -71,7 +71,8 @@ namespace Philips.CodeAnalysis.Common
 		AssertFail = 2076,
 		AvoidSwitchStatementsWithNoCases = 2077,
 		AvoidPrivateKeyProperty = 2078,
-		NamespacePrefix = 2079
+		NamespacePrefix = 2079,
+		NoHardcodedPaths = 2080
 
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/NoHardCodedPathsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/NoHardCodedPathsAnalyzer.cs
@@ -10,7 +10,9 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 {
 	/*
 	 * Analyzer for hardcoded absolute path. 
-	 * Reports diagnostics if an absolute path is used, for example: c:\users\Bin\example.xml.
+	 * Reports diagnostics if an absolute path is used,
+	 * For example: c:\users\Bin\example.xml - Windows & /home/kt/abc.sql - Linux
+	 * 
 	 */
 	[DiagnosticAnalyzer(LanguageNames.CSharp)]
 	public class NoHardCodedPathsAnalyzer : DiagnosticAnalyzer
@@ -21,7 +23,9 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 		private const string MessageFormat = @"Absolute paths must not be hardcoded";
 		private const string Description = @"Absolute paths must not be hardcoded";
 		private const string Category = Categories.Maintainability;
-		private Regex Pattern = new Regex(@"^[a-zA-Z]:\\(((?![<>:/\\|?*]).)+((?<![ .])\\)?)*$");
+		private Regex WindowsPattern = new Regex(@"^[a-zA-Z]:\\{1,2}(((?![<>:/\\|?*]).)+((?<![ .])\\{1,2})?)*$");
+		private Regex LinuxPattern = new Regex(@"^\/$|(^(?=\/)|^\.|^\.\.)(\/(?=[^/\0])[^/\0]+)*\/?$");
+
 		#endregion
 
 		#region Non-Public Data Members
@@ -31,7 +35,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 			// Get the text value of the string literal expression.
 			string pathValue = stringLiteralExpressionNode.Token.ValueText;
 			// If the pattern matches the text value, report the diagnostic.
-			if (Pattern.IsMatch(pathValue))
+			if (WindowsPattern.IsMatch(pathValue) || LinuxPattern.IsMatch(pathValue))
 			{
 				Diagnostic diagnostic = Diagnostic.Create(Rule, stringLiteralExpressionNode.GetLocation());
 				context.ReportDiagnostic(diagnostic);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/NoHardCodedPathsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/NoHardCodedPathsAnalyzer.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Immutable;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
+{
+	/*
+	 * Analyzer for hardcoded absolute path. 
+	 * Reports diagnostics if an absolute path is used, for example: c:\users\Bin\example.xml.
+	 */
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class NoHardCodedPathsAnalyzer : DiagnosticAnalyzer
+	{
+
+		#region Non-Public Data Members
+		private const string Title = @"Paths must not be hardcoded";
+		private const string MessageFormat = @"Paths must not be hardcoded";
+		private const string Description = @"Paths must not be hardcoded";
+		private const string Category = Categories.Maintainability;
+		private Regex Pattern = new Regex(@"^[a-zA-Z]:\\(((?![<>:/\\|?*]).)+((?<![ .])\\)?)*$");
+		#endregion
+
+		#region Non-Public Data Members
+		private void Analyze(SyntaxNodeAnalysisContext context)
+		{
+			LiteralExpressionSyntax stringLiteralExpressionNode = (LiteralExpressionSyntax)context.Node;
+			// Get the text value of the literal expression.
+			string pathValue = stringLiteralExpressionNode.Token.ValueText;
+			// If the pattern matches the text value, report the diagnostic.
+			if (Pattern.IsMatch(pathValue))
+			{
+				Diagnostic diagnostic = Diagnostic.Create(Rule, stringLiteralExpressionNode.GetLocation());
+				context.ReportDiagnostic(diagnostic);
+			}
+		}
+		#endregion
+
+		#region Public Interface
+		public static DiagnosticDescriptor Rule = new DiagnosticDescriptor(Helper.ToDiagnosticId(DiagnosticIds.NoHardcodedPaths), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+		{
+			get { return ImmutableArray.Create(Rule); }
+		}
+		public override void Initialize(AnalysisContext context)
+		{
+			context.EnableConcurrentExecution();
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.StringLiteralExpression);
+		}
+		#endregion
+
+	}
+}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/NoHardCodedPathsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/NoHardCodedPathsAnalyzer.cs
@@ -1,4 +1,10 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Collections.Immutable;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Philips.CodeAnalysis.Common;
 
 namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 {

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/NoHardCodedPathsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/NoHardCodedPathsAnalyzer.cs
@@ -1,10 +1,4 @@
-﻿using System.Collections.Immutable;
-using System.Text.RegularExpressions;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Philips.CodeAnalysis.Common;
+﻿using System.Text.RegularExpressions;
 
 namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 {
@@ -17,9 +11,9 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 	{
 
 		#region Non-Public Data Members
-		private const string Title = @"Paths must not be hardcoded";
-		private const string MessageFormat = @"Paths must not be hardcoded";
-		private const string Description = @"Paths must not be hardcoded";
+		private const string Title = @"Absolute paths must not be hardcoded";
+		private const string MessageFormat = @"Absolute paths must not be hardcoded";
+		private const string Description = @"Absolute paths must not be hardcoded";
 		private const string Category = Categories.Maintainability;
 		private Regex Pattern = new Regex(@"^[a-zA-Z]:\\(((?![<>:/\\|?*]).)+((?<![ .])\\)?)*$");
 		#endregion
@@ -28,7 +22,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 		private void Analyze(SyntaxNodeAnalysisContext context)
 		{
 			LiteralExpressionSyntax stringLiteralExpressionNode = (LiteralExpressionSyntax)context.Node;
-			// Get the text value of the literal expression.
+			// Get the text value of the string literal expression.
 			string pathValue = stringLiteralExpressionNode.Token.ValueText;
 			// If the pattern matches the text value, report the diagnostic.
 			if (Pattern.IsMatch(pathValue))

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/NoHardCodedPathsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/NoHardCodedPathsAnalyzer.cs
@@ -12,7 +12,6 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 	 * Analyzer for hardcoded absolute path. 
 	 * Reports diagnostics if an absolute path is used,
 	 * For example: c:\users\Bin\example.xml - Windows & /home/kt/abc.sql - Linux
-	 * 
 	 */
 	[DiagnosticAnalyzer(LanguageNames.CSharp)]
 	public class NoHardCodedPathsAnalyzer : DiagnosticAnalyzer
@@ -34,6 +33,10 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 			LiteralExpressionSyntax stringLiteralExpressionNode = (LiteralExpressionSyntax)context.Node;
 			// Get the text value of the string literal expression.
 			string pathValue = stringLiteralExpressionNode.Token.ValueText;
+
+			//if the character of the string do not match either of the characters : for windows and / for linux; no need to run regex, simply return.
+			if (!pathValue[1].Equals(':') && !pathValue[0].Equals('/')) return;
+
 			// If the pattern matches the text value, report the diagnostic.
 			if (WindowsPattern.IsMatch(pathValue) || LinuxPattern.IsMatch(pathValue))
 			{

--- a/Philips.CodeAnalysis.Test/NoHardCodedPathsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/NoHardCodedPathsAnalyzerTest.cs
@@ -14,7 +14,7 @@ namespace Philips.CodeAnalysis.Test
 		}
 
 		[TestMethod]
-		public void CatchesHardCodedPaths()
+		public void CatchesHardCodedAbsoluteWindowsPaths()
 		{
 			const string template = @"
 using System;
@@ -23,6 +23,42 @@ class Foo
 	public void Test()
 	{
 		string path = @""c:\users\Bin\example.xml"";
+	}
+}
+";
+
+			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
+
+		}
+
+		[TestMethod]
+		public void CatchesHardCodedAbsoluteLinuxPaths()
+		{
+			const string template = @"
+using System;
+class Foo
+{
+	public void Test()
+	{
+		string path = @""/boot/grub/grub.conf"";
+	}
+}
+";
+
+			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
+
+		}
+
+		[TestMethod]
+		public void CatchesHardCodedAbsoluteWindowsPathWithDoubleSlash()
+		{
+			const string template = @"
+using System;
+class Foo
+{
+	public void Test()
+	{
+		string path = @""c:\\users\\Bin\\example.xml"";
 	}
 }
 ";
@@ -170,6 +206,8 @@ class Foo
 		}
 
 	}
+
+
 
 
 }

--- a/Philips.CodeAnalysis.Test/NoHardCodedPathsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/NoHardCodedPathsAnalyzerTest.cs
@@ -1,0 +1,175 @@
+﻿using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Philips.CodeAnalysis.Common;
+using Philips.CodeAnalysis.MaintainabilityAnalyzers;
+
+namespace Philips.CodeAnalysis.Test
+{
+	[TestClass]
+	public class NoHardcodedPathsAnalyzerTest : DiagnosticVerifier
+	{
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		{
+			return new NoHardCodedPathsAnalyzer();
+		}
+
+		[TestMethod]
+		public void CatchesHardCodedPaths()
+		{
+			const string template = @"
+using System;
+class Foo
+{
+	public void Test()
+	{
+		string path = @""c:\users\Bin\example.xml"";
+	}
+}
+";
+
+			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
+
+		}
+
+
+		[TestMethod]
+		public void CatchesHardCodedPathsRegardlessOfCase()
+		{
+			const string template = @"
+using System;
+class Foo
+{
+	public void Test()
+	{
+		string path = @""C:\USERS\BIN\EXAMPLE.XML"";
+	}
+}
+";
+
+			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
+
+		}
+
+		[TestMethod]
+		public void CatchesHardCodedPaths2()
+		{
+			const string template = @"
+using System;
+
+enum DialogResult { }
+
+static class MessageBoxHelper
+{
+	public static DialogResult Warn(string format, params object[] args)
+	{
+		return string.Empty;
+	}
+}
+
+class Foo
+{
+	public void Test()
+	{
+		string t = @""c:\users\Bin\example.xml"";
+	}
+}
+";
+
+			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
+
+		}
+
+		[TestMethod]
+		public void CatchesHardCodedPathsWithSpace()
+		{
+			const string template = @"
+using System;
+class Foo
+{
+	public void Test()
+	{
+		string path = @""c:\users\test first\Bin\example.xml"";
+	}
+}
+";
+
+			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
+
+		}
+
+		[TestMethod]
+		public void CatchesHardCodedPathsWithSpecialCharacters()
+		{
+			const string template = @"
+using System;
+class Foo
+{
+	public void Test()
+	{
+		string path = @""c:\users\test_first-second.third@fourth\Bin\example.xml"";
+	}
+}
+";
+
+			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
+
+		}
+		[TestMethod]
+		public void DoesNotCatchNormalString()
+		{
+			const string template = @"
+using System;
+class Foo
+{
+	public void Test()
+	{
+		string path = @""Test"";
+	}
+}
+";
+
+			VerifyCSharpDiagnostic(template);
+
+		}
+
+
+		[TestMethod]
+		public void DoesnotCatchRelativePath()
+		{
+			const string template = @"
+using system;
+class foo
+{
+	public void test()
+	{
+		string path = @""..\..\bin\example.xml"";
+	}
+}
+";
+			VerifyCSharpDiagnostic(template);
+		}
+
+		[TestMethod]
+		public void DoesnotCatchPathsInComments()
+		{
+			const string template = @"
+using System;
+class Foo
+{
+	/*
+	* This is a test: c:\users\Bin\example.xml
+	*/
+	public void Test()
+	{
+		string path = @""This is a test"";
+	}
+}
+";
+			VerifyCSharpDiagnostic(template);
+
+		}
+
+	}
+
+
+}

--- a/Philips.CodeAnalysis.Test/NoHardCodedPathsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/NoHardCodedPathsAnalyzerTest.cs
@@ -26,7 +26,6 @@ class Foo
 	}
 }
 ";
-
 			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
 
 		}
@@ -44,7 +43,6 @@ class Foo
 	}
 }
 ";
-
 			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
 
 		}
@@ -62,7 +60,6 @@ class Foo
 	}
 }
 ";
-
 			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
 
 		}
@@ -81,7 +78,6 @@ class Foo
 	}
 }
 ";
-
 			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
 
 		}
@@ -110,7 +106,6 @@ class Foo
 	}
 }
 ";
-
 			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
 
 		}
@@ -206,8 +201,4 @@ class Foo
 		}
 
 	}
-
-
-
-
 }


### PR DESCRIPTION
Reports diagnostics if an absolute path is used, for example: c:\users\Bin\example.xml.

**Files Modified:**
Philips.CodeAnalysis.Common/DiagnosticIds.cs

**Files Added:**
Philips.CodeAnalysis.MaintainabilityAnalyzers/NoHardCodedPathsAnalyzer.cs
Philips.CodeAnalysis.Test/NoHardCodedPathsAnalyzerTest.cs

**Files Removed:**
None
