### PR TITLE
Enable most IntelliSense findings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,7 +19,7 @@ dotnet_style_require_accessibility_modifiers = always:error
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
 
 # IDE0060 should not trip on [DataRow] tests
-dotnet_code_quality_unused_parameters = non_public
+#dotnet_code_quality_unused_parameters = non_public
 
 # Do not require CultureInfo for string formatting
 dotnet_diagnostic.CA1305.severity = none
@@ -40,28 +40,92 @@ dotnet_diagnostic.CA2241.severity = error
 # We do not need compile-time generated RegExs in Unit Tests. We'll prefer code readability.
 dotnet_diagnostic.SYSLIB1045.severity = none
 
+dotnet_diagnostic.IDE0001.severity = error
+dotnet_diagnostic.IDE0002.severity = error
+dotnet_diagnostic.IDE0003.severity = error
+dotnet_diagnostic.IDE0004.severity = error
+###dotnet_diagnostic.IDE0005.severity = error
+dotnet_diagnostic.IDE0007.severity = error
+###dotnet_diagnostic.IDE0008.severity = error
 dotnet_diagnostic.IDE0009.severity = error
+dotnet_diagnostic.IDE0010.severity = none   # Do not add missing switch cases. (SyntaxKind has hundreds)
+dotnet_diagnostic.IDE0011.severity = error
+dotnet_diagnostic.IDE0016.severity = error
+dotnet_diagnostic.IDE0017.severity = error
 dotnet_diagnostic.IDE0018.severity = error
 dotnet_diagnostic.IDE0019.severity = error
+dotnet_diagnostic.IDE0020.severity = error
+dotnet_diagnostic.IDE0021.severity = error
+dotnet_diagnostic.IDE0022.severity = error
+dotnet_diagnostic.IDE0024.severity = error
+###dotnet_diagnostic.IDE0025.severity = error
+dotnet_diagnostic.IDE0026.severity = error
+dotnet_diagnostic.IDE0027.severity = error
 dotnet_diagnostic.IDE0028.severity = error
+dotnet_diagnostic.IDE0029.severity = error
+dotnet_diagnostic.IDE0030.severity = error
+dotnet_diagnostic.IDE0031.severity = error
+dotnet_diagnostic.IDE0032.severity = error
+dotnet_diagnostic.IDE0033.severity = error
 dotnet_diagnostic.IDE0034.severity = error
+dotnet_diagnostic.IDE0035.severity = error
+dotnet_diagnostic.IDE0036.severity = error
+dotnet_diagnostic.IDE0037.severity = error
 dotnet_diagnostic.IDE0038.severity = error
+dotnet_diagnostic.IDE0039.severity = error
+dotnet_diagnostic.IDE0040.severity = error
+dotnet_diagnostic.IDE0041.severity = error
+dotnet_diagnostic.IDE0042.severity = error
 dotnet_diagnostic.IDE0044.severity = error
+###dotnet_diagnostic.IDE0045.severity = error
+dotnet_diagnostic.IDE0046.severity = error
+dotnet_diagnostic.IDE0047.severity = error
+dotnet_diagnostic.IDE0048.severity = error
+dotnet_diagnostic.IDE0049.severity = error
+dotnet_diagnostic.IDE0050.severity = error
 dotnet_diagnostic.IDE0051.severity = error
 dotnet_diagnostic.IDE0052.severity = error
+dotnet_diagnostic.IDE0053.severity = error
 dotnet_diagnostic.IDE0054.severity = error
+###dotnet_diagnostic.IDE0055.severity = error
+dotnet_diagnostic.IDE0056.severity = none   # Cannot use index/range with .NET Standard 2.0
+dotnet_diagnostic.IDE0057.severity = none   # Cannot use index/range with .NET Standard 2.0
+###dotnet_diagnostic.IDE0058.severity = error
 dotnet_diagnostic.IDE0059.severity = error
-dotnet_diagnostic.IDE0060.severity = error
+dotnet_diagnostic.IDE0060.severity = none   # Revisit!
+dotnet_diagnostic.IDE0061.severity = error
 dotnet_diagnostic.IDE0062.severity = error
+dotnet_diagnostic.IDE0063.severity = error
+dotnet_diagnostic.IDE0064.severity = error
+dotnet_diagnostic.IDE0065.severity = error
 dotnet_diagnostic.IDE0066.severity = error
+dotnet_diagnostic.IDE0070.severity = error
+dotnet_diagnostic.IDE0071.severity = error
+dotnet_diagnostic.IDE0072.severity = none   # Do not add missing switch cases. (SyntaxKind has hundreds)
+dotnet_diagnostic.IDE0073.severity = error
 dotnet_diagnostic.IDE0074.severity = error
+dotnet_diagnostic.IDE0075.severity = error
+dotnet_diagnostic.IDE0076.severity = error
+dotnet_diagnostic.IDE0077.severity = error
+dotnet_diagnostic.IDE0078.severity = error
+dotnet_diagnostic.IDE0079.severity = error
+dotnet_diagnostic.IDE0080.severity = error
+dotnet_diagnostic.IDE0081.severity = error
+dotnet_diagnostic.IDE0082.severity = error
 dotnet_diagnostic.IDE0083.severity = error
+dotnet_diagnostic.IDE0084.severity = error
 dotnet_diagnostic.IDE0090.severity = error
+dotnet_diagnostic.IDE0100.severity = error
+dotnet_diagnostic.IDE0110.severity = error
+dotnet_diagnostic.IDE0140.severity = error
+dotnet_diagnostic.IDE0150.severity = error
+dotnet_diagnostic.IDE0160.severity = error
+dotnet_diagnostic.IDE0161.severity = error
+dotnet_diagnostic.IDE0170.severity = error
+dotnet_diagnostic.IDE0180.severity = error
 dotnet_diagnostic.IDE0250.severity = error
-
-# Cannot use index/range with .NET Standard 2.0
-dotnet_diagnostic.IDE0056.severity = none
-dotnet_diagnostic.IDE0057.severity = none
+dotnet_diagnostic.IDE1005.severity = error
+dotnet_diagnostic.IDE1006.severity = error
 
 dotnet_code_quality.PH2028.company_name = Koninklijke Philips N.V.
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -21,6 +21,9 @@ csharp_preferred_modifier_order = public,private,protected,internal,static,exter
 # IDE0060 should not trip on [DataRow] tests
 #dotnet_code_quality_unused_parameters = non_public
 
+# IDE0046 can result in nested ternary operations
+dotnet_style_prefer_conditional_expression_over_return = false
+
 # Do not require CultureInfo for string formatting
 dotnet_diagnostic.CA1305.severity = none
 dotnet_diagnostic.CA1310.severity = none
@@ -78,7 +81,7 @@ dotnet_diagnostic.IDE0041.severity = error
 dotnet_diagnostic.IDE0042.severity = error
 dotnet_diagnostic.IDE0044.severity = error
 ###dotnet_diagnostic.IDE0045.severity = error
-dotnet_diagnostic.IDE0046.severity = error
+dotnet_diagnostic.IDE0046.severity = error  # Also see non-default setting of dotnet_style_prefer_conditional_expression_over_return
 dotnet_diagnostic.IDE0047.severity = error
 dotnet_diagnostic.IDE0048.severity = error
 dotnet_diagnostic.IDE0049.severity = error

--- a/Philips.CodeAnalysis.Common/AdditionalFilesHelper.cs
+++ b/Philips.CodeAnalysis.Common/AdditionalFilesHelper.cs
@@ -82,8 +82,8 @@ namespace Philips.CodeAnalysis.Common
 			{
 				return value == null ? string.Empty : value.ToString();
 			}
-#nullable disable
 			return string.Empty;
+#nullable disable
 		}
 
 		public virtual string GetValueFromEditorConfig(string diagnosticId, string settingKey)

--- a/Philips.CodeAnalysis.Common/AdditionalFilesHelper.cs
+++ b/Philips.CodeAnalysis.Common/AdditionalFilesHelper.cs
@@ -80,11 +80,7 @@ namespace Philips.CodeAnalysis.Common
 #nullable enable
 			if (analyzerConfigOptions.TryGetValue(settingKey, out string? value))
 			{
-				if (value == null)
-				{
-					return string.Empty;
-				}
-				return value.ToString();
+				return value == null ? string.Empty : value.ToString();
 			}
 #nullable disable
 			return string.Empty;

