### PR TITLE
EnableNETAnalyzers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,11 +21,20 @@ csharp_preferred_modifier_order = public,private,protected,internal,static,exter
 # IDE0060 should not trip on [DataRow] tests
 dotnet_code_quality_unused_parameters = non_public
 
+# Do not require CultureInfo for string formatting
+dotnet_diagnostic.CA1305.severity = none
+dotnet_diagnostic.CA1310.severity = none
+dotnet_diagnostic.CA1824.severity = none
+
 # Do not facilitate static methods
 dotnet_diagnostic.CA1822.severity = none
 
 dotnet_diagnostic.CA1825.severity = error
+dotnet_diagnostic.CA1827.severity = error
 dotnet_diagnostic.CA1829.severity = error
+dotnet_diagnostic.CA1853.severity = error
+dotnet_diagnostic.CA2016.severity = error
+dotnet_diagnostic.CA2211.severity = error
 dotnet_diagnostic.CA2241.severity = error
 
 # We do not need compile-time generated RegExs in Unit Tests. We'll prefer code readability.

--- a/Philips.CodeAnalysis.Common/Philips.CodeAnalysis.Common.csproj
+++ b/Philips.CodeAnalysis.Common/Philips.CodeAnalysis.Common.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Philips.CodeAnalysis.DuplicateCodeAnalyzer/AvoidDuplicateCodeAnalyzer.cs
+++ b/Philips.CodeAnalysis.DuplicateCodeAnalyzer/AvoidDuplicateCodeAnalyzer.cs
@@ -25,7 +25,7 @@ namespace Philips.CodeAnalysis.DuplicateCodeAnalyzer
 
 		public int DefaultDuplicateTokenThreshold = 100;
 
-		public static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidDuplicateCode), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidDuplicateCode), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
 		private const string InvalidTokenCountTitle = @"The token_count specified in the EditorConfig is invalid.";
 		private const string InvalidTokenCountMessage = @"The token_count {0} specified in the EditorConfig is invalid.";

--- a/Philips.CodeAnalysis.DuplicateCodeAnalyzer/Philips.CodeAnalysis.DuplicateCodeAnalyzer.csproj
+++ b/Philips.CodeAnalysis.DuplicateCodeAnalyzer/Philips.CodeAnalysis.DuplicateCodeAnalyzer.csproj
@@ -5,6 +5,7 @@
     <LangVersion>latest</LangVersion>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidPrivateKeyPropertyAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidPrivateKeyPropertyAnalyzer.cs
@@ -53,7 +53,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 		#region Public Interface
 
-		public static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidPrivateKeyProperty), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description, helpLinkUri: helpUri);
+		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidPrivateKeyProperty), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description, helpLinkUri: helpUri);
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidStaticClassesAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidStaticClassesAnalyzer.cs
@@ -21,7 +21,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		public const string MessageFormat = @"Avoid static classes";
 		private const string Description = @"Static Classes are not easily mockable. Avoid them so that your code is Unit Testable.";
 		private const string Category = Categories.Maintainability;
-		public static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidStaticClasses), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidStaticClasses), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidStaticClassesCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidStaticClassesCodeFixProvider.cs
@@ -71,7 +71,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		private async Task<Solution> AdditionalDocumentAppendLine(Document document, TextDocument textDocument, ClassDeclarationSyntax classDeclaration, CancellationToken cancellationToken)
 		{
 			SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken);
-			string newLine = semanticModel.GetDeclaredSymbol(classDeclaration).ToDisplayString();
+			string newLine = semanticModel.GetDeclaredSymbol(classDeclaration, cancellationToken).ToDisplayString();
 
 			SourceText sourceText = await textDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
 			SourceText newSourceText = AddLineToSourceText(sourceText, newLine);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidTryParseWithoutCultureAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidTryParseWithoutCultureAnalyzer.cs
@@ -90,7 +90,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 		#region Public Interface
 
