### PR TITLE
Add new analyzers

### DIFF
--- a/Philips.CodeAnalysis.Common/DiagnosticIds.cs
+++ b/Philips.CodeAnalysis.Common/DiagnosticIds.cs
@@ -75,6 +75,7 @@ namespace Philips.CodeAnalysis.Common
 		NoHardcodedPaths = 2080,
 		NoRegionsInMethods = 2081,
 		PositiveNaming = 2082,
-		DontLockNewObject = 2084
+		DontLockNewObject = 2084,
+		OrderPropertyAccessors = 2085
 	}
 }

--- a/Philips.CodeAnalysis.Common/DiagnosticIds.cs
+++ b/Philips.CodeAnalysis.Common/DiagnosticIds.cs
@@ -74,6 +74,7 @@ namespace Philips.CodeAnalysis.Common
 		NamespacePrefix = 2079,
 		NoHardcodedPaths = 2080,
 		NoRegionsInMethods = 2081,
-		PositiveNaming = 2082
+		PositiveNaming = 2082,
+		DontLockNewObject = 2084
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/DontLockNewObjectAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/DontLockNewObjectAnalyzer.cs
@@ -1,0 +1,49 @@
+﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class DontLockNewObjectAnalyzer : DiagnosticAnalyzer
+	{
+		private const string Title = @"Don't lock new object";
+		private const string MessageFormat = @"Poor choice of lock object '{0}'";
+		private const string Description = @"Lock objects must be sharable between threads";
+		private const string Category = Categories.Maintainability;
+
+		private static DiagnosticDescriptor Rule = new DiagnosticDescriptor(Helper.ToDiagnosticId(DiagnosticIds.DontLockNewObject), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+		public override void Initialize(AnalysisContext context)
+		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.EnableConcurrentExecution();
+
+			context.RegisterCompilationStartAction(startContext =>
+			{
+				startContext.RegisterOperationAction(Analyze, OperationKind.Lock);
+			});
+		}
+
+		private static void Analyze(OperationAnalysisContext context)
+		{
+			ILockOperation lockOperation = (ILockOperation)context.Operation;
+
+			if (lockOperation.LockedValue is IObjectCreationOperation || lockOperation is IDynamicObjectCreationOperation)
+			{
+				context.ReportDiagnostic(Diagnostic.Create(Rule, lockOperation.LockedValue.Syntax.GetLocation(), lockOperation.LockedValue.Syntax));
+			}
+
+			if (lockOperation.LockedValue is IInvocationOperation invocationOperation && invocationOperation.Instance is IObjectCreationOperation)
+			{
+				context.ReportDiagnostic(Diagnostic.Create(Rule, lockOperation.LockedValue.Syntax.GetLocation(), lockOperation.LockedValue.Syntax));
+			}
+		}
+	}
+}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/OrderPropertyAccessorsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/OrderPropertyAccessorsAnalyzer.cs
@@ -1,0 +1,76 @@
+﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class OrderPropertyAccessorsAnalyzer : DiagnosticAnalyzer
+	{
+		private const string Title = @"Accessors should be ordered";
+		private const string MessageFormat = @"Accessors should be ordered.";
+		private const string Description = @"Properties should be ordered get then set (or init)";
+		private const string Category = Categories.Documentation;
+
+		private static DiagnosticDescriptor Rule = new DiagnosticDescriptor(Helper.ToDiagnosticId(DiagnosticIds.OrderPropertyAccessors), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+		public override void Initialize(AnalysisContext context)
+		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.EnableConcurrentExecution();
+
+			context.RegisterCompilationStartAction(startContext =>
+			{
+				startContext.RegisterSyntaxNodeAction(Analyze, SyntaxKind.PropertyDeclaration);
+			});
+		}
+
+		private static void Analyze(SyntaxNodeAnalysisContext context)
+		{
+			PropertyDeclarationSyntax node = (PropertyDeclarationSyntax)context.Node;
+
+			AccessorListSyntax accessors = node.AccessorList;
+
+			if (accessors is null)
+			{
+				return;
+			}
+
+			int getIndex = -1;
+			int setIndex = int.MaxValue;
+
+			for (int i = 0; i < accessors.Accessors.Count; i++)
+			{
+				var accessor = accessors.Accessors[i];
+
+				if (accessor.Keyword.IsKind(SyntaxKind.GetKeyword))
+				{
+					getIndex = i;
+					continue;
+				}
+
+				// SyntaxKind.InitKeyword doesn't exist in the currently used version of Roslyn (it exists in at least 3.9.0)
+				if (accessor.Keyword.IsKind(SyntaxKind.SetKeyword) || accessor.Keyword.Text == "init")
+				{
+					setIndex = i;
+					continue;
+				}
+			}
+
+			if (setIndex < getIndex)
+			{
+				context.ReportDiagnostic(Diagnostic.Create(Rule, accessors.GetLocation()));
+			}
+
+
+			//get, set
+		}
+	}
+}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -40,9 +40,9 @@
     <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <Version>1.2.7</Version>
