### PR TITLE
Force testmethods to return void or task only

### DIFF
--- a/Philips.CodeAnalysis.Common/DiagnosticIds.cs
+++ b/Philips.CodeAnalysis.Common/DiagnosticIds.cs
@@ -87,5 +87,6 @@ namespace Philips.CodeAnalysis.Common
 		LimitConditionComplexity = 2092,
 		PreferTuplesWithNamedFields = 2093,
 		PreferUsingNamedTupleField = 2094,
+		TestMethodsMustHaveValidReturnType = 2095,
 	}
 }

--- a/Philips.CodeAnalysis.MsTestAnalyzers/Philips.CodeAnalysis.MsTestAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/Philips.CodeAnalysis.MsTestAnalyzers.csproj
@@ -24,9 +24,9 @@
     <PackageTags>CSharp MsTest Roslyn CodeAnalysis analyzers Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <Version>1.1.5</Version>
+    <Version>1.1.6</Version>
     <AssemblyVersion>1.0.1.0</AssemblyVersion>
-    <FileVersion>1.1.5</FileVersion>
+    <FileVersion>1.1.6</FileVersion>
   </PropertyGroup>
   
   <ItemGroup>

--- a/Philips.CodeAnalysis.MsTestAnalyzers/Philips.CodeAnalysis.MsTestAnalyzers.md
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/Philips.CodeAnalysis.MsTestAnalyzers.md
@@ -29,4 +29,5 @@
 | PH2058  | Avoid Assert conditional check                       | Do not use an inline null check while asserting. Use a different Assert.IsNotNull check. Assert.AreEqual(&lt;actual>?.attribute, &lt;expected>) => Assert.IsNotNull(&lt;actual>); Assert.AreEqual(&lt;actual>.attribute, &lt;expected>) |
 | PH2059  | Public Method should be TestMethod                   | Public methods inside a TestClass should either be a test method or non-public. |
 | PH2076  | Assert.Fail alternatives                             | Assert.Fail should not be used if an alternative is more appropriate |
+| PH2095  | TestMethods must return void/Task for async methods  | TestMethods must return Task if they are async methods, or void if not |
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsShouldHaveValidReturnTypesAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsShouldHaveValidReturnTypesAnalyzer.cs
@@ -26,7 +26,8 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 		{
 			ISymbol symbolInfo = context.SemanticModel.GetDeclaredSymbol(methodDeclaration);
 
-			if (symbolInfo is not IMethodSymbol methodSymbol)
+			IMethodSymbol methodSymbol = symbolInfo as IMethodSymbol;
+			if (methodSymbol is null)
 			{
 				return;
 			}

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsShouldHaveValidReturnTypesAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsShouldHaveValidReturnTypesAnalyzer.cs
@@ -1,0 +1,59 @@
+﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.MsTestAnalyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class TestMethodsShouldHaveValidReturnTypesAnalyzer : TestMethodDiagnosticAnalyzer
+	{
+		private const string Title = @"TestMethods must return void or Task for async methods";
+		public static string MessageFormat = @"Test method should return '{0}', actually returns '{1}'";
+		private const string Description = @"MSTest will not run tests that return something other than void, or Task for async tests.";
+		private const string Category = Categories.Maintainability;
+
+		private static DiagnosticDescriptor Rule = new DiagnosticDescriptor(Helper.ToDiagnosticId(DiagnosticIds.TestMethodsMustHaveValidReturnType),
+												Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+		protected override void OnTestMethod(SyntaxNodeAnalysisContext context, MethodDeclarationSyntax methodDeclaration, bool isDataTestMethod)
+		{
+			ISymbol symbolInfo = context.SemanticModel.GetDeclaredSymbol(methodDeclaration);
+
+			if (symbolInfo is not IMethodSymbol methodSymbol)
+			{
+				return;
+			}
+
+			if (!methodSymbol.IsAsync && methodSymbol.ReturnsVoid)
+			{
+				// not async, returns void.
+				return;
+			}
+
+			if (!methodSymbol.IsAsync)
+			{
+				// error.  Not async, doesn't return void.
+				context.ReportDiagnostic(Diagnostic.Create(Rule, methodDeclaration.ReturnType.GetLocation(), context.Compilation.GetSpecialType(SpecialType.System_Void).ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat), methodSymbol.ReturnType.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat)));
+				return;
+			}
+
+			// async method.  Must return Task or Task<T>
+			INamedTypeSymbol expectedReturnType = context.Compilation.GetTypeByMetadataName("System.Threading.Tasks.Task");
+
+			if (SymbolEqualityComparer.Default.Equals(expectedReturnType, methodSymbol.ReturnType))
+			{
+				return;
+			}
+
+			context.ReportDiagnostic(Diagnostic.Create(Rule, methodDeclaration.ReturnType.GetLocation(), expectedReturnType.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat), methodSymbol.ReturnType.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat)));
+		}
+
+	}
+}

--- a/Philips.CodeAnalysis.Test/TestMethodsShouldHaveValidReturnTypesAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/TestMethodsShouldHaveValidReturnTypesAnalyzerTest.cs
@@ -1,0 +1,53 @@
+// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Philips.CodeAnalysis.Common;
+using Philips.CodeAnalysis.MsTestAnalyzers;
+
+namespace Philips.CodeAnalysis.Test
+{
+	[TestClass]
+	public class TestMethodsShouldHaveValidReturnTypesAnalyzerTest : DiagnosticVerifier
+	{
+		#region Non-Public Data Members
+
+		#endregion
+
+		#region Non-Public Properties/Methods
+
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new TestMethodsShouldHaveValidReturnTypesAnalyzer();
+
+		#endregion
+
+		#region Public Interface
+
+		[DataRow(false, "void", false)]
+		[DataRow(false, "int", true)]
+		[DataRow(false, "Task", true)]
+		[DataRow(false, "Task<int>", true)]
+		[DataRow(true, "void", true)]
+		[DataRow(true, "int", true)]
+		[DataRow(true, "Task", false)]
+		[DataRow(true, "Task<int>", true)]
+		[DataTestMethod]
+		public void TestMethodsMustReturnVoid(bool isAsync, string returnType, bool isError)
+		{
+			string code = $@"using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class Tests
+{{
+	[TestMethod]
+	public {(isAsync ? "async" : string.Empty)} {returnType} Foo() {{ throw new Exception(); }}
+}}";
+
+			VerifyCSharpDiagnostic(code, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.TestMethodsMustHaveValidReturnType) : Array.Empty<DiagnosticResult>());
+		}
+
+		#endregion
+	}
+}


### PR DESCRIPTION
Add an error for returning something  other than void or Task from a testmethod (Task for async, void otherwise)