### PR TITLE
Fix multiple false positives on 'as' expression

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -20,64 +20,65 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Description>Roslyn Diagnostic Analyzers for helping maintainability or readability of C# code</Description>
     <PackageReleaseNotes>
-      1.1:
-      * Depend on .NET Standard version 2.0 instead of 1.3
-      * Add "Avoid AssemblyVersion Change" Analyzer
-      1.2.1
-      * Introduce PH2077 Avoid switch statements with no cases
-      1.2.4
-      * Introduce PH2078 Avoid X509Certificate2.PrivateKey
-      * Introduce PH2079 Use configured namespace prefix
-      1.2.5
-      * Fixes for PH2067 string interpolation
-      * Introduce PH2080: Avoid hardcoded paths
-      * Introduce PH2081: Avoid regions in methods
-      1.2.6
-      * Introduce PH2082 Positive naming
-      1.2.7
-      * Introduce PH2083, which flags accepting a parameter by reference where it is never written to
-      1.2.8
-      * Introduce PH2084: Avoid lock (new object)
-      * Introduce PH2085: Order get/set
-      1.2.9
-      * Introduce PH2086: Avoid Task.Result
-      1.2.10
-      * Introduce PH2087: No space in filename
-      * Introduce PH2088: Limit path length
-      * Introduce PH2089: Avoid assignment in condition
-      1.2.11
-      * Extend "Copyright Present Analyzer" with year and configurable company name
-      1.2.12
-      * Introduce PH2090: Log Exceptions
-      * Introduce PH2091:	Throw Inner Exception
-      * Introduce PH2092: Limit Condition Complexity
-      1.2.13
-      * Introduced PH2093: Prefer creating tuples with named fields
-      * Introduced PH2094: Prefer using the named tuple field, not ItemX
-      1.2.15
-      * Avoid returning async void
-      1.2.16
-      * Introduced PH2097: Avoid empty statement blocks
-      1.2.19
-      * Fixes for PH2097 (less strict)
-      * Introduce PH2098: Avoid empty catch block
-      1.2.20
-      * PH2096: Prevent converting async delegates to actions if they lose the task return type
-      * PH2090: Improve confusing message when not configured
-      * PH2032: Rename "Avoid empty constructors" to note only applicable to type initializers
-      1.2.26
-      * Introduce PH2101: Detect null dereference after "as" keyword
-      1.2.27-28
-      * Fixes for PH2101
-      1.2.29
-      * Fixes for 2028: Allow copyright statement as header of first region
-      1.2.30
-      * Fixed issue 134: False positive of PH2069 on invocation of a method with FormattableString as one of the arguments.
-      1.2.31
-      * Introduce PH2102: Xml documentation should add value. 
+		1.1:
+		* Depend on .NET Standard version 2.0 instead of 1.3
+		* Add "Avoid AssemblyVersion Change" Analyzer
+		1.2.1
+		* Introduce PH2077 Avoid switch statements with no cases
+		1.2.4
+		* Introduce PH2078 Avoid X509Certificate2.PrivateKey
+		* Introduce PH2079 Use configured namespace prefix
+		1.2.5
+		* Fixes for PH2067 string interpolation
+		* Introduce PH2080: Avoid hardcoded paths
+		* Introduce PH2081: Avoid regions in methods
+		1.2.6
+		* Introduce PH2082 Positive naming
+		1.2.7
+		* Introduce PH2083, which flags accepting a parameter by reference where it is never written to
+		1.2.8
+		* Introduce PH2084: Avoid lock (new object)
+		* Introduce PH2085: Order get/set
+		1.2.9
+		* Introduce PH2086: Avoid Task.Result
+		1.2.10
+		* Introduce PH2087: No space in filename
+		* Introduce PH2088: Limit path length
+		* Introduce PH2089: Avoid assignment in condition
+		1.2.11
+		* Extend "Copyright Present Analyzer" with year and configurable company name
+		1.2.12
+		* Introduce PH2090: Log Exceptions
+		* Introduce PH2091:	Throw Inner Exception
+		* Introduce PH2092: Limit Condition Complexity
+		1.2.13
+		* Introduced PH2093: Prefer creating tuples with named fields
+		* Introduced PH2094: Prefer using the named tuple field, not ItemX
+		1.2.15
+		* Avoid returning async void
+		1.2.16
+		* Introduced PH2097: Avoid empty statement blocks
+		1.2.19
+		* Fixes for PH2097 (less strict)
+		* Introduce PH2098: Avoid empty catch block
+		1.2.20
+		* PH2096: Prevent converting async delegates to actions if they lose the task return type
+		* PH2090: Improve confusing message when not configured
+		* PH2032: Rename "Avoid empty constructors" to note only applicable to type initializers
+		1.2.26
+		* Introduce PH2101: Detect null dereference after "as" keyword
+		1.2.27-28
+		* Fixes for PH2101
+		1.2.29
+		* Fixes for 2028: Allow copyright statement as header of first region
+		1.2.30
+		* Fixed issue 134: False positive of PH2069 on invocation of a method with FormattableString as one of the arguments.
+		1.2.31
+		* Introduce PH2102: Xml documentation should add value.
+		* Fixed issue 156: Multiple false positive on PH2101: Using 'as' expression
     </PackageReleaseNotes>
