### PR TITLE
Extend copyright present analyzer with year and company name

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,4 +17,6 @@ dotnet_diagnostic.RS1025.severity = error
 dotnet_diagnostic.RS1026.severity = error
 dotnet_diagnostic.TI11409.severity = none
 
+dotnet_code_quality.PH2028.company_name = Koninklijke Philips N.V.
+
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,13 @@ root = true
 [*.cs]
 indent_style = tab
 dotnet_sort_system_directives_first = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
 
 dotnet_style_qualification_for_field = false:error
 dotnet_style_qualification_for_property = false:error

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/CopyrightPresentAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/CopyrightPresentAnalyzer.cs
@@ -23,6 +23,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 		private const string Category = Categories.Documentation;
 
 		private static DiagnosticDescriptor Rule = new DiagnosticDescriptor(Helper.ToDiagnosticId(DiagnosticIds.CopyrightPresent), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+		private static Regex yearRegex = new Regex(@"\d\d\d\d");
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
@@ -88,9 +89,12 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 			var hasCopyright = comment.Contains("©") || comment.Contains("Copyright");
 			
 			// Check the year
-			var yearRegex = new Regex(@"\d\d\d\d");
-			var hasYear = yearRegex.IsMatch(comment);
-			
+			bool hasYear;
+			lock (yearRegex)
+			{
+				hasYear = yearRegex.IsMatch(comment);
+			}
+
 			// Check the company name, only if it is configured.
 			var additionalFilesHelper = new AdditionalFilesHelper(context.Options, context.Compilation);
 			var companyName = additionalFilesHelper.GetValueFromEditorConfig(Rule.Id, @"company_name");

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/CopyrightPresentAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/CopyrightPresentAnalyzer.cs
@@ -89,11 +89,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 			var hasCopyright = comment.Contains("©") || comment.Contains("Copyright");
 			
 			// Check the year
-			bool hasYear;
-			lock (yearRegex)
-			{
-				hasYear = yearRegex.IsMatch(comment);
-			}
+			bool hasYear = yearRegex.IsMatch(comment);
 
 			// Check the company name, only if it is configured.
 			var additionalFilesHelper = new AdditionalFilesHelper(context.Options, context.Compilation);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/CopyrightPresentAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/CopyrightPresentAnalyzer.cs
@@ -1,6 +1,9 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
+using System.Text.RegularExpressions;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -13,17 +16,19 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 	public class CopyrightPresentAnalyzer : DiagnosticAnalyzer
 	{
 		private const string Title = @"Copyright Present";
-		private const string MessageFormat = @"File should start with a copyright statement.";
-		private const string Description = @"File should start with a copyright statement.";
+		private const string MessageFormat = 
+			@"File should start with a copyright statement, containing the company name, the year and either © or 'Copyright'.";
+		private const string Description =
+			@"File should start with a comment containing the company name, the year and either © or 'Copyright'.";
 		private const string Category = Categories.Documentation;
 
 		private static DiagnosticDescriptor Rule = new DiagnosticDescriptor(Helper.ToDiagnosticId(DiagnosticIds.CopyrightPresent), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
-		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 		public override void Initialize(AnalysisContext context)
 		{
-			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 			context.EnableConcurrentExecution();
 			context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.CompilationUnit);
 		}
@@ -62,8 +67,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 				copyrightSyntax = first[1];
 			}
 
-			string comment = copyrightSyntax.ToFullString();
-			if (!(comment.Contains("©") || comment.Contains("Copyright")))
+			bool isCorrectStatement = CheckCopyrightStatement(context, copyrightSyntax);
+			if (!isCorrectStatement)
 			{
 				CreateDiagnostic(context, copyrightSyntax.GetLocation());
 				return;
@@ -75,6 +80,23 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 		{
 			Diagnostic diagnostic = Diagnostic.Create(Rule, location);
 			context.ReportDiagnostic(diagnostic);
+		}
+
+		private static bool CheckCopyrightStatement(SyntaxNodeAnalysisContext context, SyntaxTrivia trivia) {
+			var comment = trivia.ToFullString();
+			// Check the copyright mar itself
+			var hasCopyright = comment.Contains("©") || comment.Contains("Copyright");
+			
+			// Check the year
+			var yearRegex = new Regex(@"\d\d\d\d");
+			var hasYear = yearRegex.IsMatch(comment);
+			
+			// Check the company name, only if it is configured.
+			var additionalFilesHelper = new AdditionalFilesHelper(context.Options, context.Compilation);
+			var companyName = additionalFilesHelper.GetValueFromEditorConfig(Rule.Id, @"company_name");
+			var hasCompanyName = string.IsNullOrEmpty(companyName) || comment.Contains(companyName);
+
+			return hasCopyright && hasYear && hasCompanyName;
 		}
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PackageId>Philips.CodeAnalysis.MaintainabilityAnalyzers</PackageId>
-    <Authors>Brian Collamore, Jean-Paul Mayer</Authors>
+    <Authors>Brian Collamore, Jean-Paul Mayer and Ynse Hoornenborg</Authors>
     <Company>Philips</Company>
     <PackageLicenseUrl>https://github.com/philips-software/roslyn-analyzers/blob/master/LICENSE.md</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/philips-software/roslyn-analyzers</RepositoryUrl>
@@ -31,7 +31,7 @@
 1.2.5
 * Fixes for PH2067 string interpolation
 * Introduce PH2080: Avoid hardcoded paths
-* Introduce PH2081:  Avoid regions in methods
+* Introduce PH2081: Avoid regions in methods
 1.2.6
 * Introduce PH2082 Positive naming
 1.2.7
@@ -45,14 +45,16 @@
 * Introduce PH2087: No space in filename
 * Introduce PH2088: Limit path length
 * Introduce PH2089: Avoid assignment in condition
+1.2.11
+* Extend "Copyright Present Analyzer" with year and configurable company name
     </PackageReleaseNotes>
     <Copyright>© 2019-2021 Koninklijke Philips N.V.</Copyright>
     <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <Version>1.2.10</Version>
+    <Version>1.2.11</Version>
     <AssemblyVersion>1.0.3.0</AssemblyVersion>
-    <FileVersion>1.2.10</FileVersion>
+    <FileVersion>1.2.11</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -6,7 +6,7 @@
 | PH2021  | Avoid inline new                             | Do not inline the constructor call.  Instead, create a local variable or a field for the temporary instance. |
 | PH2026  | Avoid SuppressMessage attribute              | SuppressMessage results in violations of codified coding guidelines.|
 | PH2027  | Avoid static methods                         | Static methods complicate Unit Testing.                      |
-| PH2028  | Copyright present                            | The top of the file should have a copyright.                 |
+| PH2028  | Copyright present                            | The top of the file should have a copyright statement. It should include: '©' or 'Copyright', the year and the company name if such is configured in the .editorconfig|
 | PH2029  | Avoid #pragma                                | #pragmas result in violations of codified coding guidelines. |
 | PH2030  | Variable naming conventions                  | Fields look like `_foo`. Locals look like `foo`.  (This analyzer does not respect IntelliSense settings in the .editorconfig.  It assumes this is your naming convention.)|
 | PH2031  | Avoid TryParse without Culture               | When interpreting a string as a number, always specify culture information.                                                             |


### PR DESCRIPTION
And make company name configurable in .editorconfig (see our own .editorconfig)