### PR TITLE
EnforceAccessModifierAnalyzer and its unit tests

### DIFF
--- a/Philips.CodeAnalysis.Common/DiagnosticIds.cs
+++ b/Philips.CodeAnalysis.Common/DiagnosticIds.cs
@@ -93,6 +93,7 @@ namespace Philips.CodeAnalysis.Common
 		AvoidEmptyCatchBlock = 2098,
 		EnforceFileVersionIsSameAsPackageVersion = 2099,
 		AvoidPasswordField = 2100,
-		DereferenceNull = 2101
+		DereferenceNull = 2101,
+		EnforceAccessModifier = 2102,
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -48,7 +48,8 @@
 | PH2093  |	Prefer creating tuples with named fields     | When creating or accepting a tuple, provide names for the elements (IE, prefer (DateTime createdAt, int id) rather than (DateTime, int) |
 | PH2094  | Prefer using the named tuple field, not ItemX| Wherever possible, use the provided name of a tuple field, not the generic name.  (IE, (DateTime createdAt, int id) value;  value.Item1.ToString(), prefer value.createdAt.ToString() |
 | PH2096  | Prefer async Task methods over async void methods | Wherever possible return Task rather then void for async methods. Exception are Event handlers |
-| PH2097  | Avoid Empty Statement Blocks| Avoid empty statement blocks |
+| PH2097  | Avoid Empty Statement Blocks                 | Avoid empty statement blocks |
 | PH2098  | Avoid Empty Catch Block| Avoid try-catch-swallow pattern |
 | PH2099  | Enforce FileVersion to be same as PackageVersion | For NuGet packages, this analyzer enforces the .NET AssemblyFileVersion value to be equal to the AssemblyInformationalVersion. |
-| PH2101  | Detect Null Dereference after "as" | After "as" include null checks; or, use static cast to set expectations |
+| PH2101  | Detect Null Dereference after "as"           | After "as" include null checks; or, use static cast to set expectations |
+| PH2102  | Enforce Access Modifiers                     | Explicitly provide the access modifiers for classes, fields, methods and properties. Do not rely on the defaults, as not all developers might know the defaults by hard.|

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -52,4 +52,4 @@
 | PH2098  | Avoid Empty Catch Block| Avoid try-catch-swallow pattern |
 | PH2099  | Enforce FileVersion to be same as PackageVersion | For NuGet packages, this analyzer enforces the .NET AssemblyFileVersion value to be equal to the AssemblyInformationalVersion. |
 | PH2101  | Detect Null Dereference after "as"           | After "as" include null checks; or, use static cast to set expectations |
-| PH2102  | Enforce Access Modifiers                     | Explicitly provide the access modifiers for classes, fields, methods and properties. Do not rely on the defaults, as not all developers might know the defaults by hard.|
+| PH2102  | Enforce Access Modifiers                     | Explicitly provide the access modifiers for classes, fields, methods and properties. Do not rely on the defaults, as not all developers might know the defaults by heart.|

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceAccessModifiersAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceAccessModifiersAnalyzer.cs
@@ -20,7 +20,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 	{
 		private const string Title = "Access modifier must be explicitly stated";
 		private const string Message =
-			"Missing access modifiers in {0}. Access modifier must be explicitly stated, instead of relying on the default value.";
+			"Missing access modifiers in '{0}'. Access modifier must be explicitly stated, instead of relying on the default value.";
 		private const string Description = "Access modifier must be explicitly stated";
 		private const string Category = Categories.Readability;
 
@@ -106,6 +106,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 		{
 			return token.IsKind(SyntaxKind.PublicKeyword) ||
 			       token.IsKind(SyntaxKind.PrivateKeyword) ||
+				   token.IsKind(SyntaxKind.InternalKeyword) ||
 			       token.IsKind(SyntaxKind.ProtectedKeyword);
 		}
 	}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceAccessModifiersAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceAccessModifiersAnalyzer.cs
@@ -1,0 +1,112 @@
+﻿// © 2022 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
+{
+	/// <summary>
+	/// Access modifier must be explicitly stated, instead of relying on the default value.
+	/// </summary>
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class EnforceAccessModifierAnalyzer : DiagnosticAnalyzer
+	{
+		private const string Title = "Access modifier must be explicitly stated";
+		private const string Message =
+			"Missing access modifiers in {0}. Access modifier must be explicitly stated, instead of relying on the default value.";
+		private const string Description = "Access modifier must be explicitly stated";
+		private const string Category = Categories.Readability;
+
+		private static readonly DiagnosticDescriptor Rule =
+			new DiagnosticDescriptor(
+				Helper.ToDiagnosticId(DiagnosticIds.EnforceAccessModifier),
+				Title,
+				Message,
+				Category,
+				DiagnosticSeverity.Error,
+				isEnabledByDefault: false,
+				description: Description);
+
+		/// <summary>
+		/// <inheritdoc cref="DiagnosticAnalyzer.SupportedDiagnostics"/>
+		/// </summary>
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		/// <summary>
+		/// <inheritdoc/>
+		/// </summary>
+		public override void Initialize(AnalysisContext context)
+		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.EnableConcurrentExecution();
+			context.RegisterSyntaxNodeAction(
+				AnalyzeClass,
+				SyntaxKind.ClassDeclaration);
+			context.RegisterSyntaxNodeAction(
+				AnalyzeField,
+				SyntaxKind.FieldDeclaration);
+			context.RegisterSyntaxNodeAction(
+				AnalyzeMethod,
+				SyntaxKind.MethodDeclaration);
+			context.RegisterSyntaxNodeAction(
+				AnalyzeProperty,
+				SyntaxKind.PropertyDeclaration);
+		}
+
+		private void AnalyzeClass(SyntaxNodeAnalysisContext context)
+		{
+			var classDeclaration = (ClassDeclarationSyntax)context.Node;
+			if (!classDeclaration.Modifiers.Where(ModifiersFilter).Any())
+			{
+				ReportDiagnostics(context, classDeclaration, classDeclaration.Identifier.Text);
+			}
+		}
+
+		private void AnalyzeField(SyntaxNodeAnalysisContext context)
+		{
+			var fieldDeclaration = (FieldDeclarationSyntax)context.Node;
+			if (!fieldDeclaration.Modifiers.Where(ModifiersFilter).Any())
+			{
+				ReportDiagnostics(context, fieldDeclaration, fieldDeclaration.TryGetInferredMemberName());
+			}
+		}
+
+		private void AnalyzeMethod(SyntaxNodeAnalysisContext context)
+		{
+			var methodDeclaration = (MethodDeclarationSyntax)context.Node;
+			if (!methodDeclaration.Modifiers.Where(ModifiersFilter).Any())
+			{
+				ReportDiagnostics(context, methodDeclaration, methodDeclaration.Identifier.Text);
+			}
+		}
+
+		private void AnalyzeProperty(SyntaxNodeAnalysisContext context)
+		{
+			var propertyDeclaration = (PropertyDeclarationSyntax)context.Node;
+			if (!propertyDeclaration.Modifiers.Where(ModifiersFilter).Any())
+			{
+				ReportDiagnostics(context, propertyDeclaration, propertyDeclaration.Identifier.Text);
+			}
+		}
+
+		private void ReportDiagnostics(SyntaxNodeAnalysisContext context, SyntaxNode node, string name)
+		{
+			var newLineLocation = node.GetLocation();
+			context.ReportDiagnostic(Diagnostic.Create(Rule, newLineLocation, name));
+		}
+
+		private bool ModifiersFilter(SyntaxToken token)
+		{
+			return token.IsKind(SyntaxKind.PublicKeyword) ||
+			       token.IsKind(SyntaxKind.PrivateKeyword) ||
+			       token.IsKind(SyntaxKind.ProtectedKeyword);
+		}
+	}
+}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceAccessModifiersAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceAccessModifiersAnalyzer.cs
@@ -74,7 +74,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 			var fieldDeclaration = (FieldDeclarationSyntax)context.Node;
 			if (!fieldDeclaration.Modifiers.Where(ModifiersFilter).Any())
 			{
-				ReportDiagnostics(context, fieldDeclaration, fieldDeclaration.TryGetInferredMemberName());
+				var fieldName = fieldDeclaration.Declaration.Variables.First().Identifier.Text;
+				ReportDiagnostics(context, fieldDeclaration, fieldName);
 			}
 		}
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/EnforceAccessModifierAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/EnforceAccessModifierAnalyzerTest.cs
@@ -1,4 +1,4 @@
-﻿// © 2020 Koninklijke Philips N.V. See License.md in the project root for license information.
+﻿// © 2022 Koninklijke Philips N.V. See License.md in the project root for license information.
 
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/EnforceAccessModifierAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/EnforceAccessModifierAnalyzerTest.cs
@@ -28,6 +28,12 @@ namespace AccessModifierUnitTests {
 		protected void ProtectedMethod() {
 		}
 
+		internal void InternalMethod() {
+		}
+
+		protected internal void ProtectedInternalMethod() {
+		}
+
 		private void PrivateMethod() {
 		}
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/EnforceAccessModifierAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/EnforceAccessModifierAnalyzerTest.cs
@@ -1,0 +1,132 @@
+﻿// © 2020 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Philips.CodeAnalysis.Common;
+using Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability;
+
+namespace Philips.CodeAnalysis.Test.Maintainability.Readability
+{
+	/// <summary>
+	/// Test class for <see cref="EnforceAccessModifierAnalyzer"/>.
+	/// </summary>
+	[TestClass]
+	public class EnforceAccessModifierAnalyzerTest : DiagnosticVerifier
+	{
+		private const string Correct = @"
+using System;
+
+namespace AccessModifierUnitTests {
+    public class Program {
+        private int intField;
+		protected string stringField;
+
+		public static void Main(string[] args) {
+        }
+
+		protected void ProtectedMethod() {
+		}
+
+		private void PrivateMethod() {
+		}
+
+		public string PublicReadOnlyProperty {
+			get {
+			}
+		}
+
+		private int PrivateProperty {
+			get {
+			}
+			private set {
+			}
+		}
+    }
+}";
+
+
+		private const string WrongClass = @"
+using System;
+
+namespace AccessModifierUnitTests {
+    class Program {
+    }
+}";
+
+		private const string WrongField = @"
+using System;
+
+namespace AccessModifierUnitTests {
+    public class Program {
+        int intField;
+    }
+}";
+		
+		private const string WrongMethod = @"
+using System;
+
+namespace AccessModifierUnitTests {
+    public class Program {
+		static void Main(string[] args) {
+        }
+    }
+}";
+
+		private const string WrongProperty = @"
+using System;
+
+namespace AccessModifierUnitTests {
+    public class Program {
+		int PrivateProperty {
+			get {
+			}
+			set {
+			}
+		}
+    }
+}";
+
+		/// <summary>
+		/// No diagnostics expected to show up.
+		/// </summary>
+		[TestMethod]
+		[DataRow(Correct, DisplayName = nameof(Correct))]
+		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
+		{
+			VerifyCSharpDiagnostic(testCode);
+		}
+
+		/// <summary>
+		/// Diagnostics expected to show up.
+		/// </summary>
+		[TestMethod]
+		[DataRow(WrongClass, DisplayName = nameof(WrongClass))]
+		[DataRow(WrongField, DisplayName = nameof(WrongField))]
+		[DataRow(WrongMethod, DisplayName = nameof(WrongMethod))]
+		[DataRow(WrongProperty, DisplayName = nameof(WrongProperty))]
+		public void WhenAccessModifierIsMissingDiagnosticIsTriggered(string testCode)
+		{
+			var expected = DiagnosticResultHelper.Create(DiagnosticIds.EnforceAccessModifier);
+			VerifyCSharpDiagnostic(testCode, expected);
+		}
+
+		/// <summary>
+		/// No diagnostics expected to show up 
+		/// </summary>
+		[TestMethod]
+		[DataRow(WrongClass, "Dummy.Designer", DisplayName = "OutOfScopeSourceFile")]
+		public void WhenSourceFileIsOutOfScopeNoDiagnosticIsTriggered(string testCode, string filePath)
+		{
+			VerifyCSharpDiagnostic(testCode, filePath);
+		}
+
+		/// <summary>
+		/// <inheritdoc cref="DiagnosticVerifier"/>
+		/// </summary>
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		{
+			return new EnforceAccessModifierAnalyzer();
+		}
+	}
+}


### PR DESCRIPTION
Add an Analyzer to check for explicit access modifiers (public, private, protected, internal, and their combinations).
If these are omitted, the code relies on the compiler's defaults. These are not very well known and make the code more difficult to read.

I intend to create a CodeFixProvider in a separate PR, but let's first agree on the Analyzer itself.