### PR TITLE
Member calling related analyzers

### DIFF
--- a/Philips.CodeAnalysis.Common/DiagnosticIds.cs
+++ b/Philips.CodeAnalysis.Common/DiagnosticIds.cs
@@ -85,5 +85,11 @@ namespace Philips.CodeAnalysis.Common
 		LogException = 2090,
 		ThrowInnerException = 2091,
 		LimitConditionComplexity = 2092,
+		AvoidGcCollect = 2093,
+		AvoidGcWaitForPendingFinalizers = 2094,
+		StringBuilderCapacity = 2095,
+		AvoidThreadStart = 2096,
+		AvoidWeakReferenceIsAlive = 2097,
+		AvoidMethodImplSynchronized = 2098,
 	}
 }

--- a/Philips.CodeAnalysis.Common/Helper.cs
+++ b/Philips.CodeAnalysis.Common/Helper.cs
@@ -424,5 +424,33 @@ namespace Philips.CodeAnalysis.Common
 					return false;
 			}
 		}
+
+		public static SyntaxToken GetInvokedMemberIdentifier(ExpressionSyntax node)
+		{
+			var expression = node;
+			if (expression.IsKind(SyntaxKind.ObjectCreationExpression))
+			{
+				var creation = (ObjectCreationExpressionSyntax)expression;
+				if (creation.Parent != null && creation.Parent.Parent is VariableDeclaratorSyntax varDecl)
+				{
+					return varDecl.Identifier;
+				}
+			}
+			else if (expression.IsKind(SyntaxKind.InvocationExpression))
+			{
+				expression = ((InvocationExpressionSyntax)expression).Expression;
+			}
+			if (expression.IsKind(SyntaxKind.SimpleMemberAccessExpression))
+			{
+				var memberAccess = (MemberAccessExpressionSyntax)expression;
+				expression = memberAccess.Expression;
+			}
+			if (expression.IsKind(SyntaxKind.IdentifierName))
+			{
+				var identifierName = (IdentifierNameSyntax)expression;
+				return identifierName.Identifier;
+			}
+			return SyntaxFactory.Identifier("unnamed");
+		}
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/MemberInClassAnalyzerBase.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/MemberInClassAnalyzerBase.cs
@@ -1,0 +1,220 @@
+﻿// © 2020 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
+{
+	/// <summary>
+	/// Base class for reporting when calling specific methods or properties.
+	/// </summary>
+	public abstract class MemberInClassAnalyzerBase : DiagnosticAnalyzer
+	{
+		private readonly string _classId;
+		private readonly string _methodId;
+		private readonly string[] _argumentIds;
+		private readonly bool _expectToCall;
+
+		private ImmutableArray<ISymbol> _memberSymbols;
+
+		/// <summary>
+		/// Constructor.
+		/// </summary>
+		/// <param name="className">Fully qualified classname (including namespace).</param>
+		/// <param name="methodName">The method or property name.</param>
+		protected MemberInClassAnalyzerBase(
+			string className,
+			string methodName
+		)
+		{
+			_classId = className;
+			_methodId = methodName;
+			_argumentIds = null;
+			_expectToCall = false;
+		}
+
+		/// <summary>
+		/// Constructor.
+		/// </summary>
+		/// <param name="className">Fully qualified classname (including namespace).</param>
+		/// <param name="methodName">The method or property name.</param>
+		/// <param name="expected">
+		/// If true encourage usage of this overload, otherwise discourage this overload
+		/// from being called.
+		/// </param>
+		/// <param name="arguments">
+		/// Method overload selection, based on type of the arguments
+		/// </param>
+		protected MemberInClassAnalyzerBase(
+			string className,
+			string methodName,
+			bool expected,
+			string[] arguments
+		)
+		{
+			_classId = className;
+			_methodId = methodName;
+			_argumentIds = arguments;
+			_expectToCall = expected;
+		}
+
+		/// <summary>
+		/// Called when a Diagnostic is identified.
+		/// </summary>
+		/// <param name="context">The analysis context.</param>
+		/// <param name="node">The <see cref="SyntaxNode"/> to report a Diagnostic on.</param>
+		protected abstract void OnReportDiagnostic(
+			SyntaxNodeAnalysisContext context,
+			ExpressionSyntax node
+		);
+
+		/// <summary>
+		/// <inheritdoc cref="DiagnosticAnalyzer"/>
+		/// </summary>
+		/// <param name="context"></param>
+		public override void Initialize(AnalysisContext context)
+		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.EnableConcurrentExecution();
+			context.RegisterCompilationStartAction(CompilationStart);
+		}
+
+		private void CompilationStart(CompilationStartAnalysisContext context)
+		{
+			var classSymbol = context.Compilation.GetTypeByMetadataName(_classId);
+			// Only continue when the class is accessible for this compilation.
+			if (classSymbol != null)
+			{
+				_memberSymbols = classSymbol.GetMembers(_methodId);
+				// Filter overloads
+				if (_argumentIds != null)
+				{
+					var argumentSymbols = _argumentIds.Select(
+						attr => context.Compilation.GetTypeByMetadataName(attr)).ToList();
+					_memberSymbols = _memberSymbols.Where(
+						method =>
+						{
+							if (method is IMethodSymbol methodSymbol)
+							{
+								var parameters = methodSymbol.Parameters.ToList();
+								return IsSameOverload(argumentSymbols, parameters);
+							}
+
+							return false;
+						}).ToImmutableArray();
+				}
+
+				// Register actions on invocations
+				// (Either constructor or accessing a method / property).
+				context.RegisterSyntaxNodeAction(
+					AnalyzeExpression,
+					SyntaxKind.ObjectCreationExpression);
+				context.RegisterSyntaxNodeAction(
+					AnalyzeExpression,
+					SyntaxKind.SimpleMemberAccessExpression);
+			}
+		}
+
+		private void AnalyzeExpression(SyntaxNodeAnalysisContext context)
+		{
+			if (context.Node is ExpressionSyntax invocation)
+			{
+				// Match the invoked symbol.
+				var args = GetArguments(invocation);
+				var invokeInfo = context.SemanticModel.GetSymbolInfo(context.Node);
+				var invokedSymbols = GetSymbols(invokeInfo);
+				if (
+					!invokedSymbols.IsEmpty &&
+					CheckMember(invokedSymbols.First()) &&
+					CheckMethodArguments(context, args) != _expectToCall
+				)
+				{
+					OnReportDiagnostic(context, invocation);
+				}
+			}
+		}
+
+		private ImmutableArray<ISymbol> GetSymbols(SymbolInfo info)
+		{
+			return info.Symbol != null ? ImmutableArray.Create(info.Symbol) : info.CandidateSymbols;
+		}
+
+		private ArgumentListSyntax GetArguments(ExpressionSyntax expression)
+		{
+			ArgumentListSyntax arguments = null;
+			if (expression is ObjectCreationExpressionSyntax creation)
+			{
+				arguments = creation.ArgumentList;
+			}
+			else if (expression is InvocationExpressionSyntax invocation)
+			{
+				arguments = invocation.ArgumentList;
+			}
+			return arguments;
+		}
+
+		private bool CheckMember(ISymbol symbol)
+		{
+			bool result = true;
+			if (symbol.ContainingType != null)
+			{
+				result = _classId.EndsWith(symbol.ContainingType.Name, StringComparison.Ordinal);
+			}
+			return result && _methodId.Equals(symbol.Name, StringComparison.Ordinal);
+		}
+
+		private bool CheckMethodArguments(SyntaxNodeAnalysisContext context, ArgumentListSyntax args)
+		{
+			bool result = false;
+			if (_argumentIds != null && _argumentIds.Any())
+			{
+				if (args != null)
+				{
+					// Expect same number of arguments
+					result = _argumentIds.Length == args.Arguments.Count;
+					if (result)
+					{
+						// Check the types of the arguments, in same order.
+						for (int i = 0; i < _argumentIds.Length; i++)
+						{
+							var variable = args.Arguments[i].Expression;
+							var variableType = ModelExtensions.GetTypeInfo(context.SemanticModel, variable).Type;
+							if (variableType != null)
+							{
+								result &= _argumentIds[i].EndsWith(variableType.Name, StringComparison.Ordinal);
+							}
+						}
+					}
+				}
+			}
+			else
+			{
+				// Expecting no arguments.
+				result = args == null || args.Arguments.Any();
+			}
+			return result;
+		}
+		private bool IsSameOverload(
+			List<INamedTypeSymbol> expected,
+			List<IParameterSymbol> actual
+		)
+		{
+			var areSame = expected.Count == actual.Count;
+			if (areSame)
+			{
+				for (var i = 0; i < expected.Count; i++)
+				{
+					areSame &= ReferenceEquals(expected[i], actual[i].Type);
+				}
+			}
+			return areSame;
+		}
+	}
+}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -50,7 +50,13 @@
 1.2.12
 * Introduce PH2090: Log Exceptions
 * Introduce PH2091:	Throw Inner Exception