-    <Copyright>© 2019-2022 Koninklijke Philips N.V.</Copyright>
-    <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>
+	  <Copyright>© 2019-2022 Koninklijke Philips N.V.</Copyright>
+	  <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DevelopmentDependency>true</DevelopmentDependency>
     <Version>1.2.31</Version>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/DereferenceNullAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/DereferenceNullAnalyzer.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Linq.Expressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -212,7 +211,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
 							}
 						}
 
-						if (firstStatementOfAnalysis.DescendantNodesAndSelf().Any(s => s is ConditionalExpressionSyntax c && HasNullCheck(c.Condition)))
+						if (firstStatementOfAnalysis.DescendantNodesAndSelf().OfType<ConditionalExpressionSyntax>().Any(c => HasNullCheck(c.Condition)))
 						{
 							return;
 						}
@@ -270,9 +269,6 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
 		#endregion
 
 		#region Public Interface
-
-		public SimpleMemberAccessVisitor() : base(SyntaxWalkerDepth.Node)
-		{ }
 
 		public override void VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
 		{

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/DereferenceNullAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/DereferenceNullAnalyzer.cs
@@ -1,3 +1,5 @@
+// © 2022 Koninklijke Philips N.V. See License.md in the project root for license information.
+
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -9,6 +11,9 @@ using Philips.CodeAnalysis.Common;
 
 namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
 {
+	/// <summary>
+	/// Analyzer class that verifies that after the 'as' keyword, the variable is checked for null before being used. This prevents an <see cref="System.NullReferenceException"/> being thrown at runtime.
+	/// </summary>
 	[DiagnosticAnalyzer(LanguageNames.CSharp)]
 	public class DereferenceNullAnalyzer : DiagnosticAnalyzer
 	{
@@ -22,7 +27,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
 			Title, MessageFormat, Category,
 			DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
-		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 
 		public override void Initialize(AnalysisContext context)
@@ -32,7 +37,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
 			context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.AsExpression);
 		}
 
-		private void Report(SyntaxNodeAnalysisContext context, IdentifierNameSyntax identifier)
+		private static void Report(SyntaxNodeAnalysisContext context, IdentifierNameSyntax identifier)
 		{
 			var diagnostic = Diagnostic.Create(Rule, identifier.GetLocation(), identifier.Identifier.ValueText);
 			context.ReportDiagnostic(diagnostic);
@@ -51,15 +56,12 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
 		/// But if the firstStatement is the if clause, it includes the entire if block, of which endStatement is inside of.
 		/// This causes DataFlowAnalysis to throw an exception.
 
-		/// Stated differently (and more problematically), DataFlowAnalysis only works on statements in the same statementlist, ie the same block.
+		/// Stated differently (and more problematically), DataFlowAnalysis only works on statements in the same statement list, ie the same block.
 		/// https://github.com/kislyuk/roslyn/blob/89169a3380e48fc834c72e38355867881d030e94/Src/Compilers/CSharp/Source/Compilation/SyntaxTreeSemanticModel.cs#L1902
 		///
 		/// Fortunately, from a practical perspective, it is likely a common scenario that in this case, the reason it is in a nested block is precisely because
 		/// it checked for null.
 		/// </summary>
-		/// <param name="blockOfInterest"></param>
-		/// <param name="node"></param>
-		/// <returns></returns>
 		private bool SameBlock(BlockSyntax blockOfInterest, SyntaxNode node)
 		{
 			BlockSyntax ourSymbolsBlock = node.Ancestors().OfType<BlockSyntax>().First();
@@ -69,8 +71,6 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
 		/// <summary>
 		/// Just handle the simple case of "y = x as yType;"
 		/// </summary>
-		/// <param name="syntaxNode"></param>
-		/// <returns></returns>
 		private bool IsCaseWeUnderstand(SyntaxNode syntaxNode)
 		{
 			BinaryExpressionSyntax binaryExpressionSyntax = syntaxNode as BinaryExpressionSyntax;
@@ -79,12 +79,12 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
 				return false;
 			}
 
-			if (binaryExpressionSyntax != null && binaryExpressionSyntax.Parent is EqualsValueClauseSyntax equalsValueClauseSyntax)
+			if (
+				binaryExpressionSyntax != null && 
+				binaryExpressionSyntax.Parent is EqualsValueClauseSyntax equalsValueClauseSyntax &&
+				equalsValueClauseSyntax.Parent is VariableDeclaratorSyntax)
 			{
-				if (equalsValueClauseSyntax.Parent is VariableDeclaratorSyntax)
-				{
-					return true;
-				}
+				return true;
 			}
 			return false;
 		}
@@ -114,12 +114,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
 
 
 		/// <summary>
-		/// Find the first time ourSymbol is used, i.e., dereferenced.
+		/// Find the first time ourSymbol is used, i.e., de-referenced.
 		/// </summary>
-		/// <param name="ourSymbol"></param>
-		/// <param name="model"></param>
-		/// <param name="blockOfInterest"></param>
-		/// <returns></returns>
 		private IdentifierNameSyntax GetFirstMemberAccess(ISymbol ourSymbol, SemanticModel model, BlockSyntax blockOfInterest)
 		{
 			SimpleMemberAccessVisitor visitor = new SimpleMemberAccessVisitor();
@@ -139,14 +135,14 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
 				}
 			}
 
-			// It was never dereferenced.
+			// It was never de-referenced.
 			return null;
 		}
 
 		private bool HasNullCheck(ExpressionSyntax condition)
 		{
 			string conditionAsString = condition.ToString();
-			if(conditionAsString.Contains(@"null") || conditionAsString.Contains(@".HasValue"))
+			if (conditionAsString.Contains(@"null") || conditionAsString.Contains(@".HasValue"))
 			{
 				// There's a null check of some kind in some order. Don't be too picky, just let it go to minimize risk of a false positive
 				return true;
@@ -163,92 +159,87 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
 			}
 
 			// Collect some items we'll use repeatedly
-			if (context.Node.Parent != null)
+			if (context.Node.Parent?.Parent is VariableDeclaratorSyntax variableDeclarationSyntax)
 			{
-				VariableDeclaratorSyntax variableDeclaratorSyntax = context.Node.Parent.Parent as VariableDeclaratorSyntax;
-				if (variableDeclaratorSyntax != null)
+				BlockSyntax blockOfInterest = variableDeclarationSyntax.Ancestors().OfType<BlockSyntax>().First();
+				var model = context.SemanticModel;
+				ISymbol ourSymbol = model.GetDeclaredSymbol(variableDeclarationSyntax);
+
+				//  Identify where y is first used (ie., MemberAccessExpression)
+				IdentifierNameSyntax identifierNameSyntax = GetFirstMemberAccess(ourSymbol, model, blockOfInterest);
+				if (identifierNameSyntax == null)
 				{
-					BlockSyntax blockOfInterest = variableDeclaratorSyntax.Ancestors().OfType<BlockSyntax>().First();
-					var model = context.SemanticModel;
-					ISymbol ourSymbol = model.GetDeclaredSymbol(variableDeclaratorSyntax);
+					return;
+				}
+				if (!SameBlock(blockOfInterest, identifierNameSyntax))
+				{
+					return;
+				}
 
-					//  Identify where y is first used (ie., MemberAccessExpression)
-					IdentifierNameSyntax identifierNameSyntax = GetFirstMemberAccess(ourSymbol, model, blockOfInterest);
-					if (identifierNameSyntax == null)
+				//  Evaluate the code between (ie after) "y = x as yType" and "y.Foo" (ie before) to see if y is read (ie checked for null) or written to (ie rendering our check moot)
+				(StatementSyntax firstStatementOfAnalysis, int firstStatementOfAnalysisIndex) = GetStatement(blockOfInterest, variableDeclarationSyntax, offset: 1);
+				(StatementSyntax lastStatementOfAnalysis, int lastStatementOfAnalysisIndex) = GetStatement(blockOfInterest, identifierNameSyntax, offset: -1);
+
+				if (lastStatementOfAnalysisIndex < firstStatementOfAnalysisIndex)
+				{
+					// There's nothing to analyze; they immediately used the symbol after the 'as'
+
+					// Before reporting an error, note common possibility that the situation could be:
+					// string y = obj as string;
+					// if (y != null && y.ToString() == @"")
+					// Ie there's nothing to analyze between the statements, but within the statement exists a check
+					if (firstStatementOfAnalysis is IfStatementSyntax ifStatementSyntax)
 					{
-						return;
-					}
-					if (!SameBlock(blockOfInterest, identifierNameSyntax))
-					{
-						return;
-					}
-
-					//  Evaluate the code between (ie after) "y = x as yType" and "y.Foo" (ie before) to see if y is read (ie checked for null) or written to (ie rendering our check moot)
-					(StatementSyntax firstStatementOfAnalysis, int firstStatementOfAnalysisIndex) = GetStatement(blockOfInterest, variableDeclaratorSyntax, offset: 1);
-					(StatementSyntax lastStatementOfAnalysis, int lastStatementOfAnalysisIndex) = GetStatement(blockOfInterest, identifierNameSyntax, offset: -1);
-
-					if (lastStatementOfAnalysisIndex < firstStatementOfAnalysisIndex)
-					{
-						// There's nothing to analyze; they immediately used the symbol after the 'as'
-
-						// Before reporting an error, note common possibility that the situation could be:
-						// string y = obj as string;
-						// if (y != null && y.ToString() == @"")
-						// Ie there's nothing to analyze between the statements, but within the statement exists a check
-						if (firstStatementOfAnalysis is IfStatementSyntax ifStatementSyntax)
-						{
-							if (HasNullCheck(ifStatementSyntax.Condition))
-							{
-								return;
-							}
-						}
-						
-						if(firstStatementOfAnalysis is WhileStatementSyntax whileStatementSyntax)
-						{
-							if (HasNullCheck(whileStatementSyntax.Condition))
-							{
-								return;
-							}
-						}
-
-						if (firstStatementOfAnalysis.DescendantNodesAndSelf().OfType<ConditionalExpressionSyntax>().Any(c => HasNullCheck(c.Condition)))
+						if (HasNullCheck(ifStatementSyntax.Condition))
 						{
 							return;
 						}
-
-						Report(context, identifierNameSyntax);
-						return;
 					}
-
-					bool ourSymbolIsReadOrWritten = false;
-					DataFlowAnalysis result = model.AnalyzeDataFlow(firstStatementOfAnalysis, lastStatementOfAnalysis);
-					if (result != null)
+					
+					if(firstStatementOfAnalysis is WhileStatementSyntax whileStatementSyntax)
 					{
-						foreach (ISymbol assignedValue in result.ReadInside)
+						if (HasNullCheck(whileStatementSyntax.Condition))
 						{
-							if (SymbolEqualityComparer.Default.Equals(assignedValue, ourSymbol))
-							{
-								// We shouldn't just be checking that we read our symbol; we should really see if it's checked for null
-								ourSymbolIsReadOrWritten = true;
-								break;
-							}
-						}
-
-						foreach (ISymbol assignedValue in result.WrittenInside)
-						{
-							if (SymbolEqualityComparer.Default.Equals(assignedValue, ourSymbol))
-							{
-								ourSymbolIsReadOrWritten = true;
-								break;
-							}
+							return;
 						}
 					}
 
-					if (!ourSymbolIsReadOrWritten)
+					if (firstStatementOfAnalysis.DescendantNodesAndSelf().OfType<ConditionalExpressionSyntax>().Any(c => HasNullCheck(c.Condition)))
 					{
-						Report(context, identifierNameSyntax);
 						return;
 					}
+
+					Report(context, identifierNameSyntax);
+					return;
+				}
+
+				bool ourSymbolIsReadOrWritten = false;
+				DataFlowAnalysis result = model.AnalyzeDataFlow(firstStatementOfAnalysis, lastStatementOfAnalysis);
+				if (result != null)
+				{
+					foreach (ISymbol assignedValue in result.ReadInside)
+					{
+						if (SymbolEqualityComparer.Default.Equals(assignedValue, ourSymbol))
+						{
+							// We shouldn't just be checking that we read our symbol; we should really see if it's checked for null
+							ourSymbolIsReadOrWritten = true;
+							break;
+						}
+					}
+
+					foreach (ISymbol assignedValue in result.WrittenInside)
+					{
+						if (SymbolEqualityComparer.Default.Equals(assignedValue, ourSymbol))
+						{
+							ourSymbolIsReadOrWritten = true;
+							break;
+						}
+					}
+				}
+
+				if (!ourSymbolIsReadOrWritten)
+				{
+					Report(context, identifierNameSyntax);
 				}
 			}
 		}