--- a/Philips.CodeAnalysis.Common/ConstructorSyntaxHelper.cs
+++ b/Philips.CodeAnalysis.Common/ConstructorSyntaxHelper.cs
@@ -24,7 +24,10 @@ namespace Philips.CodeAnalysis.Common
 			foreach (var ctor in constructors)
 			{
 				IMethodSymbol method = context.SemanticModel.GetDeclaredSymbol(ctor);
-				if (method != null) symbolToCtor[method] = ctor;
+				if (method != null)
+				{
+					symbolToCtor[method] = ctor;
+				}
 
 				if (ctor.Initializer != null && ctor.Initializer.ThisOrBaseKeyword.IsKind(SyntaxKind.ThisKeyword))
 				{
@@ -62,7 +65,9 @@ namespace Philips.CodeAnalysis.Common
 			while (true)
 			{
 				if (!mapping.TryGetValue(ctor, out ctor))
+				{
 					break;
+				}
 
 				if (!seenConstructors.Add(ctor))
 				{

--- a/Philips.CodeAnalysis.Common/Helper.cs
+++ b/Philips.CodeAnalysis.Common/Helper.cs
@@ -29,13 +29,13 @@ namespace Philips.CodeAnalysis.Common
 				return false;
 			}
 			SyntaxList<AttributeListSyntax> classAttributeList = classDeclaration.AttributeLists;
-			return Helper.HasAttribute(classAttributeList, context, MsTestFrameworkDefinitions.TestClassAttribute, out _);
+			return HasAttribute(classAttributeList, context, MsTestFrameworkDefinitions.TestClassAttribute, out _);
 		}
 
 		public static bool IsTestClass(ClassDeclarationSyntax classDeclaration, SyntaxNodeAnalysisContext context)
 		{
 			SyntaxList<AttributeListSyntax> classAttributeList = classDeclaration.AttributeLists;
-			return Helper.HasAttribute(classAttributeList, context, MsTestFrameworkDefinitions.TestClassAttribute, out _);
+			return HasAttribute(classAttributeList, context, MsTestFrameworkDefinitions.TestClassAttribute, out _);
 		}
 
 		/// <summary>

--- a/Philips.CodeAnalysis.DuplicateCodeAnalyzer/AvoidDuplicateCodeAnalyzer.cs
+++ b/Philips.CodeAnalysis.DuplicateCodeAnalyzer/AvoidDuplicateCodeAnalyzer.cs
@@ -25,7 +25,7 @@ namespace Philips.CodeAnalysis.DuplicateCodeAnalyzer
 
 		public int DefaultDuplicateTokenThreshold = 100;
 
-		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidDuplicateCode), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+		public static readonly DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidDuplicateCode), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
 		private const string InvalidTokenCountTitle = @"The token_count specified in the EditorConfig is invalid.";
 		private const string InvalidTokenCountMessage = @"The token_count {0} specified in the EditorConfig is invalid.";
@@ -623,7 +623,7 @@ namespace Philips.CodeAnalysis.DuplicateCodeAnalyzer
 			if (isPurged)
 			{
 				// Remove old value
-				HashCode = (HashCode - ((purgedHashComponent.GetHashCode() * _basePowMaxComponentsModulusCache) % _modulus) + _modulus) % _modulus;
+				HashCode = (HashCode - (purgedHashComponent.GetHashCode() * _basePowMaxComponentsModulusCache % _modulus) + _modulus) % _modulus;
 			}
 		}
 	}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/XmlDocumentationShouldAddValueAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/XmlDocumentationShouldAddValueAnalyzer.cs
@@ -115,7 +115,9 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 		private void AnalyzeNamedNode(SyntaxNodeAnalysisContext context, string name)
 		{
 			if (string.IsNullOrEmpty(name))
+			{
 				return;
+			}
 
 			name = name.ToLowerInvariant();
 			var xmlElements = context.Node.GetLeadingTrivia()
@@ -125,7 +127,9 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 			foreach(var xmlElement in xmlElements)
 			{
 				if (xmlElement.StartTag.Name.LocalName.Text != @"summary")
+				{
 					continue;
+				}
 
 				string content = GetContent(xmlElement);
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/LocationRangeModel.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/LocationRangeModel.cs
@@ -4,24 +4,14 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 {
 	public class LocationRangeModel
 	{
-		private readonly int _startLine;
-		private int _endLine;
-
 		public LocationRangeModel(int startLine, int endLine)
 		{
-			_startLine = startLine;
-			_endLine = endLine;
+			StartLine = startLine;
+			EndLine = endLine;
 		}
 
-		public int StartLine
-		{
-			get { return _startLine; }
-		}
+		public int StartLine { get; }
 
-		public int EndLine
-		{
-			get { return _endLine; }
-			set { _endLine = value; }
-		}
+		public int EndLine { get; set; }
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidEmptyStatementBlocksAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidEmptyStatementBlocksAnalyzer.cs
@@ -68,7 +68,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			}
 
 			// ParanthesizedLambdaExpressions are acceptable () => { }, until a pre-canned static "EmptyAction" is defined.
-			if (blockSyntax.Parent is ParenthesizedLambdaExpressionSyntax || blockSyntax.Parent is SimpleLambdaExpressionSyntax)
+			if (blockSyntax.Parent is ParenthesizedLambdaExpressionSyntax or SimpleLambdaExpressionSyntax)
 			{
 				return;
 			}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidEmptyTypeInitializerCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidEmptyTypeInitializerCodeFixProvider.cs
@@ -55,7 +55,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 			rootNode = rootNode.ReplaceNode(ctor, newCtor);
 
-			ClassDeclarationSyntax cls = (ClassDeclarationSyntax)rootNode.DescendantNodesAndSelf().OfType<ClassDeclarationSyntax>().First(x => x.Identifier.Text == ctor.Identifier.Text);
+			ClassDeclarationSyntax cls = rootNode.DescendantNodesAndSelf().OfType<ClassDeclarationSyntax>().First(x => x.Identifier.Text == ctor.Identifier.Text);
 
 			ctor = (ConstructorDeclarationSyntax)cls.Members.First(x => x.IsKind(SyntaxKind.ConstructorDeclaration) && ((ConstructorDeclarationSyntax)x).Modifiers.Any(SyntaxKind.StaticKeyword));
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidPrivateKeyPropertyAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidPrivateKeyPropertyAnalyzer.cs
@@ -53,7 +53,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 		#region Public Interface
 
-		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidPrivateKeyProperty), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description, helpLinkUri: helpUri);
+		public static readonly DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidPrivateKeyProperty), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description, helpLinkUri: helpUri);
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidPublicMemberVariableAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidPublicMemberVariableAnalyzer.cs
@@ -41,7 +41,9 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 			// ignore struct
 			if (fieldDeclaration.Parent.Kind() == SyntaxKind.StructDeclaration)
+			{
 				return;
+			}
 
 			if (fieldDeclaration.Modifiers.Any(SyntaxKind.PublicKeyword))
 			{

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidStaticClassesAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidStaticClassesAnalyzer.cs
@@ -21,7 +21,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		public const string MessageFormat = @"Avoid static classes";
 		private const string Description = @"Static Classes are not easily mockable. Avoid them so that your code is Unit Testable.";
 		private const string Category = Categories.Maintainability;
-		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidStaticClasses), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+		public static readonly DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidStaticClasses), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidStaticMethodCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidStaticMethodCodeFixProvider.cs
@@ -60,7 +60,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		{
 			SyntaxNode rootNode = await document.GetSyntaxRootAsync(cancellationToken);
 			var modifierToRemove = method.Modifiers.Where(m => m.ValueText == @"static").First();
-			var newModifiers = ((SyntaxTokenList)method.Modifiers).Remove(modifierToRemove);
+			var newModifiers = method.Modifiers.Remove(modifierToRemove);
 
 			MethodDeclarationSyntax newMethod = method.WithModifiers(newModifiers);
 			SyntaxNode newRoot = rootNode.ReplaceNode(method, newMethod);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidSuppressMessageAttributeAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidSuppressMessageAttributeAnalyzer.cs
@@ -59,11 +59,13 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 				var builder = ImmutableHashSet.CreateBuilder<string>();
 				if (text != null)
+				{
 					foreach (var textLine in text.Lines)
 					{
 						var line = textLine.ToString();
 						builder.Add(line);
 					}
+				}
 
 				return builder.ToImmutable();
 			}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidTryParseWithoutCultureAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidTryParseWithoutCultureAnalyzer.cs
@@ -90,7 +90,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 		#region Public Interface
 
-		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidTryParseWithoutCulture), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+		public static readonly DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidTryParseWithoutCulture), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/CallExtensionMethodsAsInstanceMethodsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/CallExtensionMethodsAsInstanceMethodsAnalyzer.cs
@@ -130,12 +130,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 				}
 			}
 
-			if (type.BaseType is null)
-			{
-				return false;
-			}
-
-			return HasMatchingMethod(type.BaseType, targetMethod);
+			return type.BaseType is not null && HasMatchingMethod(type.BaseType, targetMethod);
 		}
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/EnforceEditorConfigAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/EnforceEditorConfigAnalyzer.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		private const string Description = @".editorconfig files help enforce and configure Analyzers";
 		private const string Category = Categories.Maintainability;
 