-* Introduce PH2092: Limit Condition Complexity 
+* Introduce PH2092: Limit Condition Complexity
+* Introduce PH2093: Avoid GC.Collect()
+* Introduce PH2094: Avoid GC.WaitForPendingFinalizers()
+* Introduce PH2095: StringBuilder capacity
+* Introduce PH2096: Avoid Thread start
+* Introduce PH2097: Avoid WeakReference.IsAlive
+* Introduce PH2098: Avoid MethodImpl.Synchronized
     </PackageReleaseNotes>
     <Copyright>© 2019-2021 Koninklijke Philips N.V.</Copyright>
     <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -45,4 +45,9 @@
 | PH2090  |	Log Exception                                | Log any of the caught exceptions. The Log method names are configurable in the .editorconfig using key: 'dotnet_code_quality.PH2090.log_method_names'.|
 | PH2091  |	Throw Inner Exception                        | When throwing an exception inside a catch block, include the original exception as arguments. This will show the inner exception also in a Callstack, aiding debugability. |
 | PH2092  | Limit Condition Complexity                   | Limit the number of logical expressions in a single condition. Humans are not very good of keeping track of large logical expressions. The maximum allowed number is configurable in the .editorconfig using key: 'dotnet_code_quality.PH2092.max_operators'.|
