### PR TITLE
Fix false positive on FormattableString method argument

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/NoNestedStringFormatsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/NoNestedStringFormatsAnalyzer.cs
@@ -54,7 +54,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			var onlyInterpolation = interpolation.Parts[0];
 
 			if (
-				onlyInterpolation is not IInterpolatedStringTextOperation && 
+				!(onlyInterpolation is IInterpolatedStringTextOperation) && 
 				onlyInterpolation is IInterpolationOperation interpolationOperation)
 			{
 				if (!(interpolationOperation.FormatString is null))

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoNestedStringFormatsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoNestedStringFormatsAnalyzerTest.cs
@@ -466,32 +466,11 @@ class Foo
 			VerifyCSharpDiagnostic(string.Format(template, format, args), expected);
 		}
 
-		[DataRow("\"{0}\"", ", errorMessage")]
-		[DataRow("\"this is a test\"", "")]
+		[DataRow("$\"{0}\"")]
+		[DataRow("$\"this is a test\"")]
+		[DataRow("$\"{errorMessage}\"")]
 		[DataTestMethod]
-		public void DontStringFormatUselesslyIssue134_1(string format, string args)
-		{
-			const string template = @"
-using System;
-
-class Foo
-{{
-	public void Err(FormattableString fs)
-	{{
-	}}
-
-	public void Test(out string errorMessage)
-	{{
-		errorMessage = this.ToString();
-		Err({0}{1});
-	}}
-}}
-";
-			VerifyCSharpDiagnostic(string.Format(template, format, args));
-		}
-
-		[TestMethod]
-		public void DontStringFormatUselesslyIssue134_2()
+		public void DontStringFormatUselesslyIssue134(string format)
 		{
 			const string template = @"
 using System;
@@ -505,11 +484,11 @@ class Foo
 	public void Test()
 	{{
 		string errorMessage = ""Some text"";
-		Err(""{errorMessage}"");
+		Err({0});
 	}}
 }}
 ";
-			VerifyCSharpDiagnostic(template);
+			VerifyCSharpDiagnostic(string.Format(template, format));
 		}
 
 		[TestMethod]


### PR DESCRIPTION
After some experimentation around the reported #134 I have found a reproduction scenario. Reworked the issue134 testcases such that it reproduced the false positive.

The root cause in the Analyzer was that _any_ interpolated string was considered a violation. But if used as argument to a method that has 'FormattableString' as its Parameter, the interpolated format is OK. Make an explicit check for this in the Analyzer, searching in the Operation hierarchy for an `IInvocationOperation`, as this might be several levels up the hierarchy..