-		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.EnforceEditorConfig), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: false, description: Description);
+		public static readonly DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.EnforceEditorConfig), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: false, description: Description);
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 
 		public override void Initialize(AnalysisContext context)

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/NoHardCodedPathsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/NoHardCodedPathsAnalyzer.cs
@@ -33,10 +33,16 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			// Get the text value of the string literal expression.
 			string pathValue = stringLiteralExpressionNode.Token.ValueText;
 
-			if (pathValue.Length < 2) return;
+			if (pathValue.Length < 2)
+			{
+				return;
+			}
 
 			//if the character of the string do not match either of the characters : for windows and / for linux; no need to run regex, simply return.
-			if (!pathValue[1].Equals(':') && !pathValue[0].Equals('/')) return;
+			if (!pathValue[1].Equals(':') && !pathValue[0].Equals('/'))
+			{
+				return;
+			}
 
 			// If the pattern matches the text value, report the diagnostic.
 			if (WindowsPattern.IsMatch(pathValue))
@@ -48,7 +54,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		#endregion
 
 		#region Public Interface
-		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.NoHardcodedPaths), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+		public static readonly DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.NoHardcodedPaths), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
 		{
 			get { return ImmutableArray.Create(Rule); }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/NoNestedStringFormatsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/NoNestedStringFormatsAnalyzer.cs
@@ -54,8 +54,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			var onlyInterpolation = interpolation.Parts[0];
 
 			if (
-				onlyInterpolation is not IInterpolatedStringTextOperation && 
-				onlyInterpolation is IInterpolationOperation interpolationOperation)
+				onlyInterpolation is not IInterpolatedStringTextOperation and
+				IInterpolationOperation interpolationOperation)
 			{
 				if (interpolationOperation.FormatString is not null)
 				{
@@ -109,7 +109,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 					break;
 			}
 
-			if (returnType.SpecialType == SpecialType.System_String || returnType.SpecialType == SpecialType.System_Void)
+			if (returnType.SpecialType is SpecialType.System_String or SpecialType.System_Void)
 			{
 				var paramsArguments = invocation.Arguments[formatStringParameterIndex + 1].Value;
 
@@ -264,12 +264,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 			var arrayType = ((IArrayTypeSymbol)possibleArgsParameter.Type).ElementType;
 
-			if (arrayType.SpecialType != SpecialType.System_Object)
-			{
-				return false;
-			}
-
-			return true;
+			return arrayType.SpecialType == SpecialType.System_Object;
 		}
 
 		private static bool IsFormattableStringMethodArgument(IInterpolationOperation interpolationOperation)

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/WinFormsInitializeComponentMustBeCalledOnceAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/WinFormsInitializeComponentMustBeCalledOnceAnalyzer.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		#region Non-Public Data Members
 
 		private const string Title = @"Check for UserControl constructor chains calls to InitializeComponent()";
-		public readonly static string MessageFormat = @"Class ""{0}"" constructor triggers {1} calls to ""InitializeComponent()"".  Must only trigger 1.";
+		public static readonly string MessageFormat = @"Class ""{0}"" constructor triggers {1} calls to ""InitializeComponent()"".  Must only trigger 1.";
 		private const string Description = @"All UserControl constructor chains must call InitializeComponent().";
 		private const string Category = Categories.Maintainability;
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/EnforceBoolNamingConventionAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/EnforceBoolNamingConventionAnalyzer.cs
@@ -200,7 +200,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 			}
 
 			var type = context.SemanticModel.GetDeclaredSymbol(property);
-			if (type != null && (type is IPropertySymbol propertySymbol))
+			if (type is not null and IPropertySymbol propertySymbol)
 			{
 				if (propertySymbol.ContainingType.AllInterfaces.Any(x => x.GetMembers(propertySymbol.Name).Any()))
 				{
@@ -223,12 +223,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 		{
 			string name = identifier.ValueText;
 
-			if (validator.IsMatch(name))
-			{
-				return true;
-			}
-
-			return false;
+			return validator.IsMatch(name);
 		}
 
 		private bool IsTypeBool(TypeSyntax typeSyntax, SemanticModel semanticModel)

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/EnforceBoolNamingConventionAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/EnforceBoolNamingConventionAnalyzer.cs
@@ -200,7 +200,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 			}
 
 			var type = context.SemanticModel.GetDeclaredSymbol(property);
-			if (type is not null and IPropertySymbol propertySymbol)
+			if (type is IPropertySymbol propertySymbol)
 			{
 				if (propertySymbol.ContainingType.AllInterfaces.Any(x => x.GetMembers(propertySymbol.Name).Any()))
 				{

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/NamespacePrefixAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/NamespacePrefixAnalyzer.cs
@@ -50,8 +50,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 		#region Public Interface
 		public static readonly string RuleId = Helper.ToDiagnosticId(DiagnosticIds.NamespacePrefix);
 
-		public readonly static DiagnosticDescriptor RuleForIncorrectNamespace = new(RuleId, TitleForIncorrectPrefix, MessageFormatForIncorrectPrefix, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: DescriptionForIncorrectPrefix);
-		public readonly static DiagnosticDescriptor RuleForEmptyPrefix = new(RuleId, TitleForEmptyPrefix, string.Format(MessageFormatForEmptyPrefix, RuleId), Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: string.Format(DescriptionForEmptyPrefix, RuleId));
+		public static readonly DiagnosticDescriptor RuleForIncorrectNamespace = new(RuleId, TitleForIncorrectPrefix, MessageFormatForIncorrectPrefix, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: DescriptionForIncorrectPrefix);
+		public static readonly DiagnosticDescriptor RuleForEmptyPrefix = new(RuleId, TitleForEmptyPrefix, string.Format(MessageFormatForEmptyPrefix, RuleId), Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: string.Format(DescriptionForEmptyPrefix, RuleId));
 
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(RuleForIncorrectNamespace, RuleForEmptyPrefix); } }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/VariableNamingConventionAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/VariableNamingConventionAnalyzer.cs
@@ -144,12 +144,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 		{
 			string name = identifier.ValueText;
 
-			if (validator.IsMatch(name))
-			{
-				return true;
-			}
-
-			return false;
+			return validator.IsMatch(name);
 		}
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidInlineNewAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidInlineNewAnalyzer.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 		private const string Description = @"Create a local variable, or a field for the temporary instance of class '{0}'";
 		private const string Category = Categories.Readability;
 
-		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidInlineNew), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+		public static readonly DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidInlineNew), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 
@@ -44,17 +44,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 
 		private static bool IsInlineNew(SyntaxNode node)
 		{
-			if (node is MemberAccessExpressionSyntax)
-			{
-				return true;
-			}
-
-			if (node is ParenthesizedExpressionSyntax syntax)
-			{
-				return IsInlineNew(syntax.Parent);
-			}
-
-			return false;
+			return node is MemberAccessExpressionSyntax
+			|| (node is ParenthesizedExpressionSyntax syntax && IsInlineNew(syntax.Parent));
 		}
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidRedundantSwitchStatementAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidRedundantSwitchStatementAnalyzer.cs
@@ -19,7 +19,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 		private const string Description = @"Elide the switch statement";
 		private const string Category = Categories.Readability;
 
-		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidSwitchStatementsWithNoCases), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+		public static readonly DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidSwitchStatementsWithNoCases), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
 		public AvoidRedundantSwitchStatementAnalyzer(GeneratedCodeAnalysisFlags generatedCodeFlags = GeneratedCodeAnalysisFlags.None)
 		{

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceRegionsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceRegionsAnalyzer.cs
@@ -188,11 +188,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 		private static bool MemberPresentInRegion(MemberDeclarationSyntax member, LocationRangeModel locationRange)
 		{
 			int memberLocation = GetMemberLineNumber(member.GetLocation());
-			if (memberLocation > locationRange.StartLine && memberLocation < locationRange.EndLine)
-			{
-				return true;
-			}
-			return false;
+			return memberLocation > locationRange.StartLine && memberLocation < locationRange.EndLine;
 		}
 
 		/// <summary>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/PreferNamedTuplesAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/PreferNamedTuplesAnalyzer.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 		private const string Description = @"Name this tuple field for readability";
 		private const string Category = Categories.Readability;
 
-		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.PreferTuplesWithNamedFields), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+		public static readonly DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.PreferTuplesWithNamedFields), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/PreferTupleFieldNamesAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/PreferTupleFieldNamesAnalyzer.cs
@@ -16,7 +16,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 		private const string Description = @"For readability use the name provided for this field, not a generic field name";
 		private const string Category = Categories.Readability;
 
