### PR TITLE
AvoidTask CodeFixer bug fix

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/AvoidTaskResultAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/AvoidTaskResultAnalyzer.cs
@@ -57,7 +57,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 				if (propertySymbol.ContainingNamespace.Name == ContainingNamespace &&
 					propertySymbol.ContainingType.Name.Contains(ContainingType))
 				{
-					Diagnostic diagnostic = Diagnostic.Create(Rule, propertyReference.Syntax.GetLocation());
+					Diagnostic diagnostic = Diagnostic.Create(Rule, propertySyntax.Name.GetLocation());
 					context.ReportDiagnostic(diagnostic);
 				}
 			}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -45,9 +45,9 @@
     <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <Version>1.2.9</Version>
+    <Version>1.2.9.1</Version>
     <AssemblyVersion>1.0.3.0</AssemblyVersion>
-    <FileVersion>1.2.9</FileVersion>
+    <FileVersion>1.2.9.1</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Philips.CodeAnalysis.Test/AvoidTaskResultAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/AvoidTaskResultAnalyzerTest.cs
@@ -36,6 +36,76 @@ class FooClass
 			VerifyCSharpFix(before, after);
 		}
 
+		[TestMethod]
+		public void AvoidTaskResultObjectCreationTest()
+		{
+			string template = $@"
+using System.Threading.Tasks;
+class FooClass
+{{{{
+  public async void Foo()
+  {{{{
+    var data = {{0}};
+  }}}}
+}}}}
+";
+			string before = string.Format(template, @"new Task<int>(() => 4).Result");
+			string after = string.Format(template, @"await new Task<int>(() => 4)");
+
+			VerifyCSharpDiagnostic(before, DiagnosticResultHelper.Create(DiagnosticIds.AvoidTaskResult));
+			VerifyCSharpFix(before, after);
+		}
+
+
+		[TestMethod]
+		public void AvoidTaskResultCallMethodTest()
+		{
+			string template = $@"
+using System.Threading.Tasks;
+class FooClass
+{{{{
+  public async Task<int> Foo(int x)
+  {{{{
+    return new Task<int>(() => x);
+  }}}}
+  public async void MyTest()
+  {{{{
+    var data = {{0}};
+  }}}}
+}}}}
+";
+			string before = string.Format(template, @"Foo(1).Result");
+			string after = string.Format(template, @"await Foo(1)");
+
+			VerifyCSharpDiagnostic(before, DiagnosticResultHelper.Create(DiagnosticIds.AvoidTaskResult));
+			VerifyCSharpFix(before, after);
+		}
+
+
+		[TestMethod]
+		public void AvoidTaskResultCallMethodThisTest()
+		{
+			string template = $@"
+using System.Threading.Tasks;
+class FooClass
+{{{{
+  public async Task<int> Foo(int x)
+  {{{{
+    return new Task<int>(() => x);
+  }}}}
+  public async void MyTest()
+  {{{{
+    var data = {{0}};
+  }}}}
+}}}}
+";
+			string before = string.Format(template, @"this.Foo(1).Result");
+			string after = string.Format(template, @"await this.Foo(1)");
+
+			VerifyCSharpDiagnostic(before, DiagnosticResultHelper.Create(DiagnosticIds.AvoidTaskResult));
+			VerifyCSharpFix(before, after);
+		}
+
 		protected override CodeFixProvider GetCSharpCodeFixProvider()
 		{
 			return new AvoidTaskResultCodeFixProvider();


### PR DESCRIPTION
Fix AvoidTask bug in CodeFixer where "foo.workAsync().Result" erroneously refactored to "await foo.Result" due to span start location