### PR TITLE
Mayerj/nested range check fix

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -40,9 +40,9 @@
     <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <Version>1.2.8.1</Version>
+    <Version>1.2.8.2</Version>
     <AssemblyVersion>1.0.3.0</AssemblyVersion>
-    <FileVersion>1.2.8.1</FileVersion>
+    <FileVersion>1.2.8.2</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/PreventUnnecessaryRangeChecksAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/PreventUnnecessaryRangeChecksAnalyzer.cs
@@ -147,6 +147,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 				{
 					return false;
 				}
+
+				return true;
 			}
 
 			if (foreachExpression is MemberAccessExpressionSyntax memberAccess && ifExpression is MemberAccessExpressionSyntax ifMemberAccess)
@@ -188,9 +190,11 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 						return false;
 					}
 				}
+
+				return true;
 			}
 
-			return true;
+			return false;
 		}
 
 		private bool TryGetIdentifiers(ExpressionSyntax expression, out ExpressionSyntax ifIdentifier, out IdentifierNameSyntax method)

--- a/Philips.CodeAnalysis.Test/PreventUnnecessaryRangeChecksAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/PreventUnnecessaryRangeChecksAnalyzerTest.cs
@@ -175,6 +175,40 @@ class Foo
 			VerifyCSharpDiagnostic(errorCode);
 		}
 
+		[TestMethod]
+		public void CheckNestedRange2a()
+		{
+			const string template = @"
+public class Container
+{{
+  public List<int> Data {{ get; set; }}
+}}
+
+class Foo
+{{
+  public void test()
+  {{
+    Container container1 = new Container();
+    Container container2 = new Container();
+
+    List<string> other = new List<string>();
+    // comment
+    if(other.Count > 0)
+    {{
+      foreach (int i in container2.data)
+      {{
+      }}
+      //middle comment
+    }}
+    // end comment
+  }}
+}}
+";
+			string errorCode = string.Format(template);
+
+			VerifyCSharpDiagnostic(errorCode);
+		}
+
 		[DataRow("int[] data = new int[0]", "Length")]
 		[DataRow("int[] data = new int[0]", "Count()")]
 		[DataRow("List<int> data = new List<int>()", "Count")]


### PR DESCRIPTION
This fixes a bug where the analyzer would recommend removing the if(count.Length > 0) in below:

```
if(data.Length >0)
{
  foreach(var item in other.Items)
  {
  }
}
```