-		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.PreferUsingNamedTupleField), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+		public static readonly DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.PreferUsingNamedTupleField), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/PreventUnnecessaryRangeChecksAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/PreventUnnecessaryRangeChecksAnalyzer.cs
@@ -78,27 +78,15 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 
 			forEachStatementSyntax = block.Statements[0] as ForEachStatementSyntax;
 
-			if (forEachStatementSyntax == null)
-			{
-				return false;
-			}
-
-			return true;
+			return forEachStatementSyntax != null;
 		}
 
 		private bool IsCountGreaterThanZero(ExpressionSyntax condition, ExpressionSyntax foreachExpression, SemanticModel semanticModel)
 		{
-			if (condition is ParenthesizedExpressionSyntax parenthesized)
-			{
-				return IsCountGreaterThanZero(parenthesized.Expression, foreachExpression, semanticModel);
-			}
-
-			if (condition is BinaryExpressionSyntax binaryExpressionSyntax)
-			{
-				return IsCountGreaterThanZero(binaryExpressionSyntax, foreachExpression, semanticModel);
-			}
-
-			return false;
+			return condition is ParenthesizedExpressionSyntax parenthesized
+				? IsCountGreaterThanZero(parenthesized.Expression, foreachExpression, semanticModel)
+				: condition is BinaryExpressionSyntax binaryExpressionSyntax
+					&& IsCountGreaterThanZero(binaryExpressionSyntax, foreachExpression, semanticModel);
 		}
 		private bool IsCountGreaterThanZero(BinaryExpressionSyntax condition, ExpressionSyntax foreachExpression, SemanticModel semanticModel)
 		{
@@ -143,12 +131,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 
 			if (foreachExpression is IdentifierNameSyntax identifier && ifExpression is IdentifierNameSyntax ifIdentifier)
 			{
-				if (ifIdentifier.Identifier.Text != identifier.Identifier.Text)
-				{
-					return false;
-				}
-
-				return true;
+				return ifIdentifier.Identifier.Text == identifier.Identifier.Text;
 			}
 
 			if (foreachExpression is MemberAccessExpressionSyntax memberAccess && ifExpression is MemberAccessExpressionSyntax ifMemberAccess)
@@ -162,17 +145,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 					}
 
 					var rightSymbol = model.GetSymbolInfo(right);
-					if (rightSymbol.Symbol is null)
-					{
-						return false;
-					}
-
-					if (!SymbolEqualityComparer.Default.Equals(leftSymbol.Symbol, rightSymbol.Symbol))
-					{
-						return false;
-					}
-
-					return true;
+					return rightSymbol.Symbol is not null && SymbolEqualityComparer.Default.Equals(leftSymbol.Symbol, rightSymbol.Symbol);
 				}
 
 				var foreachMemberAccessNodes = memberAccess.DescendantNodesAndSelf().ToList();
@@ -202,17 +175,10 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 			ifIdentifier = null;
 			method = null;
 
-			if (expression is MemberAccessExpressionSyntax memberAccessExpressionSyntax)
-			{
-				return TryGetIdentifiers(memberAccessExpressionSyntax, out ifIdentifier, out method);
-			}
-
-			if (expression is InvocationExpressionSyntax invocationExpression)
-			{
-				return TryGetIdentifiers(invocationExpression.Expression, out ifIdentifier, out method);
-			}
-
-			return false;
+			return expression is MemberAccessExpressionSyntax memberAccessExpressionSyntax
+				? TryGetIdentifiers(memberAccessExpressionSyntax, out ifIdentifier, out method)
+				: expression is InvocationExpressionSyntax invocationExpression
+				&& TryGetIdentifiers(invocationExpression.Expression, out ifIdentifier, out method);
 		}
 
 		private bool TryGetIdentifiers(MemberAccessExpressionSyntax expression, out ExpressionSyntax ifIdentifier, out IdentifierNameSyntax method)
@@ -232,12 +198,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 			}
 
 			ifIdentifier = expression.Expression as MemberAccessExpressionSyntax;
-			if (ifIdentifier != null)
-			{
-				return true;
-			}
-
-			return false;
+			return ifIdentifier != null;
 		}
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/DereferenceNullAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/DereferenceNullAnalyzer.cs
@@ -22,7 +22,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
 		private const string Description = @"Using the 'as' expression means a check should be made before dereferencing, or cast if you definitively know it will be this type in this context.";
 		private const string Category = Categories.RuntimeFailure;
 
-		public readonly static DiagnosticDescriptor Rule = new(
+		public static readonly DiagnosticDescriptor Rule = new(
 			Helper.ToDiagnosticId(DiagnosticIds.DereferenceNull),
 			Title, MessageFormat, Category,
 			DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
@@ -74,19 +74,10 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
 		private bool IsCaseWeUnderstand(SyntaxNode syntaxNode)
 		{
 			BinaryExpressionSyntax binaryExpressionSyntax = syntaxNode as BinaryExpressionSyntax;
-			if (binaryExpressionSyntax != null && binaryExpressionSyntax.OperatorToken.Kind() != SyntaxKind.AsKeyword)
-			{
-				return false;
-			}
-
-			if (
-				binaryExpressionSyntax != null && 
-				binaryExpressionSyntax.Parent is EqualsValueClauseSyntax equalsValueClauseSyntax &&
-				equalsValueClauseSyntax.Parent is VariableDeclaratorSyntax)
-			{
-				return true;
-			}
-			return false;
+			return (binaryExpressionSyntax == null || binaryExpressionSyntax.OperatorToken.Kind() == SyntaxKind.AsKeyword)
+				&& binaryExpressionSyntax != null 
+				&& binaryExpressionSyntax.Parent is EqualsValueClauseSyntax equalsValueClauseSyntax
+				&& equalsValueClauseSyntax.Parent is VariableDeclaratorSyntax;
 		}
 
 		/// <summary>
@@ -126,7 +117,9 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
 				{
 					SymbolInfo potentialSymbolOfInterest = model.GetSymbolInfo(identifierNameSyntax);
 					if (potentialSymbolOfInterest.Symbol == null)
+					{
 						continue;
+					}
 
 					if (SymbolEqualityComparer.Default.Equals(potentialSymbolOfInterest.Symbol, ourSymbol))
 					{

--- a/Philips.CodeAnalysis.MoqAnalyzers/MockRaiseArgumentsMustMatchEventAnalyzer.cs
+++ b/Philips.CodeAnalysis.MoqAnalyzers/MockRaiseArgumentsMustMatchEventAnalyzer.cs
@@ -159,7 +159,7 @@ namespace Philips.CodeAnalysis.MoqAnalyzers
 
 			for (int i = firstArgument; i < argumentsToCheck; i++)
 			{
-				ArgumentSyntax argument = invocationExpressionSyntax.ArgumentList.Arguments[(i + 1) - firstArgument];
+				ArgumentSyntax argument = invocationExpressionSyntax.ArgumentList.Arguments[i + 1 - firstArgument];
 				ITypeSymbol expectedType = namedTypeSymbol.DelegateInvokeMethod.Parameters[i].Type;
 
 				SymbolInfo typeSymbol = context.SemanticModel.GetSymbolInfo(argument.Expression);

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualAnalyzer.cs
@@ -30,7 +30,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 				SimpleNameSyntax name => name.ToString()
 			};
 
-			if ((memberName != @"AreEqual") && (memberName != @"AreNotEqual"))
+			if (memberName is not @"AreEqual" and not @"AreNotEqual")
 			{
 				return null;
 			}
@@ -76,17 +76,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			}
 
 			var constant = semanticModel.GetConstantValue(expression);
-			if (constant.HasValue)
-			{
-				return true;
-			}
-
-			if (Helper.IsConstantExpression(expression, semanticModel))
-			{
-				return true;
-			}
-
-			return false;
+			return constant.HasValue || Helper.IsConstantExpression(expression, semanticModel);
 		}
 
 		private bool IsNull(ExpressionSyntax expression)

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualCodeFixProvider.cs
@@ -63,7 +63,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 			bool isFirstArgumentNull = false;
 			bool isFirstArgumentConstant = false;
-			ArgumentListSyntax argumentList = invocationExpression.ArgumentList as ArgumentListSyntax;
+			ArgumentListSyntax argumentList = invocationExpression.ArgumentList;
 			if (argumentList.Arguments[0].Expression is LiteralExpressionSyntax arg0Literal)
 			{
 				Optional<object> literalValue = semanticModel.GetConstantValue(arg0Literal, cancellationToken);
@@ -118,12 +118,12 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 				if (argumentList.Arguments.Count == 2)
 				{
-					newArguments = SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList<ArgumentSyntax>(new ArgumentSyntax[] { argument }));
+					newArguments = SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(new ArgumentSyntax[] { argument }));
 				}
 				else
 				{
 					// make sure not to delete any custom error message
-					newArguments = SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList<ArgumentSyntax>(new ArgumentSyntax[] { argument, argumentList.Arguments[2] }));
+					newArguments = SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(new ArgumentSyntax[] { argument, argumentList.Arguments[2] }));
 				}
 
 				InvocationExpressionSyntax newInvocationExpression = SyntaxFactory.InvocationExpression(newMemberAccess, newArguments);

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualLiteralAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualLiteralAnalyzer.cs
@@ -53,13 +53,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			TypeInfo actualType = context.SemanticModel.GetTypeInfo(actual.Expression);
 
 			Conversion conversion = context.SemanticModel.Compilation.ClassifyConversion(actualType.Type, expectedType.Type);