-		public static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidTryParseWithoutCulture), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidTryParseWithoutCulture), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/DisallowDisposeRegistrationAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/DisallowDisposeRegistrationAnalyzer.cs
@@ -33,7 +33,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		public void Analyze(SyntaxNodeAnalysisContext context)
 		{
 			IEnumerable<MethodDeclarationSyntax> ancestorMethods = context.Node.Ancestors().OfType<MethodDeclarationSyntax>();
-			if (ancestorMethods.Count() > 0)
+			if (ancestorMethods.Any())
 			{
 				MethodDeclarationSyntax parentMethod = ancestorMethods.First();
 				if (parentMethod.Identifier.Text == @"Dispose")

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/EnforceEditorConfigAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/EnforceEditorConfigAnalyzer.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		private const string Description = @".editorconfig files help enforce and configure Analyzers";
 		private const string Category = Categories.Maintainability;
 
-		public static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.EnforceEditorConfig), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: false, description: Description);
+		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.EnforceEditorConfig), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: false, description: Description);
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 
 		public override void Initialize(AnalysisContext context)

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/NoHardCodedPathsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/NoHardCodedPathsAnalyzer.cs
@@ -48,7 +48,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		#endregion
 
 		#region Public Interface
-		public static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.NoHardcodedPaths), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.NoHardcodedPaths), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
 		{
 			get { return ImmutableArray.Create(Rule); }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/WinFormsInitializeComponentMustBeCalledOnceAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/WinFormsInitializeComponentMustBeCalledOnceAnalyzer.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		#region Non-Public Data Members
 
 		private const string Title = @"Check for UserControl constructor chains calls to InitializeComponent()";
-		public static string MessageFormat = @"Class ""{0}"" constructor triggers {1} calls to ""InitializeComponent()"".  Must only trigger 1.";
+		public readonly static string MessageFormat = @"Class ""{0}"" constructor triggers {1} calls to ""InitializeComponent()"".  Must only trigger 1.";
 		private const string Description = @"All UserControl constructor chains must call InitializeComponent().";
 		private const string Category = Categories.Maintainability;
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/NamespacePrefixAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/NamespacePrefixAnalyzer.cs
@@ -50,8 +50,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 		#region Public Interface
 		public static readonly string RuleId = Helper.ToDiagnosticId(DiagnosticIds.NamespacePrefix);
 
-		public static DiagnosticDescriptor RuleForIncorrectNamespace = new(RuleId, TitleForIncorrectPrefix, MessageFormatForIncorrectPrefix, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: DescriptionForIncorrectPrefix);
-		public static DiagnosticDescriptor RuleForEmptyPrefix = new(RuleId, TitleForEmptyPrefix, string.Format(MessageFormatForEmptyPrefix, RuleId), Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: string.Format(DescriptionForEmptyPrefix, RuleId));
+		public readonly static DiagnosticDescriptor RuleForIncorrectNamespace = new(RuleId, TitleForIncorrectPrefix, MessageFormatForIncorrectPrefix, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: DescriptionForIncorrectPrefix);
+		public readonly static DiagnosticDescriptor RuleForEmptyPrefix = new(RuleId, TitleForEmptyPrefix, string.Format(MessageFormatForEmptyPrefix, RuleId), Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: string.Format(DescriptionForEmptyPrefix, RuleId));
 
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(RuleForIncorrectNamespace, RuleForEmptyPrefix); } }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -5,6 +5,7 @@
     <LangVersion>latest</LangVersion>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidInlineNewAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidInlineNewAnalyzer.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 		private const string Description = @"Create a local variable, or a field for the temporary instance of class '{0}'";
 		private const string Category = Categories.Readability;
 
-		public static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidInlineNew), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidInlineNew), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidRedundantSwitchStatementAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidRedundantSwitchStatementAnalyzer.cs
@@ -19,7 +19,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 		private const string Description = @"Elide the switch statement";
 		private const string Category = Categories.Readability;
 
-		public static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidSwitchStatementsWithNoCases), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidSwitchStatementsWithNoCases), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
 		public AvoidRedundantSwitchStatementAnalyzer(GeneratedCodeAnalysisFlags generatedCodeFlags = GeneratedCodeAnalysisFlags.None)
 		{

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceRegionsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceRegionsAnalyzer.cs
@@ -135,9 +135,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 
 					if (RegionChecks.ContainsKey(regionName))
 					{
-						if (regionLocations.ContainsKey(regionName))
+						if (regionLocations.Remove(regionName))
 						{
-							regionLocations.Remove(regionName);
 							CreateDiagnostic(region.DirectiveNameToken.GetLocation(), context, regionName, EnforceNonDupliateRegion);
 						}
 						else

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/PreferNamedTuplesAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/PreferNamedTuplesAnalyzer.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 		private const string Description = @"Name this tuple field for readability";
 		private const string Category = Categories.Readability;
 
-		public static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.PreferTuplesWithNamedFields), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.PreferTuplesWithNamedFields), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/PreferTupleFieldNamesAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/PreferTupleFieldNamesAnalyzer.cs
@@ -16,7 +16,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 		private const string Description = @"For readability use the name provided for this field, not a generic field name";
 		private const string Category = Categories.Readability;
 