+    <Version>1.2.8</Version>
     <AssemblyVersion>1.0.3.0</AssemblyVersion>
-    <FileVersion>1.2.7.0</FileVersion>
+    <FileVersion>1.2.8.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -36,3 +36,5 @@
 | PH2081  | Avoid #regions within methods                | A #region cannot start or end within a method. Consider refactoring long methods instead.|
 | PH2082  | Positive naming                              | Name properties, fields and variables after the positive case. People can handle double negations poorly, and by using positive naming this is prevented.|
 | PH2083  | Avoid Pass By Reference                      | Parameters that are passed by reference should be written to, otherwise they should not be passed by reference|
+| PH2084  | Don't lock on "new x()"                      | Locking on a newly created object has no effect|
+| PH2085  | Order property accessors                     | Consistently order property accessors as get, set, init|

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -21,7 +22,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 
-		protected override Diagnostic Analyze(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocationExpressionSyntax, MemberAccessExpressionSyntax memberAccessExpression)
+		protected override IEnumerable<Diagnostic> Analyze(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocationExpressionSyntax, MemberAccessExpressionSyntax memberAccessExpression)
 		{
 			string memberName = memberAccessExpression.Name switch
 			{
@@ -59,7 +60,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			if (arg1Literal)
 			{
 				Diagnostic diagnostic = Diagnostic.Create(Rule, invocationExpressionSyntax.GetLocation());
-				return diagnostic;
+				return new[] { diagnostic };
 			}
 
 			return null;

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualLiteralAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualLiteralAnalyzer.cs
@@ -1,5 +1,6 @@
 // © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -22,7 +23,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 
-		protected override Diagnostic Analyze(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocationExpressionSyntax, MemberAccessExpressionSyntax memberAccessExpression)
+		protected override IEnumerable<Diagnostic> Analyze(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocationExpressionSyntax, MemberAccessExpressionSyntax memberAccessExpression)
 		{
 			switch (memberAccessExpression.Name.ToString())
 			{
@@ -58,7 +59,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			}
 
 
-			return Diagnostic.Create(Rule, invocationExpressionSyntax.GetLocation());
+			return new[] { Diagnostic.Create(Rule, invocationExpressionSyntax.GetLocation()) };
 		}
 
 		private bool IsLiteral(ExpressionSyntax expression)

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueFalseDiagnosticAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueFalseDiagnosticAnalyzer.cs
@@ -1,5 +1,7 @@
 // © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -14,9 +16,9 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 		#region Non-Public Properties/Methods
 
-		protected override Diagnostic Analyze(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocationExpressionSyntax, MemberAccessExpressionSyntax memberAccessExpression)
+		protected override IEnumerable<Diagnostic> Analyze(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocationExpressionSyntax, MemberAccessExpressionSyntax memberAccessExpression)
 		{
-			bool isIsTrue = false;
+			bool isIsTrue;
 			string memberName = memberAccessExpression.Name.ToString();
 			switch (memberName)
 			{
@@ -30,7 +32,14 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 					return null;
 			}
 
-			return Check(context, invocationExpressionSyntax, invocationExpressionSyntax.ArgumentList, isIsTrue);
+			Diagnostic result = Check(context, invocationExpressionSyntax, invocationExpressionSyntax.ArgumentList, isIsTrue);
+
+			if (result is null)
+			{
+				return Array.Empty<Diagnostic>();
+			}
+
+			return new[] { result };
 		}
 		protected virtual Diagnostic Check(SyntaxNodeAnalysisContext context, SyntaxNode node, ArgumentListSyntax arguments, bool isIsTrue)
 		{

--- a/Philips.CodeAnalysis.Test/AvoidAssertConditionalAccessAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/AvoidAssertConditionalAccessAnalyzerTest.cs
@@ -30,16 +30,25 @@ namespace Philips.CodeAnalysis.Test
 		[DataTestMethod]
 		[DataRow("string name=\"xyz\"; Assert.AreEqual(name?.ToString(), \"xyz\")")]
 		[DataRow("string name=\"xyz\"; Assert.AreEqual(\"xyz\",name?.ToString())")]
-		[DataRow("string name1=\"xyz\"; string name2=\"abc\"; Assert.AreEqual(name1?.ToString(), name2?.ToString())")]
+		[DataRow("string name1=\"xyz\"; string name2=\"abc\"; Assert.AreEqual((name1?.ToString()), name2.ToString())")]
+		[DataRow("string name1=\"xyz\"; string name2=\"abc\"; Assert.AreEqual(name1.ToString(), (name2?.ToString()))")]
 		public void AvoidAssertConditionalAccessAnalyzerFailTest(string test)
 		{
 			VerifyError(test, Helper.ToDiagnosticId(DiagnosticIds.AvoidAssertConditionalAccess));
 		}
 
 		[DataTestMethod]
+		[DataRow("string name1=\"xyz\"; string name2=\"abc\"; Assert.AreEqual((name1?.ToString()), (name2?.ToString()))")]
+		public void AvoidAssertConditionalAccessAnalyzerFailTestMultipleErrors(string test)
+		{
+			VerifyError(test, Helper.ToDiagnosticId(DiagnosticIds.AvoidAssertConditionalAccess), Helper.ToDiagnosticId(DiagnosticIds.AvoidAssertConditionalAccess));
+		}
+
+		[DataTestMethod]
 		[DataRow("string name=\"xyz\"; Assert.AreEqual(name.ToString(), \"xyz\")")]
 		[DataRow("string name=\"xyz\"; Assert.AreEqual(\"xyz\",name.ToString())")]
 		[DataRow("string name1=\"xyz\"; string name2=\"abc\"; Assert.AreEqual(name1.ToString(), name2.ToString())")]
+		[DataRow("string name1=\"xyz\"; string name2=\"abc\"; Assert.AreEqual(name1.ToString(), name2.ToString(), $\"error{name1?.ToString()}\")")]
 		public void AvoidAssertConditionalAccessAnalyzerSuccessTest(string test)
 		{
 			VerifyCSharpDiagnostic(test, Array.Empty<DiagnosticResult>());

--- a/Philips.CodeAnalysis.Test/DontLockNewObjectAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/DontLockNewObjectAnalyzerTest.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Philips.CodeAnalysis.Common;
+using Philips.CodeAnalysis.MaintainabilityAnalyzers;
+
+namespace Philips.CodeAnalysis.Test
+{
+	[TestClass]
+	public class DontLockNewObjectAnalyzerTest : DiagnosticVerifier
+	{
+		#region Non-Public Data Members
+		#endregion
+
+		#region Non-Public Properties/Methods
+
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new DontLockNewObjectAnalyzer();
+
+		#endregion
+
+		#region Public Interface
+
+		[DataRow("this", false)]
+		[DataRow("lockObj", false)]
+		[DataRow("new object()", true)]
+		[DataRow("new object().ToString()", true)]
+		[DataTestMethod]
+		public void PreventLockOnUncapturedVariable(string lockText, bool expectedError)
+		{
+			string text = @$"
+public class Foo
+{{
+	public void TestMethod()
+	{{
+		object lockObj = new object();
+		lock({lockText}){{}}
+	}}
+}}
+";
+
+			VerifyCSharpDiagnostic(text, expectedError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.DontLockNewObject) : Array.Empty<DiagnosticResult>());
+		}
+
+		#endregion
+	}
+}

--- a/Philips.CodeAnalysis.Test/OrderPropertyAccessorsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/OrderPropertyAccessorsAnalyzerTest.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Philips.CodeAnalysis.Common;
+using Philips.CodeAnalysis.MaintainabilityAnalyzers;
+
+namespace Philips.CodeAnalysis.Test
+{
+	[TestClass]
+	public class OrderPropertyAccessorsAnalyzerTest : DiagnosticVerifier
+	{
+		#region Non-Public Data Members
+		#endregion
+
+		#region Non-Public Properties/Methods
+
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new OrderPropertyAccessorsAnalyzer();
+
+		#endregion
+
+		#region Public Interface
+		[DataRow(@"{ get; set; }", false)]
+		[DataRow(@"{ get; }", false)]
+		[DataRow(@"{ get { return null; } }", false)]
+		[DataRow(@"{ set {} }", false)]
+		[DataRow(@"{ get; init; }", false)]
+		[DataRow(@"{ init; get; }", true)]
+		[DataRow(@"{ set; get; }", true)]
+		[DataRow(@"{ set{ } get{ return default; } }", true)]
+		[DataTestMethod]
+		public void OrderTests(string property, bool isError)
+		{
+			string text = $@"
+public class TestClass
+{{
+	public string Foo {property}
+}}
+";
+
+			VerifyCSharpDiagnostic(text, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.OrderPropertyAccessors) : Array.Empty<DiagnosticResult>());
+		}
+
+		#endregion
+	}
+}

--- a/Philips.CodeAnalysis.Test/Verifiers/AssertDiagnosticVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/AssertDiagnosticVerifier.cs
@@ -1,6 +1,7 @@
 // © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
 
+using System.Linq;
 using Microsoft.CodeAnalysis;
 
 namespace Philips.CodeAnalysis.Test
@@ -15,20 +16,17 @@ namespace Philips.CodeAnalysis.Test
 
 		#region Non-Public Properties/Methods
 
-		protected void VerifyError(string methodBody, string expectedDiagnosticId)
+		protected void VerifyError(string methodBody, params string[] expectedDiagnosticIds)
 		{
 			var test = _helper.GetText(methodBody, string.Empty, string.Empty);
 
-			VerifyCSharpDiagnostic(test,
-			new[]
-			{
+			VerifyCSharpDiagnostic(test, expectedDiagnosticIds.Select(expectedDiagnosticId =>
 				new DiagnosticResult()
 				{
 					Id = expectedDiagnosticId,
 					Severity = DiagnosticSeverity.Error,
 					Location = new DiagnosticResultLocation("Test0.cs", null, null),
-				}
-			});
+				}).ToArray());
 		}
 
 		protected void VerifyNoError(string methodBody)


### PR DESCRIPTION
* analyzer for avoiding lock(new object())
    * note that an existing analyzer said that the lock needed to be readonly, but that only applied if it was a field
* analyzer for avoiding "set/get" properties (prefer get/set)
* Fixed an oversight which allowed nullable operators in asserts, as long as they weren't directly in the ArgumentSytax
