### PR TITLE
Fix argument out of range exception

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -1,6 +1,10 @@
 name: .NET Core
 
-on: [push]
+on:
+  push:
+    branches: [ master, release/** ]
+  pull_request:
+    branches: [ master, release/** ]
 
 jobs:
   build:

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -72,9 +72,9 @@
     <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <Version>1.2.27</Version>
+    <Version>1.2.28</Version>
     <AssemblyVersion>1.0.3.0</AssemblyVersion>
-    <FileVersion>1.2.27</FileVersion>
+    <FileVersion>1.2.28</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Philips.CodeAnalysis.Test/DereferenceNullAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/DereferenceNullAnalyzerTest.cs
@@ -32,7 +32,7 @@ class Foo
 		}
 		
 		[TestMethod]
-		public void DereferenceNullAsExpressionIfDereferenceTest()
+		public void DereferenceNullAsExpressionWithNestedExpression()
 		{
 			string testCode = @"
 class Foo 

--- a/Philips.CodeAnalysis.Test/DereferenceNullAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/DereferenceNullAnalyzerTest.cs
@@ -30,8 +30,42 @@ class Foo
 }}
 ";
 		}
+		
+		[TestMethod]
+		public void DereferenceNullAsExpressionIfDereferenceTest()
+		{
+			string testCode = @"
+class Foo 
+{{
+  public void Scan(MethodDefinition method, MethodData data)
+		{
+
+Instruction i = method.Body.Instructions[0];
+			
+				switch (i.OpCode.Code)
+				{
+					case Code.Call:
+					case Code.Calli:
+					case Code.Callvirt:
+						MethodReference mr = i.Operand as MethodReference;
+
+						MethodDefinition md = mr.Resolve();
+
+						Scan(md, _locks[md]);
 
 
+						break;
+					default:
+						break;
+				}
+			
+		}
+}}
+";
+			var expected = DiagnosticResultHelper.CreateArray(DiagnosticIds.DereferenceNull);
+			VerifyCSharpDiagnostic(testCode, expected);
+		}
+		
 		/// <summary>
 		/// In this test, y is dereferenced after "y = obj as string" without first checking or re-assigning y.
 		/// </summary>


### PR DESCRIPTION
If the statement of interest (where the typecasting occurs) is nested within another statement, the DereferenceNullAnalyzer fails to find the statement. Failure to find the statement results in a null reference exception.