-
+| PH2093  | Avoid GC.Collect                             | GC.Collect does not guarantee the Garbage Collecter will run. |
+| PH2094  | Avoid GC.WaitForPendingFinalizers            | Code should not rely on behavior in finalizers. Also, in multithreaded application, there is no guarantee this method will terminate. |
+| PH2095  | StringBuilder capacity                       | Create a StringBuilder instance, with a large enough capacity. If not, garbage is created anyhow. |
+| PH2096  | Avoid new Thread()                           | Avoid creating your own thread, this is an expensive operation. Use the ThreadPool instead. |
+| PH2097  | Avoid WeakReference.IsAlive                  | After checking WeakReference.IsAlive, there is no guarantee that the reference is still alive the next statement, the Garbage Collector could have finalized it in the (short) meantime. |
+| PH2098  | Avoid MethodImpl.Synchronized                | The attribute [MethodImpl(MothodImplOptions.Synchronized)] will inject code around the method, which locks on the class instance. |

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/AvoidGcCollectAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/AvoidGcCollectAnalyzer.cs
@@ -1,0 +1,59 @@
+﻿// © 2020 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System.Collections.Immutable;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
+{
+	/// <summary>
+	/// Diagnostic to avoid calling <see cref="System.GC.Collect()"/> directly.
+	/// </summary>
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class AvoidGcCollectAnalyzer : MemberInClassAnalyzerBase
+	{
+		private const string Title = "Avoid explicitly call GC.Collect().";
+		private const string Message = "Avoid calling GC.Collect() explicitly.";
+		private const string Description = "Avoid explicitly call GC.Collect().";
+		private const string Category = Categories.RuntimeFailure;
+
+		/// <summary>
+		/// Constructor.
+		/// </summary>
+		public AvoidGcCollectAnalyzer() : base("System.GC", "Collect")
+		{
+		}
+
+		private static readonly DiagnosticDescriptor Rule =
+			new DiagnosticDescriptor(
+				Helper.ToDiagnosticId(DiagnosticIds.AvoidGcCollect),
+				Title,
+				Message,
+				Category,
+				DiagnosticSeverity.Error,
+				isEnabledByDefault: true,
+				description: Description
+			);
+
+		/// <summary>
+		/// <inheritdoc cref="DiagnosticAnalyzer"/>
+		/// </summary>
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		/// <summary>
+		/// <inheritdoc cref="DiagnosticAnalyzer"/>
+		/// </summary>
+		protected override void OnReportDiagnostic(
+			SyntaxNodeAnalysisContext context,
+			ExpressionSyntax node
+		)
+		{
+			var location = node.GetLocation();
+			context.ReportDiagnostic(Diagnostic.Create(Rule, location));
+		}
+	}
+}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/AvoidGcWaitForPendingFinalizersAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/AvoidGcWaitForPendingFinalizersAnalyzer.cs
@@ -1,0 +1,62 @@
+﻿// © 2020 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System.Collections.Immutable;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
+{
+	/// <summary>
+	/// Diagnostic to avoid calling <see cref="System.GC.WaitForPendingFinalizers()"/>.
+	/// </summary>
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class AvoidGcWaitForPendingFinalizersAnalyzer : MemberInClassAnalyzerBase
+	{
+		private const string Title = "Avoid calling GC.WaitForPendingFinalizers().";
+		private const string Message = "Avoid calling GC.WaitForPendingFinalizers().";
+		private const string Description = "Avoid calling GC.WaitForPendingFinalizers().";
+		private const string Category = Categories.RuntimeFailure;
+
+		/// <summary>
+		/// Constructor.
+		/// </summary>
+		public AvoidGcWaitForPendingFinalizersAnalyzer() : base(
+			"System.GC",
+			"WaitForPendingFinalizers"
+		)
+		{
+		}
+
+		private static readonly DiagnosticDescriptor Rule =
+			new DiagnosticDescriptor(
+				Helper.ToDiagnosticId(DiagnosticIds.AvoidGcWaitForPendingFinalizers),
+				Title,
+				Message,
+				Category,
+				DiagnosticSeverity.Error,
+				isEnabledByDefault: true,
+				description: Description
+			);
+
+		/// <summary>
+		/// <inheritdoc cref="DiagnosticAnalyzer"/>
+		/// </summary>
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		/// <summary>
+		/// <inheritdoc cref="DiagnosticAnalyzer"/>
+		/// </summary>
+		protected override void OnReportDiagnostic(
+			SyntaxNodeAnalysisContext context,
+			ExpressionSyntax node
+		)
+		{
+			var location = node.GetLocation();
+			context.ReportDiagnostic(Diagnostic.Create(Rule, location));
+		}
+	}
+}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/AvoidMethodImplSynchronizedAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/AvoidMethodImplSynchronizedAnalyzer.cs
@@ -1,0 +1,87 @@
+﻿// © 2020 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
+{
+	/// <summary>
+	/// Report when a class or method has the MethodImplAttribute with the option
+	/// MethodImplOptions.Synchronized.
+	/// </summary>
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class AvoidMethodImplSynchronizedAnalyzer : DiagnosticAnalyzer
+	{
+		private const string Title =
+			"Avoid using [MethodImpl(MethodImplOptions.Synchorinzed] on methods.";
+		private const string MethodMessage =
+			"Method {0} should not have the MethodImplOptions.Synchronized.";
+		private const string Description =
+			"Avoid using [MethodImpl(MethodImplOptions.Synchronized)] on methods.";
+		private const string Category = "Usage";
+
+		private static readonly DiagnosticDescriptor Rule =
+			new DiagnosticDescriptor(
+				Helper.ToDiagnosticId(DiagnosticIds.AvoidMethodImplSynchronized),
+				Title,
+				MethodMessage,
+				Category,
+				DiagnosticSeverity.Error,
+				isEnabledByDefault: true,
+				description: Description
+			);
+
+		/// <summary>
+		/// <inheritdoc cref="DiagnosticAnalyzer"/>
+		/// </summary>
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		/// <summary>
+		/// <inheritdoc cref="DiagnosticAnalyzer"/>
+		/// </summary>
+		public override void Initialize(AnalysisContext context)
+		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.EnableConcurrentExecution();
+			context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Method);
+		}
+
+		private void AnalyzeSymbol(SymbolAnalysisContext context)
+		{
+			var symbol = context.Symbol;
+			var attributes = symbol.GetAttributes();
+			if (attributes.Any())
+			{
+				var methodImpl = attributes.Where(IsMethodImplAttributeWithSynchronizedOption);
+				if (methodImpl.Any())
+				{
+					var diagnostic = Diagnostic.Create(Rule, symbol.Locations[0], symbol.Name);
+					context.ReportDiagnostic(diagnostic);
+				}
+			}
+		}
+
+		private bool IsMethodImplAttributeWithSynchronizedOption(AttributeData attr)
+		{
+			bool isMethodImpl = false;
+			if (
+				attr.AttributeClass != null &&
+				attr.AttributeClass.Name == "MethodImplAttribute" &&
+				!attr.ConstructorArguments.IsEmpty
+			)
+			{
+				var argument = attr.ConstructorArguments.First();
+				// Check is Synchronized flag is set (value is 32).
+				var isSynchronized = ((int)argument.Value & 32) != 0;
+				isMethodImpl = isSynchronized;
+			}
+			return isMethodImpl;
+		}
+	}
+}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/AvoidThreadStartAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/AvoidThreadStartAnalyzer.cs
@@ -1,0 +1,60 @@
+﻿// © 2020 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System.Collections.Immutable;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
+{
+	/// <summary>
+	/// Diagnostic for using threads from the <see cref="System.Threading.ThreadPool"/> exclusively.
+	/// </summary>
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class AvoidThreadStartAnalyzer : MemberInClassAnalyzerBase
+	{
+		private const string Title = "Avoid creating threads directly.";
+		private const string Message = "Thread {0} should be taken from the ThreadPool.";
+		private const string Description = "Avoid creating threads directly.";
+		private const string Category = Categories.RuntimeFailure;
+
+		/// <summary>
+		/// Constructor.
+		/// </summary>
+		public AvoidThreadStartAnalyzer() : base("System.Threading.Thread", ".ctor")
+		{
+		}
+
+		private static readonly DiagnosticDescriptor Rule =
+			new DiagnosticDescriptor(
+				Helper.ToDiagnosticId(DiagnosticIds.AvoidThreadStart),
+				Title,
+				Message,
+				Category,
+				DiagnosticSeverity.Error,
+				isEnabledByDefault: true,
+				description: Description
+			);
+
+		/// <summary>
+		/// <inheritdoc cref="DiagnosticAnalyzer"/>
+		/// </summary>
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		/// <summary>
+		/// <inheritdoc cref="DiagnosticAnalyzer"/>
+		/// </summary>
+		protected override void OnReportDiagnostic(
+			SyntaxNodeAnalysisContext context,
+			ExpressionSyntax node
+		)
+		{
+			var variableName = Helper.GetInvokedMemberIdentifier(node).Text;
+			var loc = node.GetLocation();
+			context.ReportDiagnostic(Diagnostic.Create(Rule, loc, variableName));
+		}
+	}
+}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/AvoidWeakReferenceIsAliveAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/AvoidWeakReferenceIsAliveAnalyzer.cs
@@ -1,0 +1,60 @@
+﻿// © 2020 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System.Collections.Immutable;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
+{
+	/// <summary>
+	/// Diagnostic for calling <see cref="System.WeakReference.IsAlive"/>.
+	/// </summary>
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class AvoidWeakReferenceIsAliveAnalyzer : MemberInClassAnalyzerBase
+	{
+		private const string Title = "Avoid calling WeakReference.IsAlive.";
+		private const string Message =
+			"Calling IsAlive on variable {0} which is of type WeakReference.";
+		private const string Description = "Avoid calling WeakReference.IsAlive.";
+		private const string Category = Categories.RuntimeFailure;
+
+		/// <summary>
+		/// Constructor.
+		/// </summary>
+		public AvoidWeakReferenceIsAliveAnalyzer() : base("System.WeakReference", "IsAlive")
+		{
+		}
+
+		private static readonly DiagnosticDescriptor Rule =
+			new DiagnosticDescriptor(
+				Helper.ToDiagnosticId(DiagnosticIds.AvoidWeakReferenceIsAlive),
+				Title,
+				Message,
+				Category,
+				DiagnosticSeverity.Error,
+				isEnabledByDefault: true,
+				description: Description
+			);
+
+		/// <summary>
+		/// <inheritdoc cref="DiagnosticAnalyzer"/>
+		/// </summary>
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		/// <summary>
+		/// <inheritdoc cref="DiagnosticAnalyzer"/>
+		/// </summary>
+		protected override void OnReportDiagnostic(
+			SyntaxNodeAnalysisContext context,
+			ExpressionSyntax node
+		)
+		{
+			var variableName = Helper.GetInvokedMemberIdentifier(node).Text;
+			context.ReportDiagnostic(Diagnostic.Create(Rule, node.GetLocation(), variableName));
+		}
+	}
+}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/StringBuilderCapacityAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/StringBuilderCapacityAnalyzer.cs
@@ -1,0 +1,65 @@
+﻿// © 2020 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System.Collections.Immutable;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
+{
+	/// <summary>
+	/// Diagnostic for creating <see cref="System.Text.StringBuilder"/> with an explicitly set capacity.
+	/// </summary>
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class StringBuilderCapacityAnalyzer : MemberInClassAnalyzerBase
+	{
+		private const string Title = "Create StringBuilder with Capacity.";
+		private const string Message = "Initialize StringBuilder variable {0} with Capacity.";
+		private const string Description = "Create StringBuilder with Capacity.";
+		private const string Category = Categories.RuntimeFailure;
+
+		/// <summary>
+		/// Constructor.
+		/// </summary>
+		public StringBuilderCapacityAnalyzer() : base(
+			"System.Text.StringBuilder",
+			".ctor",
+			true,
+			new[] { "System.Int32" }
+		)
+		{
+		}
+
+		private static readonly DiagnosticDescriptor Rule =
+			new DiagnosticDescriptor(
+				Helper.ToDiagnosticId(DiagnosticIds.StringBuilderCapacity),
+				Title,
+				Message,
+				Category,
+				DiagnosticSeverity.Error,
+				isEnabledByDefault: true,
+				description: Description
+			);
+
+		/// <summary>
+		/// <inheritdoc cref="DiagnosticAnalyzer"/>
+		/// </summary>
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		/// <summary>
+		/// <inheritdoc cref="DiagnosticAnalyzer"/>
+		/// </summary>
+		protected override void OnReportDiagnostic(
+			SyntaxNodeAnalysisContext context,
+			ExpressionSyntax node
+		)
+		{
+			var variableName = Helper.GetInvokedMemberIdentifier(node).Text;
+			var loc = node.GetLocation();
+			context.ReportDiagnostic(Diagnostic.Create(Rule, loc, variableName));
+		}
+	}
+}