-			if (conversion.IsNullable)
-			{
-				return null;
-			}
-
-
-			return new[] { Diagnostic.Create(Rule, invocationExpressionSyntax.GetLocation()) };
+			return conversion.IsNullable ? null : (IEnumerable<Diagnostic>)(new[] { Diagnostic.Create(Rule, invocationExpressionSyntax.GetLocation()) });
 		}
 
 		private bool IsLiteral(ExpressionSyntax expression)

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualLiteralCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualLiteralCodeFixProvider.cs
@@ -109,14 +109,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 		{
 			if (literalExpected is LiteralExpressionSyntax literal)
 			{
-				if (literal.Token.IsKind(SyntaxKind.TrueKeyword))
-				{
-					return true;
-				}
-				else
-				{
-					return false;
-				}
+				return literal.Token.IsKind(SyntaxKind.TrueKeyword);
 			}
 			else if (literalExpected is PrefixUnaryExpressionSyntax prefixUnaryExpressionSyntax)
 			{

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualTypesMatchAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualTypesMatchAnalyzer.cs
@@ -49,7 +49,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			}
 
 			string memberName = maes.Name.ToString();
-			if ((memberName != @"AreEqual") && (memberName != @"AreNotEqual"))
+			if (memberName is not @"AreEqual" and not @"AreNotEqual")
 			{
 				return;
 			}
@@ -65,7 +65,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 				return;
 			}
 
-			ArgumentListSyntax argumentList = mds.ArgumentList as ArgumentListSyntax;
+			ArgumentListSyntax argumentList = mds.ArgumentList;
 			TypeInfo ti1 = context.SemanticModel.GetTypeInfo(argumentList.Arguments[0].Expression);
 			TypeInfo ti2 = context.SemanticModel.GetTypeInfo(argumentList.Arguments[1].Expression);
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertFailAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertFailAnalyzer.cs
@@ -90,7 +90,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 		private bool CheckBlock(IBlockOperation blockOperation, IExpressionStatementOperation expressionOperation)
 		{
-			if (blockOperation.Parent is IUsingOperation || blockOperation.Parent is ICatchClauseOperation)
+			if (blockOperation.Parent is IUsingOperation or ICatchClauseOperation)
 			{
 				return false;
 			}

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueAnalyzer.cs
@@ -71,12 +71,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			}
 
 			//would love to check if the types are actually IComparable<> here.  Speaks to intent.
-			if (sym.Name == "Equals")
-			{
-				return true;
-			}
-
-			return false;
+			return sym.Name == "Equals";
 		}
 	}
 }

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueCodeFixProvider.cs
@@ -200,28 +200,9 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			const string IsNull = "IsNull";
 			const string IsNotNull = "IsNotNull";
 
-			if (isIsTrue)
-			{
-				if (isNotEquals)
-				{
-					return isNullArgument ? IsNotNull : AreNotEqual;
-				}
-				else
-				{
-					return isNullArgument ? IsNull : AreEqual;
-				}
-			}
-			else
-			{
-				if (isNotEquals)
-				{
-					return isNullArgument ? IsNull : AreEqual;
-				}
-				else
-				{
-					return isNullArgument ? IsNotNull : AreNotEqual;
-				}
-			}
+			return isIsTrue
+				? isNotEquals ? isNullArgument ? IsNotNull : AreNotEqual : isNullArgument ? IsNull : AreEqual
+				: isNotEquals ? isNullArgument ? IsNull : AreEqual : isNullArgument ? IsNotNull : AreNotEqual;
 		}
 
 		private ArgumentListSyntax DecomposeEqualsFunction(ArgumentListSyntax argumentList, out bool isNotEquals)

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueCodeFixProvider.cs
@@ -200,9 +200,28 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			const string IsNull = "IsNull";
 			const string IsNotNull = "IsNotNull";
 
-			return isIsTrue
-				? isNotEquals ? isNullArgument ? IsNotNull : AreNotEqual : isNullArgument ? IsNull : AreEqual
-				: isNotEquals ? isNullArgument ? IsNull : AreEqual : isNullArgument ? IsNotNull : AreNotEqual;
+			if (isIsTrue)
+			{
+				if (isNotEquals)
+				{
+					return isNullArgument ? IsNotNull : AreNotEqual;
+				}
+				else
+				{
+					return isNullArgument ? IsNull : AreEqual;
+				}
+			}
+			else
+			{
+				if (isNotEquals)
+				{
+					return isNullArgument ? IsNull : AreEqual;
+				}
+				else
+				{
+					return isNullArgument ? IsNotNull : AreNotEqual;
+				}
+			}
 		}
 
 		private ArgumentListSyntax DecomposeEqualsFunction(ArgumentListSyntax argumentList, out bool isNotEquals)

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueFalseDiagnosticAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueFalseDiagnosticAnalyzer.cs
@@ -34,12 +34,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 			Diagnostic result = Check(context, invocationExpressionSyntax, invocationExpressionSyntax.ArgumentList, isIsTrue);
 
-			if (result is null)
-			{
-				return Array.Empty<Diagnostic>();
-			}
-
-			return new[] { result };
+			return result is null ? Array.Empty<Diagnostic>() : (IEnumerable<Diagnostic>)(new[] { result });
 		}
 		protected virtual Diagnostic Check(SyntaxNodeAnalysisContext context, SyntaxNode node, ArgumentListSyntax arguments, bool isIsTrue)
 		{
@@ -47,11 +42,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 			var test = allArguments.FirstOrDefault()?.Expression;
 
-			if (test != null)
-			{
-				return Check(context, node, test, isIsTrue);
-			}
-			return null;
+			return test != null ? Check(context, node, test, isIsTrue) : null;
 		}
 
 		protected abstract Diagnostic Check(SyntaxNodeAnalysisContext context, SyntaxNode node, ExpressionSyntax test, bool isIsTrue);

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueLiteralAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueLiteralAnalyzer.cs
@@ -24,12 +24,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 		protected override Diagnostic Check(SyntaxNodeAnalysisContext context, SyntaxNode node, ExpressionSyntax test, bool isIsTrue)
 		{
-			if (!Helper.IsLiteralTrueFalse(test))
-			{
-				return null;
-			}
-
-			return Diagnostic.Create(IsTrueRule, test.GetLocation());
+			return !Helper.IsLiteralTrueFalse(test) ? null : Diagnostic.Create(IsTrueRule, test.GetLocation());
 		}
 	}
 }

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueParenthesisAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueParenthesisAnalyzer.cs
@@ -46,7 +46,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			}
 
 			string memberName = memberAccessExpression.Name.ToString();
-			if (memberName != "IsTrue" && memberName != "IsFalse")
+			if (memberName is not "IsTrue" and not "IsFalse")
 			{
 				return;
 			}

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertMethodCallDiagnosticAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertMethodCallDiagnosticAnalyzer.cs
@@ -45,7 +45,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 		#region Public Interface
 
-		public override sealed void Initialize(AnalysisContext context)
+		public sealed override void Initialize(AnalysisContext context)
 		{
 			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
 			context.EnableConcurrentExecution();

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AvoidAssertConditionalAccessAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AvoidAssertConditionalAccessAnalyzer.cs
@@ -27,7 +27,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 		protected override IEnumerable<Diagnostic> Analyze(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocationExpressionSyntax, MemberAccessExpressionSyntax memberAccessExpression)
 		{
 			string memberName = memberAccessExpression.Name.ToString();
-			if (memberName != @"AreEqual" && memberName != @"AreNotEqual")
+			if (memberName is not @"AreEqual" and not @"AreNotEqual")
 			{
 				yield break;
 			}

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AvoidAttributeAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AvoidAttributeAnalyzer.cs
@@ -18,7 +18,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 		private static readonly ImmutableDictionary<string, ImmutableArray<AttributeModel>> attributes = GetAttributeModels();
 
-		public readonly static ImmutableArray<DiagnosticDescriptor> Rules = GetRules(attributes);
+		public static readonly ImmutableArray<DiagnosticDescriptor> Rules = GetRules(attributes);
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return Rules; } }
 
