### PR TITLE
Replace soft link with ProjectReference

### DIFF
--- a/Philips.CodeAnalysis.Benchmark/Philips.CodeAnalysis.Benchmark.csproj
+++ b/Philips.CodeAnalysis.Benchmark/Philips.CodeAnalysis.Benchmark.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Philips.CodeAnalysis.Common\Philips.CodeAnalysis.Common.csproj" />
     <ProjectReference Include="..\Philips.CodeAnalysis.DuplicateCodeAnalyzer\Philips.CodeAnalysis.DuplicateCodeAnalyzer.csproj" />
   </ItemGroup>
 

--- a/Philips.CodeAnalysis.Common/AdditionalFilesHelper.cs
+++ b/Philips.CodeAnalysis.Common/AdditionalFilesHelper.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Philips.CodeAnalysis.Common
 {
-	internal class AdditionalFilesHelper
+	public class AdditionalFilesHelper
 	{
 		private readonly ImmutableArray<AdditionalText> _additionalFiles;
 		private readonly AnalyzerOptions _options;
@@ -116,7 +116,7 @@ namespace Philips.CodeAnalysis.Common
 	}
 
 
-	internal class ExceptionsOptions
+	public class ExceptionsOptions
 	{
 		public bool IgnoreExceptionsFile { get; set; } = false;
 		public bool GenerateExceptionsFile { get; set; } = false;

--- a/Philips.CodeAnalysis.Common/AllowedSymbols.cs
+++ b/Philips.CodeAnalysis.Common/AllowedSymbols.cs
@@ -12,7 +12,7 @@ namespace Philips.CodeAnalysis.Common
 	/// <summary>
 	/// Keep track of allowed symbols and provide ability to check requested symbols.
 	/// </summary>
-	internal class AllowedSymbols
+	public class AllowedSymbols
 	{
 		private readonly HashSet<IMethodSymbol> _allowedMethods;
 		private readonly HashSet<ITypeSymbol> _allowedTypes;

--- a/Philips.CodeAnalysis.Common/AttributeDefinition.cs
+++ b/Philips.CodeAnalysis.Common/AttributeDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace Philips.CodeAnalysis.Common
 {
-	internal class AttributeDefinition
+	public class AttributeDefinition
 	{
 		public AttributeDefinition(string name, string fullName)
 		{
@@ -14,7 +14,7 @@ namespace Philips.CodeAnalysis.Common
 		public string FullName { get; }
 	}
 
-	internal class MsTestAttributeDefinition : AttributeDefinition
+	public class MsTestAttributeDefinition : AttributeDefinition
 	{
 		public MsTestAttributeDefinition(string name) : base(name, $"Microsoft.VisualStudio.TestTools.UnitTesting.{name}Attribute")
 		{ }

--- a/Philips.CodeAnalysis.Common/AttributeModel.cs
+++ b/Philips.CodeAnalysis.Common/AttributeModel.cs
@@ -4,7 +4,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Philips.CodeAnalysis.Common
 {
-	internal class AttributeModel
+	public class AttributeModel
 	{
 		public AttributeModel(string name, string fullName, string title, string messageFormat, string description, DiagnosticIds diagnosticId, bool canBeSuppressed, bool isEnabledByDefault)
 		{

--- a/Philips.CodeAnalysis.Common/Categories.cs
+++ b/Philips.CodeAnalysis.Common/Categories.cs
@@ -2,7 +2,7 @@
 
 namespace Philips.CodeAnalysis.Common
 {
-	internal static class Categories
+	public static class Categories
 	{
 		public const string Documentation = @"Documentation";
 		public const string Maintainability = @"Maintainability";

--- a/Philips.CodeAnalysis.Common/ConstructorSyntaxHelper.cs
+++ b/Philips.CodeAnalysis.Common/ConstructorSyntaxHelper.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Philips.CodeAnalysis.Common
 {
-	internal static class ConstructorSyntaxHelper
+	public static class ConstructorSyntaxHelper
 	{
 		/// <summary>
 		/// CreateMapping

--- a/Philips.CodeAnalysis.Common/DiagnosticIds.cs
+++ b/Philips.CodeAnalysis.Common/DiagnosticIds.cs
@@ -3,7 +3,7 @@
 namespace Philips.CodeAnalysis.Common
 {
 
-	internal enum DiagnosticIds
+	public enum DiagnosticIds
 	{
 		TestMethodName = 2000,
 		EmptyXmlComments = 2001,

--- a/Philips.CodeAnalysis.Common/Helper.cs
+++ b/Philips.CodeAnalysis.Common/Helper.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Philips.CodeAnalysis.Common
 {
-	internal static class Helper
+	public static class Helper
 	{
 		private static bool HasGeneratedCodeAttribute(SyntaxNodeAnalysisContext context, SyntaxNode node)
 		{

--- a/Philips.CodeAnalysis.Common/MsTestFrameworkDefinitions.cs
+++ b/Philips.CodeAnalysis.Common/MsTestFrameworkDefinitions.cs
@@ -2,7 +2,7 @@
 
 namespace Philips.CodeAnalysis.Common
 {
-	internal static class MsTestFrameworkDefinitions
+	public static class MsTestFrameworkDefinitions
 	{
 		public static AttributeDefinition TestClassAttribute => new MsTestAttributeDefinition("TestClass");
 		public static AttributeDefinition TestInitializeAttribute => new MsTestAttributeDefinition("TestInitialize");

--- a/Philips.CodeAnalysis.DuplicateCodeAnalyzer/Philips.CodeAnalysis.DuplicateCodeAnalyzer.csproj
+++ b/Philips.CodeAnalysis.DuplicateCodeAnalyzer/Philips.CodeAnalysis.DuplicateCodeAnalyzer.csproj
@@ -34,17 +34,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Philips.CodeAnalysis.Common\AdditionalFilesHelper.cs" Link="Common\AdditionalFilesHelper.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\AttributeDefinition.cs" Link="Common\AttributeDefinition.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\AttributeModel.cs" Link="Common\AttributeModel.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\Categories.cs" Link="Common\Categories.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\ConstructorSyntaxHelper.cs" Link="Common\ConstructorSyntaxHelper.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\DiagnosticIds.cs" Link="Common\DiagnosticIds.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\Helper.cs" Link="Common\Helper.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\MsTestFrameworkDefinitions.cs" Link="Common\MsTestFrameworkDefinitions.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
@@ -54,11 +43,11 @@
     <None Include="..\packageicon.png" Pack="true" PackagePath="\" />
     <None Update="tools\*.ps1" CopyToOutputDirectory="Always" Pack="true" PackagePath="" />
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)\Philips.CodeAnalysis.Common.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="..\LICENSE.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Common\" />
+    <ProjectReference Include="..\Philips.CodeAnalysis.Common\Philips.CodeAnalysis.Common.csproj" PrivateAssets="all" />
   </ItemGroup>
-
 </Project>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -87,17 +87,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Philips.CodeAnalysis.Common\AdditionalFilesHelper.cs" Link="Common\AdditionalFilesHelper.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\AttributeDefinition.cs" Link="Common\AttributeDefinition.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\AttributeModel.cs" Link="Common\AttributeModel.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\Categories.cs" Link="Common\Categories.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\ConstructorSyntaxHelper.cs" Link="Common\ConstructorSyntaxHelper.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\DiagnosticIds.cs" Link="Common\DiagnosticIds.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\Helper.cs" Link="Common\Helper.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\MsTestFrameworkDefinitions.cs" Link="Common\MsTestFrameworkDefinitions.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -110,11 +99,12 @@
     <None Include="..\packageicon.png" Pack="true" PackagePath="\" />
     <None Update="tools\*.ps1" CopyToOutputDirectory="Always" Pack="true" PackagePath="" />
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)\Philips.CodeAnalysis.Common.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="..\LICENSE.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Common\" />
+    <ProjectReference Include="..\Philips.CodeAnalysis.Common\Philips.CodeAnalysis.Common.csproj" PrivateAssets="all" />
   </ItemGroup>
-
+  
 </Project>

--- a/Philips.CodeAnalysis.MoqAnalyzers/Philips.CodeAnalysis.MoqAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MoqAnalyzers/Philips.CodeAnalysis.MoqAnalyzers.csproj
@@ -30,17 +30,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Philips.CodeAnalysis.Common\AdditionalFilesHelper.cs" Link="Common\AdditionalFilesHelper.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\AttributeDefinition.cs" Link="Common\AttributeDefinition.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\AttributeModel.cs" Link="Common\AttributeModel.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\Categories.cs" Link="Common\Categories.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\ConstructorSyntaxHelper.cs" Link="Common\ConstructorSyntaxHelper.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\DiagnosticIds.cs" Link="Common\DiagnosticIds.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\Helper.cs" Link="Common\Helper.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\MsTestFrameworkDefinitions.cs" Link="Common\MsTestFrameworkDefinitions.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -53,11 +42,11 @@
     <None Include="..\packageicon.png" Pack="true" PackagePath="\" />
     <None Update="tools\*.ps1" CopyToOutputDirectory="Always" Pack="true" PackagePath="" />
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)\Philips.CodeAnalysis.Common.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="..\LICENSE.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Common\" />
+    <ProjectReference Include="..\Philips.CodeAnalysis.Common\Philips.CodeAnalysis.Common.csproj" PrivateAssets="all" />
   </ItemGroup>
-
 </Project>

--- a/Philips.CodeAnalysis.MsTestAnalyzers/Philips.CodeAnalysis.MsTestAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/Philips.CodeAnalysis.MsTestAnalyzers.csproj
@@ -30,17 +30,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <Compile Include="..\Philips.CodeAnalysis.Common\AdditionalFilesHelper.cs" Link="Common\AdditionalFilesHelper.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\AttributeDefinition.cs" Link="Common\AttributeDefinition.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\AttributeModel.cs" Link="Common\AttributeModel.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\Categories.cs" Link="Common\Categories.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\ConstructorSyntaxHelper.cs" Link="Common\ConstructorSyntaxHelper.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\DiagnosticIds.cs" Link="Common\DiagnosticIds.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\Helper.cs" Link="Common\Helper.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\MsTestFrameworkDefinitions.cs" Link="Common\MsTestFrameworkDefinitions.cs" />
-  </ItemGroup>
-  
-  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -53,10 +42,11 @@
     <None Include="..\packageicon.png" Pack="true" PackagePath="\" />
     <None Update="tools\*.ps1" CopyToOutputDirectory="Always" Pack="true" PackagePath="" />
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)\Philips.CodeAnalysis.Common.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="..\LICENSE.md" Pack="true" PackagePath="" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <Folder Include="Common\" />
+    <ProjectReference Include="..\Philips.CodeAnalysis.Common\Philips.CodeAnalysis.Common.csproj" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Philips.CodeAnalysis.SecurityAnalyzers/Philips.CodeAnalysis.SecurityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.SecurityAnalyzers/Philips.CodeAnalysis.SecurityAnalyzers.csproj
@@ -29,18 +29,6 @@
     <FileVersion>1.0.0</FileVersion>
   </PropertyGroup>
 
-
-  <ItemGroup>
-    <Compile Include="..\Philips.CodeAnalysis.Common\AdditionalFilesHelper.cs" Link="Common\AdditionalFilesHelper.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\AttributeDefinition.cs" Link="Common\AttributeDefinition.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\AttributeModel.cs" Link="Common\AttributeModel.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\Categories.cs" Link="Common\Categories.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\ConstructorSyntaxHelper.cs" Link="Common\ConstructorSyntaxHelper.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\DiagnosticIds.cs" Link="Common\DiagnosticIds.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\Helper.cs" Link="Common\Helper.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\MsTestFrameworkDefinitions.cs" Link="Common\MsTestFrameworkDefinitions.cs" />
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
@@ -54,7 +42,11 @@
     <None Include="..\packageicon.png" Pack="true" PackagePath="\" />
     <None Update="tools\*.ps1" CopyToOutputDirectory="Always" Pack="true" PackagePath="" />
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)\Philips.CodeAnalysis.Common.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="..\LICENSE.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Philips.CodeAnalysis.Common\Philips.CodeAnalysis.Common.csproj" PrivateAssets="all" />
+  </ItemGroup>
 </Project>

--- a/Philips.CodeAnalysis.Test/Philips.CodeAnalysis.Test.csproj
+++ b/Philips.CodeAnalysis.Test/Philips.CodeAnalysis.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -15,17 +15,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Philips.CodeAnalysis.Common\AdditionalFilesHelper.cs" Link="Common\AdditionalFilesHelper.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\AllowedSymbols.cs" Link="Common\AllowedSymbols.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\AttributeDefinition.cs" Link="Common\AttributeDefinition.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\AttributeModel.cs" Link="Common\AttributeModel.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\Categories.cs" Link="Common\Categories.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\DiagnosticIds.cs" Link="Common\DiagnosticIds.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\Helper.cs" Link="Common\Helper.cs" />
-    <Compile Include="..\Philips.CodeAnalysis.Common\MsTestFrameworkDefinitions.cs" Link="Common\MsTestFrameworkDefinitions.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Moq" Version="4.10.1" />
@@ -34,15 +23,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Philips.CodeAnalysis.Common\Philips.CodeAnalysis.Common.csproj" />
     <ProjectReference Include="..\Philips.CodeAnalysis.DuplicateCodeAnalyzer\Philips.CodeAnalysis.DuplicateCodeAnalyzer.csproj" />
     <ProjectReference Include="..\Philips.CodeAnalysis.MaintainabilityAnalyzers\Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj" />
     <ProjectReference Include="..\Philips.CodeAnalysis.MoqAnalyzers\Philips.CodeAnalysis.MoqAnalyzers.csproj" />
     <ProjectReference Include="..\Philips.CodeAnalysis.MsTestAnalyzers\Philips.CodeAnalysis.MsTestAnalyzers.csproj" />
     <ProjectReference Include="..\Philips.CodeAnalysis.SecurityAnalyzers\Philips.CodeAnalysis.SecurityAnalyzers.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Common\" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Made Common library a ProjectReference instead of soft linking the .cs files. This allows the Common types to be shared between the Analyzers and the Test Projects, for dependency injection for example (rather than each having separate implementations). The downside is that the Common dll will be deployed with the Analyzers - meaning breaking changes cannot be made, because a client could have different versions of different analyzers, referencing different versions of Common.

The Common ProjectReference is attributed as a  PrivateAsset, so that it doesn't need to be published as a Nuget package. The Common project is then explicitly added to PackagePath="analyzers/dotnet/cs" 