-		public static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.PreferUsingNamedTupleField), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.PreferUsingNamedTupleField), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/DereferenceNullAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/DereferenceNullAnalyzer.cs
@@ -22,7 +22,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
 		private const string Description = @"Using the 'as' expression means a check should be made before dereferencing, or cast if you definitively know it will be this type in this context.";
 		private const string Category = Categories.RuntimeFailure;
 
-		public static DiagnosticDescriptor Rule = new(
+		public readonly static DiagnosticDescriptor Rule = new(
 			Helper.ToDiagnosticId(DiagnosticIds.DereferenceNull),
 			Title, MessageFormat, Category,
 			DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);

--- a/Philips.CodeAnalysis.MoqAnalyzers/Philips.CodeAnalysis.MoqAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MoqAnalyzers/Philips.CodeAnalysis.MoqAnalyzers.csproj
@@ -5,6 +5,7 @@
     <LangVersion>latest</LangVersion>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualCodeFixProvider.cs
@@ -66,7 +66,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			ArgumentListSyntax argumentList = invocationExpression.ArgumentList as ArgumentListSyntax;
 			if (argumentList.Arguments[0].Expression is LiteralExpressionSyntax arg0Literal)
 			{
-				Optional<object> literalValue = semanticModel.GetConstantValue(arg0Literal);
+				Optional<object> literalValue = semanticModel.GetConstantValue(arg0Literal, cancellationToken);
 				isFirstArgumentNull = literalValue.Value == null;
 				isFirstArgumentConstant = true;
 			}
@@ -79,7 +79,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			bool isSecondArgumentConstant = false;
 			if (argumentList.Arguments[1].Expression is LiteralExpressionSyntax arg1Literal)
 			{
-				Optional<object> literalValue = semanticModel.GetConstantValue(arg1Literal);
+				Optional<object> literalValue = semanticModel.GetConstantValue(arg1Literal, cancellationToken);
 				isSecondArgumentNull = literalValue.Value == null;
 				isSecondArgumentConstant = true;
 			}

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualLiteralCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualLiteralCodeFixProvider.cs
@@ -123,7 +123,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 				return !GetMethod(prefixUnaryExpressionSyntax.Operand);
 			}
 
-			throw new ArgumentException(nameof(literalExpected));
+			throw new ArgumentException(@"A literal was expected.", nameof(literalExpected));
 		}
 	}
 }

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AvoidAttributeAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AvoidAttributeAnalyzer.cs
@@ -18,7 +18,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 		private static readonly ImmutableDictionary<string, ImmutableArray<AttributeModel>> attributes = GetAttributeModels();
 
-		public static ImmutableArray<DiagnosticDescriptor> Rules = GetRules(attributes);
+		public readonly static ImmutableArray<DiagnosticDescriptor> Rules = GetRules(attributes);
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return Rules; } }
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AvoidMsFakes.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AvoidMsFakes.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 		private const string Description = @"Avoid MS Fakes. Use Moq instead for example.  If applicable, remove the Reference and the .fakes file as well.";
 		private const string Category = Categories.Maintainability;
 
-		public static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidMsFakes), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidMsFakes), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/DataTestMethodsHaveDataRowsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/DataTestMethodsHaveDataRowsAnalyzer.cs
@@ -14,10 +14,10 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 	{
 		private const string Title = @"DataTestMethods must have at least 1 DataRow or 1 DynamicData, TestMethods must have none";
 
-		public static string MessageFormatMismatchedCount = @"Test {0} has {1} DataRowAttributes and {2} DynamicDataAttributes.";
+		public readonly static string MessageFormatMismatchedCount = @"Test {0} has {1} DataRowAttributes and {2} DynamicDataAttributes.";
 
-		public static string MessageFormatIsTestMethod = @"TestMethod has parameterized input data.  Convert to DataTestMethod.";
-		public static string MessageFormatIsDataTestMethod = @"DataTestMethod has no input data.  Convert to TestMethod.";
+		public readonly static string MessageFormatIsTestMethod = @"TestMethod has parameterized input data.  Convert to DataTestMethod.";
+		public readonly static string MessageFormatIsDataTestMethod = @"DataTestMethod has no input data.  Convert to TestMethod.";
 
 		private const string Description = @"DataTestMethods are only executed with DataRows";
 		private const string Category = Categories.Maintainability;

--- a/Philips.CodeAnalysis.MsTestAnalyzers/NoEmptyTestMethodsDiagnosticAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/NoEmptyTestMethodsDiagnosticAnalyzer.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 		private const string Description = @"Remove empty test method '{0}'";
 		private const string Category = Categories.Maintainability;
 
-		public static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.TestMethodsMustNotBeEmpty), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.TestMethodsMustNotBeEmpty), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/Philips.CodeAnalysis.MsTestAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/Philips.CodeAnalysis.MsTestAnalyzers.csproj
@@ -5,6 +5,7 @@
     <LangVersion>latest</LangVersion>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestClassMustBePublicAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestClassMustBePublicAnalyzer.cs
@@ -14,7 +14,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 	public class TestClassMustBePublicAnalyzer : TestClassDiagnosticAnalyzer
 	{
 		private const string Title = @"[TestClass] must be a public instance class";
-		public static string MessageFormat = @"'{0}' is not a public instance class";
+		public readonly static string MessageFormat = @"'{0}' is not a public instance class";
 		private const string Description = @"";
 		private const string Category = Categories.Maintainability;
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestContextAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestContextAnalyzer.cs
@@ -56,7 +56,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			string propName = property.Identifier.ToString();
 			IEnumerable<SyntaxNode> propNodes = context.Node.DescendantNodes();
 			IEnumerable<ReturnStatementSyntax> returnNodes = propNodes.OfType<ReturnStatementSyntax>();
-			if (returnNodes.Count() > 0)
+			if (returnNodes.Any())
 			{
 				ReturnStatementSyntax returnStatement = returnNodes.First();
 				if (returnStatement != null)

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestHasTimeoutAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestHasTimeoutAnalyzer.cs
@@ -16,7 +16,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 		private const string Description = @"Tests that lack a Timeout may indefinitely block.";
 		private const string Category = Categories.Maintainability;
 
-		public static string DefaultTimeoutKey = "defaultTimeout";
+		public readonly static string DefaultTimeoutKey = "defaultTimeout";
 
 		public static DiagnosticDescriptor Rule => new(Helper.ToDiagnosticId(DiagnosticIds.TestHasTimeoutAttribute), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: false, description: Description);
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsMustBeInTestClassAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsMustBeInTestClassAnalyzer.cs
@@ -13,7 +13,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 	public class TestMethodsMustBeInTestClassAnalyzer : TestAttributeDiagnosticAnalyzer
 	{
 		private const string Title = @"TestMethods/DataTestMethods must be in [TestClass]";
-		public static string MessageFormat = @"{0} is not in a [TestClass]";
+		public readonly static string MessageFormat = @"{0} is not in a [TestClass]";
 		private const string Description = @"Tests are only executed if they are [TestClass]";
 		private const string Category = Categories.Maintainability;
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsMustBePublicAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsMustBePublicAnalyzer.cs
@@ -14,7 +14,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 	public class TestMethodsMustBePublicAnalyzer : TestMethodDiagnosticAnalyzer
 	{
 		private const string Title = @"TestMethods/DataTestMethods must be public, instance methods";
-		public static string MessageFormat = @"'{0}' is not a public instance method";
+		public readonly static string MessageFormat = @"'{0}' is not a public instance method";
 		private const string Description = @"";
 		private const string Category = Categories.Maintainability;
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsMustHaveTheCorrectNumberOfArgumentsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsMustHaveTheCorrectNumberOfArgumentsAnalyzer.cs
@@ -14,7 +14,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 	public class TestMethodsMustHaveTheCorrectNumberOfArgumentsAnalyzer : TestMethodDiagnosticAnalyzer
 	{
 		private const string Title = @"TestMethods/DataTestMethods must have the correct number of arguments";
-		public static string MessageFormat = @"'{0}' has the wrong number of parameters";
+		public readonly static string MessageFormat = @"'{0}' has the wrong number of parameters";
 		private const string Description = @"DataTestMethods should have the same number of parameters of the DataRows, TestMethods should have no arguments";
 		private const string Category = Categories.Maintainability;
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsShouldHaveUniqueNamesAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsShouldHaveUniqueNamesAnalyzer.cs
@@ -13,7 +13,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 	public class TestMethodsShouldHaveUniqueNamesAnalyzer : TestClassDiagnosticAnalyzer
 	{
 		private const string Title = @"TestMethods/DataTestMethods should not have the same name";
-		public static string MessageFormat = @"Multiple tests named '{0}'";
+		public readonly static string MessageFormat = @"Multiple tests named '{0}'";
 		private const string Description = @"";
 		private const string Category = Categories.Maintainability;
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsShouldHaveValidReturnTypesAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsShouldHaveValidReturnTypesAnalyzer.cs
@@ -12,7 +12,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 	public class TestMethodsShouldHaveValidReturnTypesAnalyzer : TestMethodDiagnosticAnalyzer
 	{
 		private const string Title = @"TestMethods must return void or Task for async methods";
-		public static string MessageFormat = @"Test method should return '{0}', actually returns '{1}'";
+		public readonly static string MessageFormat = @"Test method should return '{0}', actually returns '{1}'";
 		private const string Description = @"MSTest will not run tests that return something other than void, or Task for async tests.";
 		private const string Category = Categories.Maintainability;
 

--- a/Philips.CodeAnalysis.SecurityAnalyzers/AvoidPasswordAnalyzer.cs
+++ b/Philips.CodeAnalysis.SecurityAnalyzers/AvoidPasswordAnalyzer.cs
@@ -19,7 +19,7 @@ namespace Philips.CodeAnalysis.SecurityAnalyzers
 		private const string Description = @"Avoid hard-coded passwords.  (Avoid this analyzer by not naming something Password.)";
 		private const string Category = Categories.Security;
 
-		public static DiagnosticDescriptor Rule = new(
+		public readonly static DiagnosticDescriptor Rule = new(
 			Helper.ToDiagnosticId(DiagnosticIds.AvoidPasswordField), 
 			Title, MessageFormat, Category, 
 			DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);

--- a/Philips.CodeAnalysis.SecurityAnalyzers/Philips.CodeAnalysis.SecurityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.SecurityAnalyzers/Philips.CodeAnalysis.SecurityAnalyzers.csproj
@@ -5,6 +5,7 @@
     <LangVersion>latest</LangVersion>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Philips.CodeAnalysis.Test/Common/GeneratedCodeDetectorTest.cs
+++ b/Philips.CodeAnalysis.Test/Common/GeneratedCodeDetectorTest.cs
@@ -15,12 +15,12 @@ namespace Philips.CodeAnalysis.Test.Common
 	{
 		#region Helper Analyzer
 		[DiagnosticAnalyzer(LanguageNames.CSharp)]
-		private class AvoidWritingCodeAnalyzer : DiagnosticAnalyzer
+		private sealed class AvoidWritingCodeAnalyzer : DiagnosticAnalyzer
 		{
-			public static bool ShouldAnalyzeTree { get; set; } = false;
-			public static bool ShouldAnalyzeConstructor { get; set; } = false;
-			public static bool ShouldAnalyzeStruct { get; set; } = false;
-			public static bool ShouldAnalyzeSwitch { get; set; } = false;
+			public static bool ShouldAnalyzeTree { get; set; }
+			public static bool ShouldAnalyzeConstructor { get; set; }
+			public static bool ShouldAnalyzeStruct { get; set; }
+			public static bool ShouldAnalyzeSwitch { get; set; }
 
 			private const string Title = @"Avoid writing code";
 			public DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.TestMethodName), Title, Title, Categories.Maintainability, DiagnosticSeverity.Error, true, Title);

--- a/Philips.CodeAnalysis.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/Philips.CodeAnalysis.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -52,7 +52,7 @@ namespace Philips.CodeAnalysis.Test
 			return GetSortedDiagnosticsFromDocuments(analyzer, GetDocuments(sources, filenamePrefix, language));
 		}
 
-		private class TestAdditionalText : AdditionalText
+		private sealed class TestAdditionalText : AdditionalText
 		{
 			private readonly SourceText _sourceText;
 
@@ -70,7 +70,7 @@ namespace Philips.CodeAnalysis.Test
 			}
 		}
 
-		private class TestAnalyzerConfigOptions : AnalyzerConfigOptions
+		private sealed class TestAnalyzerConfigOptions : AnalyzerConfigOptions
 		{
 			private readonly Dictionary<string, string> _options;
 
@@ -85,7 +85,7 @@ namespace Philips.CodeAnalysis.Test
 			}
 		}
 
-		private class TestAnalyzerConfigOptionsProvider : AnalyzerConfigOptionsProvider
+		private sealed class TestAnalyzerConfigOptionsProvider : AnalyzerConfigOptionsProvider
 		{
 			private readonly TestAnalyzerConfigOptions _configOptions;
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Naming/NamespaceMatchAssemblyAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Naming/NamespaceMatchAssemblyAnalyzerTest.cs
@@ -30,8 +30,6 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 			}}
 			";
 
-		private const string configuredPrefix = @"Philips.";
-
 		#endregion
 
 		#region Non-Public Properties/Methods

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/LimitConditionComplexityAnalyzerTest2.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/LimitConditionComplexityAnalyzerTest2.cs
@@ -48,7 +48,6 @@ namespace ComplexConditionUnitTests {
 		[DataRow(CorrectCode, DisplayName = nameof(WhenConfigInvalidDefaultValueUsedAndCorrectCodePasses))]
 		public void WhenConfigInvalidDefaultValueUsedAndCorrectCodePasses(string testCode)
 		{
-			var expected = DiagnosticResultHelper.Create(DiagnosticIds.LimitConditionComplexity);
 			VerifyCSharpDiagnostic(testCode);
 		}
 

--- a/Philips.CodeAnalysis.Test/MsTest/AssertAreEqualTypesMatchAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AssertAreEqualTypesMatchAnalyzerTest.cs
@@ -68,38 +68,16 @@ namespace AssertAreEqualTypesMatchAnalyzerTest
 
 		private string GetWellKnownTypeName(string variableName)
 		{
-			string typeName;
-			switch (variableName)
+			string typeName = variableName switch
 			{
-				case "i":
-				case "j":
-					typeName = "int";
-					break;
-				case "str1":
-				case "str2":
-					typeName = "string";
-					break;
-				case "f1":
-				case "f2":
-					typeName = "float";
-					break;
-				case "d1":
-				case "d2":
-					typeName = "double";
-					break;
-				case "b1":
-				case "b2":
-					typeName = "bool";
-					break;
-				case "x1":
-				case "x2":
-					typeName = "byte";
-					break;
-				default:
-					typeName = "";
-					break;
-			}
-
+				"i" or "j" => "int",
+				"str1" or "str2" => "string",
+				"f1" or "f2" => "float",
+				"d1" or "d2" => "double",
+				"b1" or "b2" => "bool",
+				"x1" or "x2" => "byte",
+				_ => "",
+			};
 			return typeName;
 		}
 	}

--- a/Philips.CodeAnalysis.Test/MsTest/AvoidOwnerAttributeCodeFixProviderTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AvoidOwnerAttributeCodeFixProviderTest.cs
@@ -42,7 +42,7 @@ class Foo
 			
 			string givenText = string.Format(baseline, test);
 
-			DiagnosticResult expected = new DiagnosticResult
+			DiagnosticResult expected = new()
 			{
 				Id = Helper.ToDiagnosticId(DiagnosticIds.AvoidOwnerAttribute),
 				Message = new Regex(".*"),

--- a/Philips.CodeAnalysis.Test/MsTest/ExpectedExceptionAttributeAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/ExpectedExceptionAttributeAnalyzerTest.cs
@@ -28,7 +28,7 @@ namespace ExpectedAnalyzerAttributeTest
   }
 }
 ";
-			DiagnosticResult expected = new DiagnosticResult
+			DiagnosticResult expected = new()
 			{
 				Id = Helper.ToDiagnosticId(DiagnosticIds.ExpectedExceptionAttribute),
 				Message = new Regex(ExpectedExceptionAttributeAnalyzer.MessageFormat),

--- a/Philips.CodeAnalysis.Test/Philips.CodeAnalysis.Test.csproj
+++ b/Philips.CodeAnalysis.Test/Philips.CodeAnalysis.Test.csproj
@@ -4,7 +4,10 @@
     <TargetFramework>net7</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
-  </PropertyGroup>
+    <AnalysisLevel>latest-Recommended</AnalysisLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+</PropertyGroup>
   
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />


### PR DESCRIPTION
.NET Standard assemblies need the NET Analyzers explicitly added, or the Nuget package explicitly added. This PR does that.

For the Test project, which is NET7, they're enabled by default. In this project, we can also treat them as errors, enable the Recommended set (rather than the Default set), and treat IntelliSense (ie IDExxxx) findings as build errors. Enabled all.