@@ -58,11 +58,13 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 				var builder = ImmutableHashSet.CreateBuilder<string>();
 				if (text != null)
+				{
 					foreach (var textLine in text.Lines)
 					{
 						string line = textLine.ToString();
 						builder.Add(line);
 					}
+				}
 
 				return builder.ToImmutable();
 			}
@@ -110,12 +112,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 			id = symbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
 
-			if (whitelist.Contains(id))
-			{
-				return true;
-			}
-
-			return false;
+			return whitelist.Contains(id);
 		}
 
 		private static ImmutableArray<DiagnosticDescriptor> GetRules(ImmutableDictionary<string, ImmutableArray<AttributeModel>> attributes)

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AvoidMsFakes.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AvoidMsFakes.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 		private const string Description = @"Avoid MS Fakes. Use Moq instead for example.  If applicable, remove the Reference and the .fakes file as well.";
 		private const string Category = Categories.Maintainability;
 
-		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidMsFakes), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+		public static readonly DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidMsFakes), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AvoidOwnerAttributeCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AvoidOwnerAttributeCodeFixProvider.cs
@@ -66,7 +66,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 				if (nodesToRemove.Length != attributelist.Attributes.Count)
 				{
-					var newAttribute = (AttributeListSyntax)attributelist.RemoveNodes(nodesToRemove, SyntaxRemoveOptions.KeepNoTrivia);
+					var newAttribute = attributelist.RemoveNodes(nodesToRemove, SyntaxRemoveOptions.KeepNoTrivia);
 					newAttributes = newAttributes.Add(newAttribute);
 				}
 			}

--- a/Philips.CodeAnalysis.MsTestAnalyzers/DataTestMethodsHaveDataRowsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/DataTestMethodsHaveDataRowsAnalyzer.cs
@@ -60,7 +60,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 					}
 
 					SymbolInfo symbol = context.SemanticModel.GetSymbolInfo(attribute);