--- a/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/AvoidGcCollectAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/AvoidGcCollectAnalyzerTest.cs
@@ -1,0 +1,76 @@
+﻿// © 2020 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Philips.CodeAnalysis.Common;
+using Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure;
+
+namespace Philips.CodeAnalysis.Test.Maintainability.RuntimeFailure
+{
+	/// <summary>
+	/// Test class for <see cref="AvoidGcCollectAnalyzer"/>.
+	/// </summary>
+	[TestClass]
+	public class AvoidGcCollectAnalyzerTest : DiagnosticVerifier
+	{
+
+		private const string Correct = @"
+    namespace GcCollectUnitTests {
+        public class Program {
+            public bool Main() {
+                return true;
+            }
+        }
+    }";
+
+		private const string Violation = @"
+    using System;
+
+    namespace GcCollectUnitTests {
+        public class Program {
+            public bool Main() {
+                GC.Collect();
+                return false;
+            }
+        }
+    }";
+
+		/// <summary>
+		/// No diagnostics expected to show up. 
+		/// </summary>
+		[TestMethod]
+		[DataRow("", DisplayName = "Empty"),
+		 DataRow(Correct, DisplayName = "Correct")]
+		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
+		{
+			VerifyCSharpDiagnostic(testCode);
+		}
+
+		/// <summary>
+		/// Diagnostic is expected to show up. 
+		/// </summary>
+		[TestMethod]
+		[DataRow(Violation, 7, 17, DisplayName = "Violation")]
+		public void WhenGcCollectIsCalledDiagnosticIsRaised(string testCode, int line, int column)
+		{
+			var expected = DiagnosticResultHelper.Create(DiagnosticIds.AvoidGcCollect);
+			VerifyCSharpDiagnostic(testCode, expected);
+		}
+
+		/// <summary>
+		/// No diagnostics expected to show up 
+		/// </summary>
+		[TestMethod]
+		[DataRow(Violation, "Test.g", DisplayName = "OutOfScopeSourceFile")]
+		public void WhenSourceFileIsOutOfScopeNoDiagnosticIsTriggered(string testCode, string filePath)
+		{
+			VerifyCSharpDiagnostic(testCode, filePath);
+		}
+
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		{
+			return new AvoidGcCollectAnalyzer();
+		}
+	}
+}

