### PR TITLE
Allow AvoidPragma to be disabled by pragma

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidPragmaAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidPragmaAnalyzer.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -36,6 +37,12 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		{
 			PragmaWarningDirectiveTriviaSyntax pragma = context.Node as PragmaWarningDirectiveTriviaSyntax;
 			if (pragma == null)
+			{
+				return;
+			}
+
+			string myOwnId = Helper.ToDiagnosticId(DiagnosticIds.AvoidPragma);
+			if (pragma.ErrorCodes.Where(e => e.IsKind(SyntaxKind.IdentifierName)).Any(i => i.ToString().Contains(myOwnId)))
 			{
 				return;
 			}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidPragmaAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidPragmaAnalyzerTest.cs
@@ -41,6 +41,22 @@ class Foo
 			VerifyCSharpDiagnostic(givenText, expected);
 		}
 
+		[TestMethod]
+		public void PragmaAllowedDisableSelf()
+		{
+			string text = @"
+class Foo 
+{{
+  #pragma warning disable PH2029
+  public void Foo()
+  {{
+    return;
+  }}
+}}
+";
+			VerifyCSharpDiagnostic(text);
+		}
+
 		[DataTestMethod]
 		[DataRow(@"#pragma warning disable 100", 5)]
 		public void PragmaAllowedGeneratedCode(string test, int expectedColumn)


### PR DESCRIPTION
Sometimes, there is a false positive in assembly level Attribute syntax.

These attributes however, cannot accept a `SuppressMessage`, as `SuppressMessageAttribute` is not allowed on `Attributes`. You also cannot specify a `Target` property pointing to an assembly level Attribute.

The only remediation then, is to use a `#pragma warning disable FP0001`, where PF0001 is the example rule that has the false positive.
However, currently this triggers PH2029. I want to disable PH2029 just for a single line and therefore I used:
`#pragma warning disable PH2029, FP0001` and restore it again right.
However, `AvoidPragmaAnalyzer` doesn't allow itself to be disabled by `#pragma`.

**This leaves me with nowhere to go.**

To break this endless loop, I created this PR.