@@ -260,16 +251,6 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
 	/// </summary>
 	public class SimpleMemberAccessVisitor : CSharpSyntaxWalker
 	{
-		#region Non-Public Data Members
-
-		#endregion
-
-		#region Non-Public Properties/Methods
-
-		#endregion
-
-		#region Public Interface
-
 		public override void VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
 		{
 			base.VisitMemberAccessExpression(node);
@@ -277,8 +258,6 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
 		}
 
 		public List<MemberAccessExpressionSyntax> MemberAccesses { get; } = new List<MemberAccessExpressionSyntax>();
-
-		#endregion
 	}
 }
 

--- a/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/DereferenceNullAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/DereferenceNullAnalyzerTest.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// © 2022 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Philips.CodeAnalysis.Common;
@@ -14,7 +16,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.RuntimeFailure
 			return new DereferenceNullAnalyzer();
 		}
 
-		private string GetTemplate()
+		private static string GetTemplate()
 		{
 			return @"
 class Foo 
@@ -67,7 +69,7 @@ Instruction i = method.Body.Instructions[0];
 		}
 		
 		/// <summary>
-		/// In this test, y is dereferenced after "y = obj as string" without first checking or re-assigning y.
+		/// In this test, y is de-referenced after "y = obj as string" without first checking or re-assigning y.
 		/// </summary>
 		/// <param name="content1"></param>
 		/// <param name="content2"></param>

