### PR TITLE
Extract Local Variable

### DIFF
--- a/Philips.CodeAnalysis.Common/DiagnosticIds.cs
+++ b/Philips.CodeAnalysis.Common/DiagnosticIds.cs
@@ -95,5 +95,6 @@ namespace Philips.CodeAnalysis.Common
 		AvoidPasswordField = 2100,
 		DereferenceNull = 2101,
 		XmlDocumentationShouldAddValue = 2102,
+		AvoidInvocationAsArgument = 2103,
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidInvocationAsArgument.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidInvocationAsArgument.cs
@@ -54,8 +54,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			}
 
 			// If nested calls (e.g., Foo(Bar(Meow()))), only trigger the outer violation Bar(Meow())
-			ArgumentSyntax nestedArgumentSyntax = argumentSyntax.Ancestors().OfType<ArgumentSyntax>().FirstOrDefault();
-			if (nestedArgumentSyntax != null)
+			if (argumentSyntax.Ancestors().OfType<ArgumentSyntax>().Any())
 			{
 				return;
 			}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidInvocationAsArgument.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidInvocationAsArgument.cs
@@ -1,0 +1,92 @@
+﻿// © 2022 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class AvoidInvocationAsArgumentAnalyzer : DiagnosticAnalyzer
+	{
+		private const string Title = @"Avoid method calls as arguments";
+		public const string MessageFormat = @"Avoid '{0}' as an argument";
+		private const string Description = @"Avoid method calls as arguments to method calls";
+		private const string Category = Categories.Maintainability;
+
+		private static readonly DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidInvocationAsArgument), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+		public override void Initialize(AnalysisContext context)
+		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.EnableConcurrentExecution();
+			context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.Argument);
+		}
+
+		private void Analyze(SyntaxNodeAnalysisContext context)
+		{
+			ArgumentSyntax argumentSyntax = (ArgumentSyntax)context.Node;
+
+			// We are looking for method calls as arguments
+			if (argumentSyntax.Expression is not InvocationExpressionSyntax argumentExpressionSyntax)
+			{
+				return;
+			}
+
+			// If it's an embedded nameof() operation, let it go.
+			if ((argumentExpressionSyntax.Expression as IdentifierNameSyntax)?.Identifier.Text == "nameof")
+			{
+				return;
+			}
+
+			// If it's calling ToString(), let it go. (ToStrings() cognitive load isn't excessive, and lots of violations)
+			if ((argumentExpressionSyntax.Expression as MemberAccessExpressionSyntax)?.Name.Identifier.Text == "ToString")
+			{
+				return;
+			}
+
+			// If nested calls (e.g., Foo(Bar(Meow()))), only trigger the outer violation Bar(Meow())
+			ArgumentSyntax nestedArgumentSyntax = argumentSyntax.Ancestors().OfType<ArgumentSyntax>().FirstOrDefault();
+			if (nestedArgumentSyntax != null)
+			{
+				return;
+			}
+
+			// If we're within a constructor initializer (this(...) or base(...) eg), let it go
+			ConstructorInitializerSyntax constructorInitializerSyntax = argumentSyntax.Ancestors().OfType<ConstructorInitializerSyntax>().FirstOrDefault();
+			if (constructorInitializerSyntax != null)
+			{
+				return;
+			}
+
+			// If the caller is Assert, let it go. (This is debatable, and ideally warrants a configuration option.)
+			MemberAccessExpressionSyntax caller = (argumentSyntax.Parent.Parent as InvocationExpressionSyntax)?.Expression as MemberAccessExpressionSyntax;
+			if (caller?.Expression is IdentifierNameSyntax identifier && identifier.Identifier.ValueText.Contains(@"Assert"))
+			{
+				return;
+			}
+
+			// If the called method is static, let it go to reduce annoyances. E.g., "Times.Once", "Mock.Of<>", "Marshal.Sizeof", etc.
+			// This is debatable, and ideally warrants a configuration option.
+			if (argumentExpressionSyntax.Expression is MemberAccessExpressionSyntax callee)
+			{
+				var symbol = context.SemanticModel.GetSymbolInfo(callee).Symbol;
+				if (symbol.IsStatic)
+				{
+					return;
+				}
+			}
+
+			Diagnostic diagnostic = Diagnostic.Create(Rule, argumentSyntax.GetLocation(), argumentSyntax.ToString());
+			context.ReportDiagnostic(diagnostic);
+		}
+	}
+}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidInvocationAsArgumentCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidInvocationAsArgumentCodeFixProvider.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Rename;
+using Microsoft.CodeAnalysis.Text;
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
+{
+
+	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AvoidInvocationAsArgumentCodeFixProvider)), Shared]
+	public class AvoidInvocationAsArgumentCodeFixProvider : CodeFixProvider
+	{
+		private const string Title = "Extract local variable";
+
+		public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticIds.AvoidInvocationAsArgument));
+		public sealed override FixAllProvider GetFixAllProvider()
+		{
+			return WellKnownFixAllProviders.BatchFixer;
+		}
+
+		public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+		{
+			SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+			Diagnostic diagnostic = context.Diagnostics.First();
+			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
+
+			// Find the nested method call identified by the diagnostic.
+			ExpressionSyntax node = root.FindNode(diagnosticSpan, false, true) as ExpressionSyntax;
+
+			// Make sure it's part of a statement that we know how to handle.
+			// For example, we do not currently handle method expressions (ie =>)
+			StatementSyntax fullExistingExpressionSyntax = node.FirstAncestorOrSelf<ExpressionStatementSyntax>();
+			fullExistingExpressionSyntax ??= node.FirstAncestorOrSelf<ReturnStatementSyntax>();
+			fullExistingExpressionSyntax ??= node.FirstAncestorOrSelf<LocalDeclarationStatementSyntax>();
+
+			if (fullExistingExpressionSyntax != null)
+			{
+				// Register a code action that will invoke the fix.
+				context.RegisterCodeFix(
+					CodeAction.Create(
+						title: Title,
+						createChangedDocument: c => ExtractLocalVariable(context.Document, node, c),
+						equivalenceKey: Title),
+					diagnostic);
+			}
+		}
+
+		private async Task<Document> ExtractLocalVariable(Document document, ExpressionSyntax argumentSyntax, CancellationToken c)
+		{
+			SyntaxNode rootNode = await document.GetSyntaxRootAsync(c).ConfigureAwait(false);
+			const string NewName = @"renameMe";
+
+			// Build "var renameMe = [blah]"
+			LocalDeclarationStatementSyntax localDeclarationStatementSyntax =
+				SyntaxFactory.LocalDeclarationStatement(
+				  SyntaxFactory.VariableDeclaration(
+					  SyntaxFactory.ParseTypeName("var"))
+					.AddVariables(
+					  SyntaxFactory.VariableDeclarator(SyntaxFactory.Identifier(NewName).WithAdditionalAnnotations(RenameAnnotation.Create()))
+						.WithInitializer(SyntaxFactory.EqualsValueClause(argumentSyntax))));
+
+
+			// Get the whole statement that contains the violation
+			StatementSyntax fullExistingExpressionSyntax = argumentSyntax.FirstAncestorOrSelf<ExpressionStatementSyntax>();
+			fullExistingExpressionSyntax ??= argumentSyntax.FirstAncestorOrSelf<ReturnStatementSyntax>();
+			fullExistingExpressionSyntax ??= argumentSyntax.FirstAncestorOrSelf<LocalDeclarationStatementSyntax>();
+
+			// Replace the violation with "renameMe"
+			IdentifierNameSyntax identifierSyntax = SyntaxFactory.IdentifierName(NewName);
+			var newFullExistingExpressionSyntax = fullExistingExpressionSyntax.ReplaceNode(argumentSyntax, identifierSyntax);
+
+			// Move all the leading trivia from the existing statement to our new statement
+			SyntaxTriviaList existingLeadingTrivia = fullExistingExpressionSyntax.GetLeadingTrivia();
+			var formattedLocalDeclarationSyntax = localDeclarationStatementSyntax.WithLeadingTrivia(existingLeadingTrivia);
+
+			// Put just the leading whitespace back into the original statement (ie, remove comments on the previous line - we put them on our new first statement instead)
+			newFullExistingExpressionSyntax = newFullExistingExpressionSyntax.WithoutLeadingTrivia();
+			if (existingLeadingTrivia.Count > 0)
+			{
+				newFullExistingExpressionSyntax = newFullExistingExpressionSyntax.WithLeadingTrivia(existingLeadingTrivia[existingLeadingTrivia.Count - 1]);
+			}
+
+			// If we're not already inside a block statement, we need to make it so.
+			// (E.g., "if (true) Foo(Moo())" => "if (true) { var renameMe=Moo();Foo(renameMe); }"
+			if (fullExistingExpressionSyntax.Parent is StatementSyntax && fullExistingExpressionSyntax.Parent is not BlockSyntax)
+			{
+				BlockSyntax blockSyntax = SyntaxFactory.Block(formattedLocalDeclarationSyntax, newFullExistingExpressionSyntax);
+				rootNode = rootNode.ReplaceNode(fullExistingExpressionSyntax, blockSyntax);
+			}
+			else
+			{
+				List<SyntaxNode> newNodes = new() { formattedLocalDeclarationSyntax, newFullExistingExpressionSyntax };
+				rootNode = rootNode.ReplaceNode(fullExistingExpressionSyntax, newNodes);
+			}
+
+			return document.WithSyntaxRoot(rootNode);
+		}
+	}
+}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidInvocationAsArgumentTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidInvocationAsArgumentTest.cs
@@ -1,0 +1,318 @@
+﻿// © 2021 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Serialization;
+using Philips.CodeAnalysis.Common;
+using Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability;
+
+namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
+{
+	[TestClass]
+	public class AvoidInvocationAsArgumentAnalyzerTest : CodeFixVerifier
+	{
+
+		[TestMethod]
+		public void AvoidInvocationAsArgumentTest()
+		{
+			string template = @"
+class Foo
+{{
+  public Foo() : base(Do()) {}
+  public Foo(string h) {}
+  public static string Do() {{ return ""hi"";}}
+  public string Moo(string s) {{ return ""hi"";}}
+
+  public void MyTest()
+  {{
+    string.Format(Foo.Do());
+    string.Format(nameof(MyTest));
+    string.Format(5.ToString());
+    string.Format(Moo(Do()));	  // Finding
+    Assert.Format(Moo("""").Format(""""));
+  }}
+}}
+";
+			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
+		}
+
+		[TestMethod]
+		public void AvoidInvocationAsArgumentReturnTest()
+		{
+			string template = @"
+class Foo
+{{
+  public string Do() {{ return ""hi"";}}
+  public string Moo(string s) {{ return ""hi"";}}
+
+  public string MyTest()
+  {{
+    return Moo(Do());
+  }}
+}}
+";
+			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
+		}
+
+		[TestMethod]
+		public void AvoidInvocationAsArgumentFixTest()
+		{
+			string errorContent = @"
+class Foo
+{
+  public string Do() { return ""hi"";}
+  public void Moo(string x) { }
+  public void MyTest()
+  {
+     Moo(Do());
+  }
+}
+";
+			string fixedContent = @"
+class Foo
+{
+  public string Do() { return ""hi"";}
+  public void Moo(string x) { }
+  public void MyTest()
+  {
+     var renameMe = Do();
+     Moo(renameMe);
+  }
+}
+";
+
+			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
+			VerifyCSharpFix(errorContent, fixedContent);
+		}
+
+		[TestMethod]
+		public void AvoidInvocationAsArgumentLocalAssignmentTest()
+		{
+			string errorContent = @"
+class Foo
+{
+  public string Do() { return ""hi"";}
+  public string Moo(string x) { }
+  public void MyTest()
+  {
+     string x = Moo(Do());
+  }
+}
+";
+			string fixedContent = @"
+class Foo
+{
+  public string Do() { return ""hi"";}
+  public string Moo(string x) { }
+  public void MyTest()
+  {
+     var renameMe = Do();
+     string x = Moo(renameMe);
+  }
+}
+";
+
+			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
+			VerifyCSharpFix(errorContent, fixedContent);
+		}
+
+		[TestMethod]
+		public void AvoidInvocationAsArgumentAssignmentTest()
+		{
+			string errorContent = @"
+class Foo
+{
+  public string Do() { return ""hi"";}
+  public string Moo(string x) { }
+  public void MyTest()
+  {
+     string x;
+     x = Moo(Do());
+  }
+}
+";
+			string fixedContent = @"
+class Foo
+{
+  public string Do() { return ""hi"";}
+  public string Moo(string x) { }
+  public void MyTest()
+  {
+     string x;
+     var renameMe = Do();
+     x = Moo(renameMe);
+  }
+}
+";
+
+			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
+			VerifyCSharpFix(errorContent, fixedContent);
+		}
+
+
+		[TestMethod]
+		public void AvoidInvocationAsArgumentFixReturnTest()
+		{
+			string errorContent = @"
+class Foo
+{
+  public string Do() { return ""hi"";}
+  public void Moo(string x) { }
+  public string MyTest()
+  {
+     // Comment
+     return Moo(Do());
+  }
+}
+";
+			string fixedContent = @"
+class Foo
+{
+  public string Do() { return ""hi"";}
+  public void Moo(string x) { }
+  public string MyTest()
+  {
+     // Comment
+     var renameMe = Do();
+     return Moo(renameMe);
+  }
+}
+";
+
+			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
+			VerifyCSharpFix(errorContent, fixedContent);
+		}
+
+		[TestMethod]
+		public void AvoidInvocationAsArgumentFixIfTest()
+		{
+			string errorContent = @"
+class Foo
+{
+  public string Do() { return ""hi"";}
+  public void Moo(string x) { }
+  public void MyTest()
+  {
+     if (true)
+       Moo(Do());
+  }
+}
+";
+			string fixedContent = @"
+class Foo
+{
+  public string Do() { return ""hi"";}
+  public void Moo(string x) { }
+  public void MyTest()
+  {
+     if (true)
+     {
+       var renameMe = Do();
+       Moo(renameMe);
+     }
+  }
+}
+";
+			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
+			VerifyCSharpFix(errorContent, fixedContent);
+		}
+
+		[TestMethod]
+		public void AvoidInvocationAsArgumentFixNewTest()
+		{
+			string errorContent = @"
+class Meow { public Meow(string x) {} }
+class Foo
+{
+  public string Do() { return ""hi"";}
+  public void MyTest()
+  {
+     new Meow(Do());
+  }
+}
+";
+			string fixedContent = @"
+class Meow { public Meow(string x) {} }
+class Foo
+{
+  public string Do() { return ""hi"";}
+  public void MyTest()
+  {
+     var renameMe = Do();
+     new Meow(renameMe);
+  }
+}
+";
+			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
+			VerifyCSharpFix(errorContent, fixedContent);
+		}
+
+		[TestMethod]
+		public void AvoidInvocationAsArgumentFixSwitchTest()
+		{
+			string errorContent = @"
+class Meow { public Meow(string x) {} }
+class Foo
+{
+  public string Do() { return ""hi"";}
+  public void Moo(string x) { }
+  public void MyTest()
+  {
+     int i;
+     switch (i)
+     {
+       case 0: Moo(Do()); break;
+     }
+  }
+}
+";
+			string fixedContent = @"
+class Meow { public Meow(string x) {} }
+class Foo
+{
+  public string Do() { return ""hi"";}
+  public void Moo(string x) { }
+  public void MyTest()
+  {
+     int i;
+     switch (i)
+     {
+       case 0: var renameMe = Do(); Moo(renameMe); break;
+     }
+  }
+}
+";
+			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
+			VerifyCSharpFix(errorContent, fixedContent);
+		}
+
+		[TestMethod]
+		public void AvoidInvocationAsArgumentFixExpressionTest()
+		{
+			string errorContent = @"
+class Meow { public Meow(string x) {} }
+class Foo
+{
+  public string Do() { return ""hi"";}
+  public void Moo(string x) { }
+  public void MyTest() => Moo(Do());
+}
+";
+
+			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
+			//VerifyCSharpFix(errorContent, fixedContent);
+		}
+
+		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		{
+			return new AvoidInvocationAsArgumentCodeFixProvider();
+		}
+
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new AvoidInvocationAsArgumentAnalyzer();
+        }
+    }
+}


### PR DESCRIPTION
New analyzer to extract a local variable. e.g.,

```
Moo(Foo())
```
becomes
```
var resultOfFoo = Foo();
Moo(resultOfFoo)
```

Many variations are accounted for, including constructor initializers, expression bodies, statics, ToString, returns, etc. The Rename Dialog is invoked.
