### PR TITLE
Add check on CodeFixProviders on their designated diagnostics

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/XmlDocumentationCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/XmlDocumentationCodeFixProvider.cs
@@ -20,7 +20,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 
 		public sealed override ImmutableArray<string> FixableDiagnosticIds
 		{
-			get { return ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticIds.EmptyXmlComments)); }
+			get { return ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticIds.EmptyXmlComments), Helper.ToDiagnosticId(DiagnosticIds.XmlDocumentationShouldAddValue)); }
 		}
 
 		public sealed override FixAllProvider GetFixAllProvider()

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/XmlDocumentationShouldAddValueAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/XmlDocumentationShouldAddValueAnalyzerTest.cs
@@ -291,7 +291,36 @@ public enum TestEnumeration
 		[DataRow("int field;")]
 		[DataRow("int Property { get; }")]
 		[DataTestMethod]
-		public void CodeFixTests(string text)
+		public void CodeFixEmptyTests(string text)
+		{
+			string errorContent = $@"
+public class TestClass
+{{
+	/// <summary>
+	/// 
+	/// </summary>
+	public {text}
+}}
+";
+
+			string fixedContent = $@"
+public class TestClass
+{{
+  public {text}
+}}
+";
+
+			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.CreateArray(DiagnosticIds.EmptyXmlComments));
+
+			VerifyCSharpFix(errorContent, fixedContent);
+		}
+
+		[DataRow("event System.EventHandler Foo;")]
+		[DataRow("void Foo() { }")]
+		[DataRow("int field;")]
+		[DataRow("int Property { get; }")]
+		[DataTestMethod]
+		public void CodeFixValueTests(string text)
 		{
 			string errorContent = $@"
 public class TestClass

--- a/Philips.CodeAnalysis.Test/Verifiers/CodeFixVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/CodeFixVerifier.cs
@@ -76,6 +76,16 @@ namespace Philips.CodeAnalysis.Test
 			var document = CreateDocument(oldSource, language);
 			var analyzerDiagnostics = GetSortedDiagnosticsFromDocuments(analyzer, new[] { document });
 			var compilerDiagnostics = GetCompilerDiagnostics(document);
+
+			// Check if the found analyzer diagnostics are to be fixed by the given CodeFixProvider.
+			if (analyzerDiagnostics.Any())
+			{
+				var analyzerDiagnosticIds = analyzerDiagnostics.Select(d => d.Id);
+				var notFixableDiagnostics = codeFixProvider.FixableDiagnosticIds.Intersect(analyzerDiagnosticIds);
+				Assert.IsTrue(notFixableDiagnostics.Any(),
+					$"CodeFixProvider {codeFixProvider.GetType().Name} is not registered to fix the reported diagnostics: {string.Join(',', analyzerDiagnosticIds)}.");
+			}
+			
 			var attempts = analyzerDiagnostics.Length;
 
 			for (int i = 0; i < attempts; ++i)


### PR DESCRIPTION
This solves #154 

Added a check in the CodeFixVerifier to make sure the fixer is fixing the designated diagnostics. This ensures the reported FixableDiagnosticsIds are actually from the associated Analyzer.

There were not many violations, but I feel this is still a good check to keep in.