--- a/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/DereferenceNullAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/DereferenceNullAnalyzerTest.cs
@@ -191,6 +191,66 @@ class Foo
 
 
 		[TestMethod]
+		public void DereferenceNullAsExpressionIfCheckDereference3Test()
+		{
+			string testCode = @"
+class Foo 
+{{
+  public void Foo()
+  {{
+    string x = String.Empty;
+    object obj = x;
+    string y = obj as string;
+    string t0 = y != null ? y.ToString() : ""null"";
+  }}
+}}
+";
+			VerifyCSharpDiagnostic(testCode, Array.Empty<DiagnosticResult>());
+		}
+
+		[TestMethod]
+		public void DereferenceNullAsExpressionIfCheckDereference4Test()
+		{
+			string testCode = @"
+class Foo 
+{{
+  public void Foo()
+  {{
+    string x = String.Empty;
+    object obj = x;
+    string y = obj as string;
+    if (x == ""SomeThing"" && y != null)
+    {{
+      string t2 = y.ToString();
+    }}
+  }}
+}}
+";
+			VerifyCSharpDiagnostic(testCode, Array.Empty<DiagnosticResult>());
+		}
+		
+		[TestMethod]
+		public void DereferenceNullAsExpressionIfCheckHasValueTest()
+		{
+			string testCode = @"
+class Foo 
+{{
+  public void Foo()
+  {{
+    string x = String.Empty;
+    object obj = x;
+    string? y = obj as string;
+    if (y.HasValue)
+	{{
+		string t0 = y.ToString();
+    }}
+  }}
+}}
+";
+			VerifyCSharpDiagnostic(testCode, Array.Empty<DiagnosticResult>());
+		}
+
+		[TestMethod]
 		public void DereferenceNullAsExpressionWhileCheckDereferenceTest()
 		{
 			string testCode = @"


### PR DESCRIPTION
This fixes #156 

Solved various cases where there is a valid null check, but where the Analyzer didn't see them.