--- a/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/AvoidGcWaitForPendingFinalizersAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/AvoidGcWaitForPendingFinalizersAnalyzerTest.cs
@@ -1,0 +1,81 @@
+﻿// © 2020 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Philips.CodeAnalysis.Common;
+using Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure;
+
+namespace Philips.CodeAnalysis.Test.Maintainability.RuntimeFailure
+{
+	/// <summary>
+	/// Test class for <see cref="AvoidGcWaitForPendingFinalizersAnalyzer"/>.
+	/// </summary>
+	[TestClass]
+	public class AvoidGcWaitForPendingFinalizersAnalyzerTest : DiagnosticVerifier
+	{
+
+		private const string Correct = @"
+    namespace GcWaitForPendingFinalizersTests {
+        public class Program {
+            public bool Main() {
+                return true;
+            }
+        }
+    }";
+
+		private const string Violation = @"
+    using System;
+
+    namespace GcWaitForPendingFinalizersTests {
+        public class Program {
+            public bool Main() {
+                GC.WaitForPendingFinalizers();
+                return false;
+            }
+        }
+    }";
+
+		/// <summary>
+		/// No diagnostics expected to show up. 
+		/// </summary>
+		[TestMethod]
+		[DataRow("", DisplayName = "Empty"),
+		 DataRow(Correct, DisplayName = "Correct")]
+		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
+		{
+			VerifyCSharpDiagnostic(testCode);
+		}
+
+		/// <summary>
+		/// Diagnostic is expected to show up. 
+		/// </summary>
+		[TestMethod]
+		[DataRow(Violation, 7, 17, DisplayName = "Violation")]
+		public void WhenGcWaitForPendingFinalizersIsCalledDiagnosticIsRaised(
+			string testCode,
+			int line,
+			int column
+		)
+		{
+			var expected =
+				DiagnosticResultHelper.Create(DiagnosticIds.AvoidGcWaitForPendingFinalizers);
+			VerifyCSharpDiagnostic(testCode, expected);
+		}
+
+		/// <summary>
+		/// No diagnostics expected to show up 
+		/// </summary>
+		[TestMethod]
+		[DataRow(Violation, "Test.Designer", DisplayName = "OutOfScopeSourceFile")]
+		public void WhenSourceFileIsOutOfScopeNoDiagnosticIsTriggered(string testCode, string filePath)
+		{
+			VerifyCSharpDiagnostic(testCode, filePath);
+		}
+
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		{
+			return new AvoidGcWaitForPendingFinalizersAnalyzer();
+		}
+	}
+}