-					if (symbol.Symbol is not null and IMethodSymbol method)
+					if (symbol.Symbol is IMethodSymbol method)
 					{
 						if (method.ContainingType.AllInterfaces.Contains(Definitions.ITestSourceSymbol))
 						{

--- a/Philips.CodeAnalysis.MsTestAnalyzers/DataTestMethodsHaveDataRowsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/DataTestMethodsHaveDataRowsAnalyzer.cs
@@ -14,10 +14,10 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 	{
 		private const string Title = @"DataTestMethods must have at least 1 DataRow or 1 DynamicData, TestMethods must have none";
 
-		public readonly static string MessageFormatMismatchedCount = @"Test {0} has {1} DataRowAttributes and {2} DynamicDataAttributes.";
+		public static readonly string MessageFormatMismatchedCount = @"Test {0} has {1} DataRowAttributes and {2} DynamicDataAttributes.";
 
-		public readonly static string MessageFormatIsTestMethod = @"TestMethod has parameterized input data.  Convert to DataTestMethod.";
-		public readonly static string MessageFormatIsDataTestMethod = @"DataTestMethod has no input data.  Convert to TestMethod.";
+		public static readonly string MessageFormatIsTestMethod = @"TestMethod has parameterized input data.  Convert to DataTestMethod.";
+		public static readonly string MessageFormatIsDataTestMethod = @"DataTestMethod has no input data.  Convert to TestMethod.";
 
 		private const string Description = @"DataTestMethods are only executed with DataRows";
 		private const string Category = Categories.Maintainability;
@@ -60,7 +60,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 					}
 
 					SymbolInfo symbol = context.SemanticModel.GetSymbolInfo(attribute);
-					if (symbol.Symbol != null && symbol.Symbol is IMethodSymbol method)
+					if (symbol.Symbol is not null and IMethodSymbol method)
 					{
 						if (method.ContainingType.AllInterfaces.Contains(Definitions.ITestSourceSymbol))
 						{

--- a/Philips.CodeAnalysis.MsTestAnalyzers/NoEmptyTestMethodsDiagnosticAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/NoEmptyTestMethodsDiagnosticAnalyzer.cs
@@ -17,11 +17,14 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 		private const string Description = @"Remove empty test method '{0}'";
 		private const string Category = Categories.Maintainability;
 
-		public readonly static DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.TestMethodsMustNotBeEmpty), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+		public static readonly DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.TestMethodsMustNotBeEmpty), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 
-		protected override Implementation OnInitializeAnalyzer(AnalyzerOptions options, Compilation compilation, MsTestAttributeDefinitions definitions) => new NoEmptyTestMethodsImplementation();
+		protected override Implementation OnInitializeAnalyzer(AnalyzerOptions options, Compilation compilation, MsTestAttributeDefinitions definitions)
+		{
+			return new NoEmptyTestMethodsImplementation();
+		}
 
 		public class NoEmptyTestMethodsImplementation : Implementation
 		{

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestClassMustBePublicAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestClassMustBePublicAnalyzer.cs
@@ -14,7 +14,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 	public class TestClassMustBePublicAnalyzer : TestClassDiagnosticAnalyzer
 	{
 		private const string Title = @"[TestClass] must be a public instance class";
-		public readonly static string MessageFormat = @"'{0}' is not a public instance class";
+		public static readonly string MessageFormat = @"'{0}' is not a public instance class";
 		private const string Description = @"";
 		private const string Category = Categories.Maintainability;
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestContextCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestContextCodeFixProvider.cs
@@ -84,7 +84,10 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 						{
 							// remove the underlying variable
 							if (varDeclaration.Parent != null)
+							{
 								rootNode = rootNode.RemoveNode(varDeclaration.Parent, SyntaxRemoveOptions.KeepNoTrivia);
+							}
+
 							break;
 						}
 					}

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestHasCategoryAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestHasCategoryAnalyzer.cs
@@ -50,7 +50,9 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 				if (methodDeclaration.Parent is ClassDeclarationSyntax classDeclaration)
 				{
 					if (_exceptions.Contains($"{classDeclaration.Identifier.Text}.{methodDeclaration.Identifier.Text}"))
+					{
 						return;
+					}
 				}
 
 				if (!Helper.HasAttribute(attributeLists, context, MsTestFrameworkDefinitions.TestCategoryAttribute, out Location categoryLocation, out AttributeArgumentSyntax argumentSyntax))

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestHasDescriptionAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestHasDescriptionAnalyzer.cs
@@ -20,7 +20,10 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 
-		protected override TestMethodImplementation OnInitializeTestMethodAnalyzer(AnalyzerOptions options, Compilation compilation, MsTestAttributeDefinitions definitions) => new TestHasDescription(definitions);
+		protected override TestMethodImplementation OnInitializeTestMethodAnalyzer(AnalyzerOptions options, Compilation compilation, MsTestAttributeDefinitions definitions)
+		{
+			return new TestHasDescription(definitions);
+		}
 
 		public class TestHasDescription : TestMethodImplementation
 		{

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestHasDescriptionCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestHasDescriptionCodeFixProvider.cs
@@ -66,7 +66,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 				if (nodesToRemove.Length != attributelist.Attributes.Count)
 				{
-					var newAttribute = (AttributeListSyntax)attributelist.RemoveNodes(nodesToRemove, SyntaxRemoveOptions.KeepNoTrivia);
+					var newAttribute = attributelist.RemoveNodes(nodesToRemove, SyntaxRemoveOptions.KeepNoTrivia);
 					newAttributes = newAttributes.Add(newAttribute);
 				}
 			}

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestHasTimeoutAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestHasTimeoutAnalyzer.cs
@@ -16,7 +16,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 		private const string Description = @"Tests that lack a Timeout may indefinitely block.";
 		private const string Category = Categories.Maintainability;
 
-		public readonly static string DefaultTimeoutKey = "defaultTimeout";
+		public static readonly string DefaultTimeoutKey = "defaultTimeout";
 
 		public static DiagnosticDescriptor Rule => new(Helper.ToDiagnosticId(DiagnosticIds.TestHasTimeoutAttribute), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: false, description: Description);
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodNameAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodNameAnalyzer.cs
@@ -37,15 +37,22 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			foreach (AttributeSyntax attribute in attributesNode.Attributes)
 			{
 				if (attribute.Name.ToString() == @"TestMethod")
+				{
 					found = true;
+				}
 			}
-			if (!found) return;
+			if (!found)
+			{
+				return;
+			}
 
 			SyntaxNode methodNode = attributesNode.Parent;
 
 			// Confirm this is actually a method...
 			if (methodNode.Kind() != SyntaxKind.MethodDeclaration)
+			{
 				return;
+			}
 
 			string invalidPrefix = string.Empty;
 			foreach (SyntaxToken token in methodNode.ChildTokens())

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsMustBeInTestClassAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsMustBeInTestClassAnalyzer.cs
@@ -13,7 +13,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 	public class TestMethodsMustBeInTestClassAnalyzer : TestAttributeDiagnosticAnalyzer
 	{
 		private const string Title = @"TestMethods/DataTestMethods must be in [TestClass]";
-		public readonly static string MessageFormat = @"{0} is not in a [TestClass]";
+		public static readonly string MessageFormat = @"{0} is not in a [TestClass]";
 		private const string Description = @"Tests are only executed if they are [TestClass]";
 		private const string Category = Categories.Maintainability;
 
@@ -24,7 +24,10 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 		public TestMethodsMustBeInTestClassAnalyzer()
 		{ }
 
-		protected override Implementation OnInitializeAnalyzer(AnalyzerOptions options, Compilation compilation, MsTestAttributeDefinitions definitions) => new TestMethodsMustBeInTestClass();
+		protected override Implementation OnInitializeAnalyzer(AnalyzerOptions options, Compilation compilation, MsTestAttributeDefinitions definitions)
+		{
+			return new TestMethodsMustBeInTestClass();
+		}
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsMustBePublicAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsMustBePublicAnalyzer.cs
@@ -14,7 +14,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 	public class TestMethodsMustBePublicAnalyzer : TestMethodDiagnosticAnalyzer
 	{
 		private const string Title = @"TestMethods/DataTestMethods must be public, instance methods";
-		public readonly static string MessageFormat = @"'{0}' is not a public instance method";
+		public static readonly string MessageFormat = @"'{0}' is not a public instance method";
 		private const string Description = @"";
 		private const string Category = Categories.Maintainability;
 
@@ -24,7 +24,10 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 
-		protected override TestMethodImplementation OnInitializeTestMethodAnalyzer(AnalyzerOptions options, Compilation compilation, MsTestAttributeDefinitions definitions) => new TestMethodsMustBePublic(definitions);
+		protected override TestMethodImplementation OnInitializeTestMethodAnalyzer(AnalyzerOptions options, Compilation compilation, MsTestAttributeDefinitions definitions)
+		{
+			return new TestMethodsMustBePublic(definitions);
+		}
 
 		private class TestMethodsMustBePublic : TestMethodImplementation
 		{

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsMustHaveTheCorrectNumberOfArgumentsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsMustHaveTheCorrectNumberOfArgumentsAnalyzer.cs
@@ -87,7 +87,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 					}
 
 					var symbol = context.SemanticModel.GetSymbolInfo(attribute);
-					if (symbol.Symbol is not null and IMethodSymbol method)
+					if (symbol.Symbol is IMethodSymbol method)
 					{
 						if (method.ContainingType.AllInterfaces.Contains(Definitions.ITestSourceSymbol))
 						{

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsMustHaveTheCorrectNumberOfArgumentsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsMustHaveTheCorrectNumberOfArgumentsAnalyzer.cs
@@ -14,7 +14,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 	public class TestMethodsMustHaveTheCorrectNumberOfArgumentsAnalyzer : TestMethodDiagnosticAnalyzer
 	{
 		private const string Title = @"TestMethods/DataTestMethods must have the correct number of arguments";
-		public readonly static string MessageFormat = @"'{0}' has the wrong number of parameters";
+		public static readonly string MessageFormat = @"'{0}' has the wrong number of parameters";
 		private const string Description = @"DataTestMethods should have the same number of parameters of the DataRows, TestMethods should have no arguments";
 		private const string Category = Categories.Maintainability;
 
@@ -25,7 +25,10 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 
 
-		protected override TestMethodImplementation OnInitializeTestMethodAnalyzer(AnalyzerOptions options, Compilation compilation, MsTestAttributeDefinitions definitions) => new TestMethodsMustHaveTheCorrectNumberOfArguments(definitions);
+		protected override TestMethodImplementation OnInitializeTestMethodAnalyzer(AnalyzerOptions options, Compilation compilation, MsTestAttributeDefinitions definitions)
+		{
+			return new TestMethodsMustHaveTheCorrectNumberOfArguments(definitions);
+		}
 
 		private class TestMethodsMustHaveTheCorrectNumberOfArguments : TestMethodImplementation
 		{
@@ -84,7 +87,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 					}
 
 					var symbol = context.SemanticModel.GetSymbolInfo(attribute);
-					if (symbol.Symbol != null && symbol.Symbol is IMethodSymbol method)
+					if (symbol.Symbol is not null and IMethodSymbol method)
 					{
 						if (method.ContainingType.AllInterfaces.Contains(Definitions.ITestSourceSymbol))
 						{

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsShouldHaveUniqueNamesAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsShouldHaveUniqueNamesAnalyzer.cs
@@ -13,7 +13,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 	public class TestMethodsShouldHaveUniqueNamesAnalyzer : TestClassDiagnosticAnalyzer
 	{
 		private const string Title = @"TestMethods/DataTestMethods should not have the same name";
-		public readonly static string MessageFormat = @"Multiple tests named '{0}'";
+		public static readonly string MessageFormat = @"Multiple tests named '{0}'";
 		private const string Description = @"";
 		private const string Category = Categories.Maintainability;
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsShouldHaveValidReturnTypesAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsShouldHaveValidReturnTypesAnalyzer.cs
@@ -12,7 +12,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 	public class TestMethodsShouldHaveValidReturnTypesAnalyzer : TestMethodDiagnosticAnalyzer
 	{
 		private const string Title = @"TestMethods must return void or Task for async methods";
-		public readonly static string MessageFormat = @"Test method should return '{0}', actually returns '{1}'";
+		public static readonly string MessageFormat = @"Test method should return '{0}', actually returns '{1}'";
 		private const string Description = @"MSTest will not run tests that return something other than void, or Task for async tests.";
 		private const string Category = Categories.Maintainability;
 
@@ -22,7 +22,10 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 
-		protected override TestMethodImplementation OnInitializeTestMethodAnalyzer(AnalyzerOptions options, Compilation compilation, MsTestAttributeDefinitions definitions) => new TestMethodsShouldHaveValidReturnTypes(compilation, definitions);
+		protected override TestMethodImplementation OnInitializeTestMethodAnalyzer(AnalyzerOptions options, Compilation compilation, MsTestAttributeDefinitions definitions)
+		{
+			return new TestMethodsShouldHaveValidReturnTypes(compilation, definitions);
+		}
 
 		private class TestMethodsShouldHaveValidReturnTypes : TestMethodImplementation
 		{

--- a/Philips.CodeAnalysis.SecurityAnalyzers/AvoidPasswordAnalyzer.cs
+++ b/Philips.CodeAnalysis.SecurityAnalyzers/AvoidPasswordAnalyzer.cs
@@ -19,7 +19,7 @@ namespace Philips.CodeAnalysis.SecurityAnalyzers
 		private const string Description = @"Avoid hard-coded passwords.  (Avoid this analyzer by not naming something Password.)";
 		private const string Category = Categories.Security;
 
-		public readonly static DiagnosticDescriptor Rule = new(
+		public static readonly DiagnosticDescriptor Rule = new(
 			Helper.ToDiagnosticId(DiagnosticIds.AvoidPasswordField), 
 			Title, MessageFormat, Category, 
 			DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
@@ -40,25 +40,31 @@ namespace Philips.CodeAnalysis.SecurityAnalyzers
 		private void AnalyzeProperty(SyntaxNodeAnalysisContext context)
 		{
 			if (context.Node is PropertyDeclarationSyntax propertyDeclarationSyntax)
+			{
 				Diagnose(propertyDeclarationSyntax.Identifier.ValueText,
 					propertyDeclarationSyntax.GetLocation(), context.ReportDiagnostic);
+			}
 		}
 
 		private void AnalyzeMethod(SyntaxNodeAnalysisContext context)
 		{
 			if (context.Node is MethodDeclarationSyntax methodDeclarationSyntax)
+			{
 				Diagnose(methodDeclarationSyntax.Identifier.ValueText,
 					methodDeclarationSyntax.GetLocation(), context.ReportDiagnostic);
+			}
 		}
 
 		private void AnalyzeFields(SyntaxNodeAnalysisContext context)
 		{
 			if (context.Node is FieldDeclarationSyntax fieldDeclarationSyntax)
+			{
 				foreach (var variable in fieldDeclarationSyntax.Declaration.Variables)
 				{
 					Diagnose(variable.Identifier.ValueText,
 						fieldDeclarationSyntax.GetLocation(), context.ReportDiagnostic);
 				}
+			}
 		}
 
 
@@ -74,13 +80,9 @@ namespace Philips.CodeAnalysis.SecurityAnalyzers
 
 		private Diagnostic CheckComment(string comment, Location location)
 		{
-			if (comment.ToLower().Contains(@"password"))
-			{
-				return Diagnostic.Create(Rule, location);
-			}
-			return null;
+			return comment.ToLower().Contains(@"password") ? Diagnostic.Create(Rule, location) : null;
 		}
-		
+
 		private void Diagnose(string valueText, Location location, Action<Diagnostic> reportDiagnostic)
 		{
 			Diagnostic diagnostic = CheckComment(valueText, location);

--- a/Philips.CodeAnalysis.Test/DuplicateCode/AvoidDuplicateCodeTest.cs
+++ b/Philips.CodeAnalysis.Test/DuplicateCode/AvoidDuplicateCodeTest.cs
@@ -74,8 +74,7 @@ Foo.WhitelistedFunction
 
 				static int Fib(int n)
 				{
-					if (n == 0) return 0;
-					return n + Fib(n - 1);
+					return n == 0 ? 0 : n + Fib(n - 1);
 				}
 
 				if (i >= duplicateTokenThreshold)

--- a/Philips.CodeAnalysis.Test/Helpers/DiagnosticResult.cs
+++ b/Philips.CodeAnalysis.Test/Helpers/DiagnosticResult.cs
@@ -53,19 +53,13 @@ namespace Philips.CodeAnalysis.Test
 				return locations;
 			}
 
-			set
-			{
-				locations = value;
-			}
+			set => locations = value;
 		}
 
 		public DiagnosticResultLocation Location
 		{
-			get { return Locations[0]; }
-			set
-			{
-				Locations = new[] { value };
-			}
+			get => Locations[0];
+			set => Locations = new[] { value };
 		}
 
 		public DiagnosticSeverity Severity { get; set; }

--- a/Philips.CodeAnalysis.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/Philips.CodeAnalysis.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -197,7 +197,7 @@ namespace Philips.CodeAnalysis.Test
 		/// <returns>A Tuple containing the Documents produced from the sources and their TextSpans if relevant</returns>
 		private Document[] GetDocuments(string[] sources, string filenamePrefix, string language)
 		{
-			if (language != LanguageNames.CSharp && language != LanguageNames.VisualBasic)
+			if (language is not LanguageNames.CSharp and not LanguageNames.VisualBasic)
 			{
 				throw new ArgumentException("Unsupported Language");
 			}

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/OrderPropertyAccessorsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/OrderPropertyAccessorsAnalyzerTest.cs
@@ -14,7 +14,10 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Documentation
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new OrderPropertyAccessorsAnalyzer();
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		{
+			return new OrderPropertyAccessorsAnalyzer();
+		}
 
 		#endregion
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/XmlDocumentationShouldAddValueAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/XmlDocumentationShouldAddValueAnalyzerTest.cs
@@ -21,7 +21,10 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Documentation
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new XmlDocumentationShouldAddValueAnalyzer();
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		{
+			return new XmlDocumentationShouldAddValueAnalyzer();
+		}
 
 		protected override CodeFixProvider GetCSharpCodeFixProvider()
 		{

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/CallExtensionMethodsAsInstanceMethodsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/CallExtensionMethodsAsInstanceMethodsAnalyzerTest.cs
@@ -57,7 +57,7 @@ public static class Program
 }}
 ";
 
-			string text = string.Format(Template, (isExtensionMethod ? "this" : ""), call);
+			string text = string.Format(Template, isExtensionMethod ? "this" : "", call);
 
 			DiagnosticResult[] result = Array.Empty<DiagnosticResult>();
 			if (isError)
@@ -69,7 +69,7 @@ public static class Program
 
 			if (!string.IsNullOrEmpty(fixedText))
 			{
-				string newText = string.Format(Template, (isExtensionMethod ? "this" : ""), fixedText);
+				string newText = string.Format(Template, isExtensionMethod ? "this" : "", fixedText);
 				VerifyCSharpFix(text, newText);
 			}
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/DontLockNewObjectAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/DontLockNewObjectAnalyzerTest.cs
@@ -14,7 +14,10 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new DontLockNewObjectAnalyzer();
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		{
+			return new DontLockNewObjectAnalyzer();
+		}
 
 		#endregion
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/PassByRefAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/PassByRefAnalyzerTest.cs
@@ -187,7 +187,10 @@ public class TestClass {baseClass}
 		}
 
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new PassByRefAnalyzer();
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		{
+			return new PassByRefAnalyzer();
+		}
 
 		#endregion
 	}

--- a/Philips.CodeAnalysis.Test/MsTest/AssertAreEqualTypesMatchAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AssertAreEqualTypesMatchAnalyzerTest.cs
@@ -58,7 +58,7 @@ namespace AssertAreEqualTypesMatchAnalyzerTest
 				}
 			}};
 
-			VerifyCSharpDiagnostic(givenText, "Test0", (isError) ? expected : Array.Empty<DiagnosticResult>());
+			VerifyCSharpDiagnostic(givenText, "Test0", isError ? expected : Array.Empty<DiagnosticResult>());
 		}
 		
 		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/Philips.CodeAnalysis.Test/MsTest/TestContextAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestContextAnalyzerTest.cs
@@ -45,7 +45,7 @@ namespace TestContextAnalyzerTest
 				}
 			}};
 			bool runsOnNetFramework = RuntimeInformation.FrameworkDescription.Contains("Framework");
-			VerifyCSharpDiagnostic(givenText, "Test0", (runsOnNetFramework) ? expected : Array.Empty<DiagnosticResult>());
+			VerifyCSharpDiagnostic(givenText, "Test0", runsOnNetFramework ? expected : Array.Empty<DiagnosticResult>());
 		}
 		
 		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/Philips.CodeAnalysis.Test/MsTest/TestHasTimeoutAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestHasTimeoutAnalyzerTest.cs
@@ -31,12 +31,15 @@ class TestDefinitions
 }";
 		}
 
-		protected override Dictionary<string, string> GetAdditionalAnalyzerConfigOptions() => new()
+		protected override Dictionary<string, string> GetAdditionalAnalyzerConfigOptions()
 		{
-			{  $"dotnet_code_quality.{TestHasTimeoutAttributeAnalyzer.Rule.Id}.Unit", "TestTimeouts.CiAppropriate,TestTimeouts.CiAcceptable" },
-			{  $"dotnet_code_quality.{TestHasTimeoutAttributeAnalyzer.Rule.Id}.Integration", "TestTimeouts.Integration" },
-			{  $"dotnet_code_quality.{TestHasTimeoutAttributeAnalyzer.Rule.Id}.Smoke", "TestTimeouts.Smoke" }
-		};
+			return new()
+			{
+				{  $"dotnet_code_quality.{TestHasTimeoutAttributeAnalyzer.Rule.Id}.Unit", "TestTimeouts.CiAppropriate,TestTimeouts.CiAcceptable" },
+				{  $"dotnet_code_quality.{TestHasTimeoutAttributeAnalyzer.Rule.Id}.Integration", "TestTimeouts.Integration" },
+				{  $"dotnet_code_quality.{TestHasTimeoutAttributeAnalyzer.Rule.Id}.Smoke", "TestTimeouts.Smoke" }
+			};
+		}
 
 		[DataTestMethod]
 		[DataRow("[TestMethod]", "[TestMethod]\n    [Timeout(1000)]")]

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodNameAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodNameAnalyzerTest.cs
@@ -53,7 +53,7 @@ namespace TestMethodNameAnalyzerTest
 				}
 			}};
 
-			VerifyCSharpDiagnostic(givenText, "Test0", (isError) ? expected : Array.Empty<DiagnosticResult>());
+			VerifyCSharpDiagnostic(givenText, "Test0", isError ? expected : Array.Empty<DiagnosticResult>());
 			VerifyCSharpFix(givenText, fixedText);
 		}
 		

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodsShouldHaveValidReturnTypesAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodsShouldHaveValidReturnTypesAnalyzerTest.cs
@@ -17,7 +17,10 @@ namespace Philips.CodeAnalysis.Test.MsTest
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new TestMethodsShouldHaveValidReturnTypesAnalyzer();
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		{
+			return new TestMethodsShouldHaveValidReturnTypesAnalyzer();
+		}
 
 		#endregion
 


### PR DESCRIPTION
Separate Issues will be created for the findings disabled with 3 hash signs in the editorconfig. Those 3 had many findings that would unduly clutter the review.

I think the most debatable was whether or not to include "Simplify If", which essentially converts it to a ternary operator. I chose to enable it because, after applying, 2-3 places triggered additional findings that removed simplified/redundant logic.