--- a/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/AvoidMethodImplSynchronizedAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/AvoidMethodImplSynchronizedAnalyzerTest.cs
@@ -1,0 +1,108 @@
+﻿// © 2020 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Philips.CodeAnalysis.Common;
+using Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure;
+
+namespace Philips.CodeAnalysis.Test.Maintainability.RuntimeFailure
+{
+	/// <summary>
+	/// Test class for <see cref="AvoidMethodImplSynchronizedAnalyzer"/>.
+	/// </summary>
+	[TestClass]
+	public class AvoidMethodImplSynchronizedUnitTests : DiagnosticVerifier
+	{
+
+		private const string NoAttribute = @"
+    using System;
+    using System.Runtime.CompilerServices;
+
+    namespace MethodImplSynchronizedUnitTests {
+        public class Program {
+            public bool Main() {
+                return true;
+            }
+        }
+    }";
+
+		private const string OtherOptionsMethod = @"
+    using System;
+    using System.Runtime.CompilerServices;
+
+    namespace MethodImplSynchronizedUnitTests {
+        public class Program {
+            [MethodImpl(MethodImplOptions.NoInlining]
+            public bool Main() {
+                return true;
+            }
+        }
+    }";
+
+		private const string OtherOptionsClass = @"
+    using System;
+    using System.Runtime.CompilerServices;
+
+    namespace MethodImplSynchronizedUnitTests {
+        [MethodImpl(MethodImplOptions.NoInlining]
+        public class Program {
+            public bool Main() {
+                return true;
+            }
+        }
+    }";
+
+		private const string ViolationOnMethod = @"
+    using System;
+    using System.Runtime.CompilerServices;
+
+    namespace MethodImplSynchronizedUnitTests {
+        public class Program {
+            [MethodImpl(MethodImplOptions.Synchronized]
+            public bool Main() {
+                return false;
+            }
+        }
+    }";
+
+		/// <summary>
+		/// No diagnostics expected to show up
+		/// </summary>
+		[TestMethod]
+		[DataRow("", DisplayName = "Empty"),
+		 DataRow(NoAttribute, DisplayName = "NoAttribute"),
+		 DataRow(OtherOptionsClass, DisplayName = "OtherOptionsClass"),
+		 DataRow(OtherOptionsMethod, DisplayName = "OtherOptionsMethod")]
+		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
+		{
+			VerifyCSharpDiagnostic(testCode);
+		}
+
+		/// <summary>
+		/// Diagnostics expected to show up
+		/// </summary>
+		[TestMethod]
+		[DataRow(ViolationOnMethod, DisplayName = "ViolationOnMethod")]
+		public void WhenMethodHasAttributeDiagnosticIsRaised(string testCode)
+		{
+			var expected = DiagnosticResultHelper.Create(DiagnosticIds.AvoidMethodImplSynchronized);
+			VerifyCSharpDiagnostic(testCode, expected);
+		}
+
+		/// <summary>
+		/// No diagnostics expected to show up 
+		/// </summary>
+		[TestMethod]
+		[DataRow(ViolationOnMethod, "Test.g", DisplayName = "OutOfScopeSourceFile")]
+		public void WhenSourceFileIsOutOfScopeNoDiagnosticIsTriggered(string testCode, string filePath)
+		{
+			VerifyCSharpDiagnostic(testCode, filePath);
+		}
+
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		{
+			return new AvoidMethodImplSynchronizedAnalyzer();
+		}
+	}
+}

--- a/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/AvoidThreadStartAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/AvoidThreadStartAnalyzerTest.cs
@@ -1,0 +1,154 @@
+﻿// © 2020 Koninklijke Philips N.V. See License.md in the project root for license information.
+ 
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Philips.CodeAnalysis.Common;
+using Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure;
+
+namespace Philips.CodeAnalysis.Test.Maintainability.RuntimeFailure
+{
+	/// <summary>
+	/// Test class for <see cref="AvoidThreadStartAnalyzer"/>.
+	/// </summary>
+	[TestClass]
+	public class AvoidThreadStartAnalyzerTest : DiagnosticVerifier
+	{
+
+		private const string Correct = @"
+    using System.Threading;
+
+    namespace ThreadStartUnitTests {
+        public class Program {
+            private void DoWork() {
+            }
+
+            public Thread Main() {
+                ThreadStart work = this.DoWork;
+                var worker = ThreadPool.QueueUserWorkItem(work);
+                return worker;
+            }
+        }
+    }";
+
+		private const string CorrectWithParameter = @"
+    using System.Threading;
+
+    namespace ThreadStartUnitTests {
+        public class Program {
+            private void DoWork(object data) {
+            }
+
+            public Thread Main() {
+                var worker = ThreadPool.QueueUserWorkItem((ParameterizedThreadStart)this.DoWork);
+                return worker;
+            }
+        }
+    }";
+
+		private const string Instance = @"
+    using System.Threading;
+
+    namespace ThreadStartUnitTests {
+        public class Program {
+            private void DoWork() {
+            }
+
+            public Thread Main() {
+                ThreadStart work = this.DoWork;
+                var worker = new Thread(work);
+                return worker;
+            }
+        }
+    }";
+
+		private const string Static = @"
+    using System.Threading;
+
+    namespace ThreadStartUnitTests {
+        public class Program {
+            private static void DoWork() {
+            }
+
+            public Thread Main() {
+                ThreadStart work = Program.DoWork;
+                var worker = new Thread(work);
+                return worker;
+            }
+        }
+    }";
+
+		private const string InstanceWithParameter = @"
+    using System.Threading;
+
+    namespace ThreadStartUnitTests {
+        public class Program {
+            private void DoWork(object data) {
+            }
+
+            public Thread Main() {
+                ParameterizedThreadStart work = this.DoWork;
+                var worker = new Thread(work);
+                return worker;
+            }
+        }
+    }";
+
+		private const string StaticWithParameter = @"
+    using System.Threading;
+
+    namespace ThreadStartUnitTests {
+        public class Program {
+            private static void DoWork(object data) {
+            }
+
+            public Thread Main() {
+                ParameterizedThreadStart work = Program.DoWork;                
+                var worker = new Thread(work);
+                return worker;
+            }
+        }
+    }";
+
+		/// <summary>
+		/// No diagnostics expected to show up
+		/// </summary>
+		[TestMethod]
+		[DataRow("", DisplayName = "Empty"),
+		 DataRow(Correct, DisplayName = "Correct"),
+		 DataRow(CorrectWithParameter, DisplayName = "CorrectWithParameter")]
+		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
+		{
+			VerifyCSharpDiagnostic(testCode);
+		}
+
+		/// <summary>
+		/// Diagnostics expected to show up
+		/// </summary>
+		[TestMethod]
+		[DataRow(Instance, DisplayName = "Instance"),
+		 DataRow(InstanceWithParameter, DisplayName = "InstanceWithParameter"),
+		 DataRow(Static, DisplayName = "Static"),
+		 DataRow(StaticWithParameter, DisplayName = "StaticWithParameter")]
+		public void WhenThreadIsCreatedDirectlyDiagnosticIsRaised(string testCode)
+		{
+			var expected = DiagnosticResultHelper.Create(DiagnosticIds.AvoidThreadStart);
+			VerifyCSharpDiagnostic(testCode, expected);
+		}
+
+		/// <summary>
+		/// No diagnostics expected to show up 
+		/// </summary>
+		[TestMethod]
+		[DataRow(Instance, "Test.g", DisplayName = "OutOfScopeSourceFile")]
+		public void WhenSourceFileIsOutOfScopeNoDiagnosticIsTriggered(string testCode, string filePath)
+		{
+			VerifyCSharpDiagnostic(testCode, filePath);
+		}
+
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		{
+			return new AvoidThreadStartAnalyzer();
+		}
+	}
+}

--- a/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/AvoidWeakReferenceIsAliveAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/AvoidWeakReferenceIsAliveAnalyzerTest.cs
@@ -1,0 +1,81 @@
+﻿// © 2020 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Philips.CodeAnalysis.Common;
+using Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure;
+
+namespace Philips.CodeAnalysis.Test.Maintainability.RuntimeFailure
+{
+	/// <summary>
+	/// Test class for <see cref="AvoidWeakReferenceIsAliveAnalyzer"/>.
+	/// </summary>
+	[TestClass]
+	public class AvoidWeakReferenceIsAliveAnalyzerTest : DiagnosticVerifier
+	{
+
+		private const string OtherType = @"
+    namespace WeakReferenceIsAliveUnitTests {
+        public class WeakRef {
+            public bool IsAlive { get; }
+        }
+
+        public class Program {
+            public bool Main() {
+                var weak = new WeakRef();
+                return weak.IsAlive;
+            }
+        }
+    }";
+
+		private const string Violation = @"
+    using System;
+
+    namespace WeakReferenceIsAliveUnitTests {
+        public class Program {
+            public bool Main() {
+                var weak = new WeakReference();
+                return weak.IsAlive;
+            }
+        }
+    }";
+
+		/// <summary>
+		/// No diagnostics expected to show up.
+		/// </summary>
+		[TestMethod]
+		[DataRow("", DisplayName = "Correct"),
+		 DataRow(OtherType, DisplayName = "OtherType")]
+		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
+		{
+			VerifyCSharpDiagnostic(testCode);
+		}
+
+		/// <summary>
+		/// Diagnostic is expected to show up.
+		/// </summary>
+		[TestMethod]
+		[DataRow(Violation, DisplayName = "Violation")]
+		public void WhenWeakReferenceIsAliveIsCalledDiagnosticIsRaised(string testCode)
+		{
+			var expected = DiagnosticResultHelper.Create(DiagnosticIds.AvoidWeakReferenceIsAlive);
+			VerifyCSharpDiagnostic(testCode, expected);
+		}
+
+		/// <summary>
+		/// No diagnostics expected to show up 
+		/// </summary>
+		[TestMethod]
+		[DataRow(Violation, "Test.Designer", DisplayName = "OutOfScopeSourceFile")]
+		public void WhenSourceFileIsOutOfScopeNoDiagnosticIsTriggered(string testCode, string filePath)
+		{
+			VerifyCSharpDiagnostic(testCode, filePath);
+		}
+
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		{
+			return new AvoidWeakReferenceIsAliveAnalyzer();
+		}
+	}
+}

--- a/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/StringBuilderCapacityAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/StringBuilderCapacityAnalyzerTest.cs
@@ -1,0 +1,101 @@
+﻿// © 2020 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Philips.CodeAnalysis.Common;
+using Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure;
+
+namespace Philips.CodeAnalysis.Test.Maintainability.RuntimeFailure
+{
+	/// <summary>
+	/// Test class for <see cref="StringBuilderCapacityAnalyzer"/>.
+	/// </summary>
+	[TestClass]
+	public class StringBuilderCapacityAnalyzerTest : DiagnosticVerifier
+	{
+
+		private const string Correct = @"
+    using System.Text;
+
+    namespace StringBuilderCapacityUnitTests {
+        public class Program {
+            public string Main() {
+                int capacity = 42;
+                var builder = new StringBuilder(capacity);
+                return builder.ToString();
+            }
+        }
+    }";
+
+		private const string Violation = @"
+    using System.Text;
+
+    namespace StringBuilderCapacityUnitTests {
+        public class Program {
+            public string Main() {
+                var builder = new StringBuilder();
+                return builder.ToString();
+            }
+        }
+    }";
+
+		private const string OtherClass = @"
+    using System;
+
+    namespace StringBuilderCapacityUnitTests {
+        public class StingBuilder {
+        }
+        public class Program {
+            public string Main() {
+                int capacity = 42;
+                var builder = new StingBuilder();
+                return builder.ToString();
+            }
+        }
+    }";
+
+		/// <summary>
+		/// No diagnostics expected to show up
+		/// </summary>
+		[TestMethod]
+		[DataRow("", DisplayName = "Empty"),
+		 DataRow(Correct, DisplayName = nameof(Correct)),
+		 DataRow(OtherClass, DisplayName = nameof(OtherClass))]
+		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
+		{
+			VerifyCSharpDiagnostic(testCode);
+		}
+
+		/// <summary>
+		/// Diagnostics expected to show up
+		/// </summary>
+		[TestMethod]
+		[DataRow(Violation, "builder", 7, 31, DisplayName = nameof(Violation))]
+		public void WhenStringBuilderIsCreatedWithoutCapacityDiagnosticIsRaised(
+			string testCode,
+			string identifier,
+			int line,
+			int column
+		)
+		{
+			var expected = DiagnosticResultHelper.Create(DiagnosticIds.StringBuilderCapacity);
+			VerifyCSharpDiagnostic(testCode, expected);
+		}
+
+		/// <summary>
+		/// No diagnostics expected to show up 
+		/// </summary>
+		[TestMethod]
+		[DataRow(Violation, "Test.g", DisplayName = "OutOfScopeSourceFile")]
+		public void WhenSourceFileIsOutOfScopeNoDiagnosticIsTriggered(string testCode, string filePath)
+		{
+			VerifyCSharpDiagnostic(testCode, filePath);
+		}
+
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		{
+			return new StringBuilderCapacityAnalyzer();
+		}
+	}
+}


### PR DESCRIPTION
Introduce several Analyzers that encourage or discourage calling certain method (overloads) or properties.

These analyzers are added:
AvoidGcCollect = 2093,
AvoidGcWaitForPendingFinalizers = 2094,
StringBuilderCapacity = 2095,
AvoidThreadStart = 2096,
AvoidWeakReferenceIsAlive = 2097,
AvoidMethodImplSynchronized = 2098,

And also a base class for these kind of Analyzers is added, MemberInClassAnalyzerBase.

