### PR TITLE
feat: Extend the existing AlignOperatorCountAnalyzer

### DIFF
--- a/Philips.CodeAnalysis.Common/DiagnosticIds.cs
+++ b/Philips.CodeAnalysis.Common/DiagnosticIds.cs
@@ -99,5 +99,8 @@ namespace Philips.CodeAnalysis.Common
 		EveryLinqStatementOnSeparateLine = 2104,
 		AlignNumberOfPlusAndMinusOperators = 2105,
 		AlignNumberOfMultiplyAndDivideOperators = 2106,
+		AlignNumberOfGreaterAndLessThanOperators = 2107,
+		AlignNumberOfShiftRightAndLeftOperators = 2108,
+		AlignNumberOfIncrementAndDecrementOperators = 2109,
 	}
 }

--- a/Philips.CodeAnalysis.Common/DiagnosticIds.cs
+++ b/Philips.CodeAnalysis.Common/DiagnosticIds.cs
@@ -100,7 +100,8 @@ namespace Philips.CodeAnalysis.Common
 		AlignNumberOfPlusAndMinusOperators = 2105,
 		AlignNumberOfMultiplyAndDivideOperators = 2106,
 		AlignNumberOfGreaterAndLessThanOperators = 2107,
-		AlignNumberOfShiftRightAndLeftOperators = 2108,
-		AlignNumberOfIncrementAndDecrementOperators = 2109,
+		AlignNumberOfGreaterAndLessThanOrEqualOperators = 2108,
+		AlignNumberOfShiftRightAndLeftOperators = 2109,
+		AlignNumberOfIncrementAndDecrementOperators = 2110,
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AlignOperatorsCountAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AlignOperatorsCountAnalyzer.cs
@@ -17,42 +17,45 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 	[DiagnosticAnalyzer(LanguageNames.CSharp)]
 	public class AlignOperatorsCountAnalyzer : DiagnosticAnalyzer
 	{
-		private const string PlusMinusTitle = "Align number of + and - operators.";
-		private const string PlusMinusMessage = "Align number of + and - operators.";
-		private const string PlusMinusDescription = 
-			"A class should have the same number of + as - operators.";
-		private const string MultiplyDivideTitle = "Align number of * and / operators.";
-		private const string MultiplyDivideMessage = "Align number of * and / operators.";
-		private const string MultiplyDivideDescription =
-			"A class should have the same number of * as / operators.";
+		private const string TitleFormat = "Align number of {0} and {1} operators.";
+		private const string MessageFormat = "Align number of {0} and {1} operators.";
+		private const string DescriptionFormat = 
+			"A class should have the same number of {0} as {1} operators.";
 		private const string Category = Categories.Maintainability;
 
+		private static readonly DiagnosticDescriptor IncrementAndDecrementRule =
+			GenerateRule("++", "--", DiagnosticIds.AlignNumberOfIncrementAndDecrementOperators);
+
 		private static readonly DiagnosticDescriptor PlusMinusRule =
-			new(
-				Helper.ToDiagnosticId(DiagnosticIds.AlignNumberOfPlusAndMinusOperators),
-				PlusMinusTitle,
-				PlusMinusMessage,
-				Category,
-				DiagnosticSeverity.Error,
-				isEnabledByDefault: true,
-				description: PlusMinusDescription
-			);
+			GenerateRule("+", "-", DiagnosticIds.AlignNumberOfPlusAndMinusOperators);
+
 		private static readonly DiagnosticDescriptor MultiplyDivideRule =
-			new(
-				Helper.ToDiagnosticId(DiagnosticIds.AlignNumberOfMultiplyAndDivideOperators),
-				MultiplyDivideTitle,
-				MultiplyDivideMessage,
+			GenerateRule("*", "/", DiagnosticIds.AlignNumberOfMultiplyAndDivideOperators);
+
+		private static readonly DiagnosticDescriptor GreaterLessThanRule =
+			GenerateRule(">", "<", DiagnosticIds.AlignNumberOfGreaterAndLessThanOperators); 
+
+		private static readonly DiagnosticDescriptor ShiftRightAndLeftRule =
+			GenerateRule(">>", "<<", DiagnosticIds.AlignNumberOfShiftRightAndLeftOperators);
+
+		private static DiagnosticDescriptor GenerateRule(string first, string second, DiagnosticIds diagnosticId)
+		{
+			return new(
+				Helper.ToDiagnosticId(diagnosticId),
+				string.Format(TitleFormat, first, second),
+				string.Format(MessageFormat, first, second),
 				Category,
 				DiagnosticSeverity.Error,
 				isEnabledByDefault: true,
-				description: MultiplyDivideDescription
+				description: string.Format(DescriptionFormat, first, second)
 			);
+		}
 
 		/// <summary>
 		/// <inheritdoc cref="DiagnosticAnalyzer"/>
 		/// </summary>
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-			ImmutableArray.Create(PlusMinusRule, MultiplyDivideRule);
+			ImmutableArray.Create(IncrementAndDecrementRule, PlusMinusRule, MultiplyDivideRule, GreaterLessThanRule, ShiftRightAndLeftRule);
 
 		/// <summary>
 		/// <inheritdoc cref="DiagnosticAnalyzer"/>
@@ -77,16 +80,34 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			OperatorsVisitor visitor = new();
 			visitor.Visit(classDeclaration);
 
-			if(visitor.PlusCount != visitor.MinusCount)
+			if (visitor.IncrementCount != visitor.DecrementCount)
+			{
+				var location = classDeclaration.Identifier.GetLocation();
+				context.ReportDiagnostic(Diagnostic.Create(IncrementAndDecrementRule, location));
+			}
+
+			if (visitor.PlusCount != visitor.MinusCount)
 			{
 				var location = classDeclaration.Identifier.GetLocation();
 				context.ReportDiagnostic(Diagnostic.Create(PlusMinusRule, location));
 			}
 
-			if(visitor.MultiplyCount != visitor.DivideCount)
+			if (visitor.MultiplyCount != visitor.DivideCount)
 			{
 				var location = classDeclaration.Identifier.GetLocation();
 				context.ReportDiagnostic(Diagnostic.Create(MultiplyDivideRule, location));
+			}
+
+			if (visitor.LessThanCount != visitor.GreaterThanCount)
+			{
+				var location = classDeclaration.Identifier.GetLocation();
+				context.ReportDiagnostic(Diagnostic.Create(GreaterLessThanRule, location));
+			}
+
+			if (visitor.ShiftLeftCount != visitor.ShiftRightCount)
+			{
+				var location = classDeclaration.Identifier.GetLocation();
+				context.ReportDiagnostic(Diagnostic.Create(ShiftRightAndLeftRule, location));
 			}
 		}
 	}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AlignOperatorsCountAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AlignOperatorsCountAnalyzer.cs
@@ -33,7 +33,10 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			GenerateRule("*", "/", DiagnosticIds.AlignNumberOfMultiplyAndDivideOperators);
 
 		private static readonly DiagnosticDescriptor GreaterLessThanRule =
-			GenerateRule(">", "<", DiagnosticIds.AlignNumberOfGreaterAndLessThanOperators); 
+			GenerateRule(">", "<", DiagnosticIds.AlignNumberOfGreaterAndLessThanOperators);
+
+		private static readonly DiagnosticDescriptor GreaterLessThanOrEqualRule =
+			GenerateRule(">=", "<=", DiagnosticIds.AlignNumberOfGreaterAndLessThanOrEqualOperators);
 
 		private static readonly DiagnosticDescriptor ShiftRightAndLeftRule =
 			GenerateRule(">>", "<<", DiagnosticIds.AlignNumberOfShiftRightAndLeftOperators);
@@ -55,7 +58,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		/// <inheritdoc cref="DiagnosticAnalyzer"/>
 		/// </summary>
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-			ImmutableArray.Create(IncrementAndDecrementRule, PlusMinusRule, MultiplyDivideRule, GreaterLessThanRule, ShiftRightAndLeftRule);
+			ImmutableArray.Create(IncrementAndDecrementRule, PlusMinusRule, MultiplyDivideRule, GreaterLessThanRule, GreaterLessThanOrEqualRule, ShiftRightAndLeftRule);
 
 		/// <summary>
 		/// <inheritdoc cref="DiagnosticAnalyzer"/>
@@ -102,6 +105,12 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			{
 				var location = classDeclaration.Identifier.GetLocation();
 				context.ReportDiagnostic(Diagnostic.Create(GreaterLessThanRule, location));
+			}
+
+			if (visitor.LessThanOrEqualCount != visitor.GreaterThanOrEqualCount)
+			{
+				var location = classDeclaration.Identifier.GetLocation();
+				context.ReportDiagnostic(Diagnostic.Create(GreaterLessThanOrEqualRule, location));
 			}
 
 			if (visitor.ShiftLeftCount != visitor.ShiftRightCount)

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/OperatorsVisitor.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/OperatorsVisitor.cs
@@ -59,28 +59,28 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 			}
 		}
 
-		public int IncrementCount { get; private set; } = 0;
+		public int IncrementCount { get; private set; }
 
-		public int DecrementCount { get; private set; } = 0;
+		public int DecrementCount { get; private set; }
 
-		public int PlusCount { get; private set; } = 0;
+		public int PlusCount { get; private set; }
 
-		public int MinusCount { get; private set; } = 0;
+		public int MinusCount { get; private set; }
 
-		public int MultiplyCount { get; private set; } = 0;
+		public int MultiplyCount { get; private set; }
 
-		public int DivideCount { get; private set; } = 0;
+		public int DivideCount { get; private set; }
 
-		public int GreaterThanCount { get; private set; } = 0;
+		public int GreaterThanCount { get; private set; }
 
-		public int LessThanCount { get; private set; } = 0;
+		public int LessThanCount { get; private set; }
 
-		public int GreaterThanOrEqualCount { get; private set; } = 0;
+		public int GreaterThanOrEqualCount { get; private set; }
 
-		public int LessThanOrEqualCount { get; private set; } = 0;
+		public int LessThanOrEqualCount { get; private set; }
 
-		public int ShiftRightCount { get; private set; } = 0;
+		public int ShiftRightCount { get; private set; }
 
-		public int ShiftLeftCount { get; private set; } = 0;
+		public int ShiftLeftCount { get; private set; }
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/OperatorsVisitor.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/OperatorsVisitor.cs
@@ -13,8 +13,6 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 	{
 		public OperatorsVisitor() : base(SyntaxWalkerDepth.Node)
 		{
-			PlusCount = 0;
-			MinusCount = 0;
 		}
 
 		public override void VisitOperatorDeclaration(OperatorDeclarationSyntax node)
@@ -22,6 +20,12 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 			base.VisitOperatorDeclaration(node);
 			switch(node.OperatorToken.Kind())
 			{
+				case SyntaxKind.PlusPlusToken:
+					IncrementCount += 1;
+					break;
+				case SyntaxKind.MinusMinusToken:
+					DecrementCount += 1;
+					break;
 				case SyntaxKind.PlusToken:
 					PlusCount += 1;
 					break;
@@ -34,15 +38,39 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 				case SyntaxKind.SlashToken:
 					DivideCount += 1;
 					break;
+				case SyntaxKind.GreaterThanToken:
+					GreaterThanCount += 1;
+					break;
+				case SyntaxKind.LessThanToken:
+					LessThanCount += 1;
+					break;
+				case SyntaxKind.GreaterThanGreaterThanToken:
+					ShiftRightCount += 1;
+					break;
+				case SyntaxKind.LessThanLessThanToken:
+					ShiftLeftCount += 1;
+					break;
 			}
 		}
 
-		public int PlusCount { get; private set; }
+		public int IncrementCount { get; private set; } = 0;
 
-		public int MinusCount { get; private set; }
+		public int DecrementCount { get; private set; } = 0;
 
-		public int MultiplyCount { get; private set; }
+		public int PlusCount { get; private set; } = 0;
 
-		public int DivideCount { get; private set; }
+		public int MinusCount { get; private set; } = 0;
+
+		public int MultiplyCount { get; private set; } = 0;
+
+		public int DivideCount { get; private set; } = 0;
+
+		public int GreaterThanCount { get; private set; } = 0;
+
+		public int LessThanCount { get; private set; } = 0;
+
+		public int ShiftRightCount { get; private set; } = 0;
+
+		public int ShiftLeftCount { get; private set; } = 0;
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/OperatorsVisitor.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/OperatorsVisitor.cs
@@ -44,6 +44,12 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 				case SyntaxKind.LessThanToken:
 					LessThanCount += 1;
 					break;
+				case SyntaxKind.GreaterThanEqualsToken:
+					GreaterThanOrEqualCount += 1;
+					break;
+				case SyntaxKind.LessThanEqualsToken:
+					LessThanOrEqualCount += 1;
+					break;
 				case SyntaxKind.GreaterThanGreaterThanToken:
 					ShiftRightCount += 1;
 					break;
@@ -68,6 +74,10 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 		public int GreaterThanCount { get; private set; } = 0;
 
 		public int LessThanCount { get; private set; } = 0;
+
+		public int GreaterThanOrEqualCount { get; private set; } = 0;
+
+		public int LessThanOrEqualCount { get; private set; } = 0;
 
 		public int ShiftRightCount { get; private set; } = 0;
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -80,6 +80,12 @@
       * Introduce PH2102: Xml documentation should add value.
       * Fixed issue 156: Multiple false positive on PH2101: Using 'as' expression
       * Improve PH2077: AvoidRedundantSwitch should exclude generated code
+      * Introduce PH2204: Put every Linq statement on a separate line.
+      * Introduce PH2105: Align number of + and - operators.
+      * Introduce PH2106: Align number of * and / operators.
+      * Introduce PH2107: Align number of &gt; and &lt; operators.
+      * Introduce PH2108: Align number of &gt;&gt; and &lt;&lt; operators.
+      * Introduce PH2109: Align number of ++ and -- operators.
     </PackageReleaseNotes>
 	  <Copyright>© 2019-2022 Koninklijke Philips N.V.</Copyright>
 	  <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -84,8 +84,9 @@
       * Introduce PH2105: Align number of + and - operators.
       * Introduce PH2106: Align number of * and / operators.
       * Introduce PH2107: Align number of &gt; and &lt; operators.
-      * Introduce PH2108: Align number of &gt;&gt; and &lt;&lt; operators.
-      * Introduce PH2109: Align number of ++ and -- operators.
+      * Introduce PH2108: Align number of &gt;= and &lt;= operators.
+      * Introduce PH2109: Align number of &gt;&gt; and &lt;&lt; operators.
+      * Introduce PH2110: Align number of ++ and -- operators.
     </PackageReleaseNotes>
 	  <Copyright>© 2019-2022 Koninklijke Philips N.V.</Copyright>
 	  <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -56,3 +56,6 @@
 | PH2104  | Every Linq statement on separate line        | Put every linq statement on a separate line, this makes it easier for a reader to follow the steps. |
 | PH2105  | Align number of + and - operators            | Align the number of operators + and -, as these are often used in combination with each other. |
 | PH2106  | Align number of * and / operators            | Align the number of operators * and /, as these are often used in combination with each other. |
+| PH2107  | Align number of > and < operators            | Align the number of operators > and <, as these are often used in combination with each other. |
+| PH2108  | Align number of >> and << operators          | Align the number of operators >> and <<, as these are often used in combination with each other. |
+| PH2109  | Align number of ++ and -- operators          | Align the number of operators ++ and --, as these are often used in combination with each other. |

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -57,5 +57,6 @@
 | PH2105  | Align number of + and - operators            | Align the number of operators + and -, as these are often used in combination with each other. |
 | PH2106  | Align number of * and / operators            | Align the number of operators * and /, as these are often used in combination with each other. |
 | PH2107  | Align number of > and < operators            | Align the number of operators > and <, as these are often used in combination with each other. |
-| PH2108  | Align number of >> and << operators          | Align the number of operators >> and <<, as these are often used in combination with each other. |
-| PH2109  | Align number of ++ and -- operators          | Align the number of operators ++ and --, as these are often used in combination with each other. |
+| PH2108  | Align number of >= and <= operators          | Align the number of operators >= and <=, as these are often used in combination with each other. |
+| PH2109  | Align number of >> and << operators          | Align the number of operators >> and <<, as these are often used in combination with each other. |
+| PH2110  | Align number of ++ and -- operators          | Align the number of operators ++ and --, as these are often used in combination with each other. |

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AlignOperatorsCountAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AlignOperatorsCountAnalyzerTest.cs
@@ -14,6 +14,21 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 	[TestClass]
 	public class AlignOperatorsCountAnalyzerTest : DiagnosticVerifier
 	{
+		private const string CorrectNumberOfIncrementDecrement = @"
+    namespace AssignmentInConditionUnitTests {
+        public class Number {
+			private int n;
+            public static Number operator ++(Number num1)
+            {
+                return num1.n + 1;
+            }
+            public static Number operator --(Number num1)
+            {
+                return num1.n - num2.n;
+            }
+        }
+    }";
+
 		private const string CorrectNumberOfPlusMinus = @"
     namespace AssignmentInConditionUnitTests {
         public class Number {
@@ -43,7 +58,45 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
             }
         }
     }";
+		private const string CorrectNumberOfGreaterLessThan = @"
+    namespace AssignmentInConditionUnitTests {
+        public class Number {
+			private int n;
+            public static bool operator >(Number num1, Number num2)
+            {
+                return num1.n > num2.n;
+            }
+            public static bool operator <(Number num1, Number num2)
+            {
+                return num1.n < num2.n;
+            }
+        }
+    }";
+		private const string CorrectNumberOfRightLeftShift = @"
+    namespace AssignmentInConditionUnitTests {
+        public class Number {
+			private int n;
+            public static Number operator >>(Number num1, int i)
+            {
+                return num1.n >> i;
+            }
+            public static Number operator <<(Number num1, int i)
+            {
+                return num1.n << i;
+            }
+        }
+    }";
 
+		private const string WrongNumberOfIncrementDecrement = @"
+    namespace AssignmentInConditionUnitTests {
+        public class Number {
+			private int n;
+            public static Number operator ++(Number num1)
+            {
+                return num1.n + 1;
+            }
+        }
+    }";
 		private const string WrongNumberOfPlusMinus = @"
     namespace AssignmentInConditionUnitTests {
         public class Number {
@@ -65,14 +118,41 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
             }
         }
     }";
+		private const string WrongNumberOfGreaterLessThan = @"
+    namespace AssignmentInConditionUnitTests {
+        public class Number {
+			private int n;
+            public static bool operator <(Number num1, Number num2)
+            {
+                return num1.n < num2.n;
+            }
+        }
+    }";
+		private const string WrongNumberOfRightLeftShift = @"
+    namespace AssignmentInConditionUnitTests {
+        public class Number {
+			private int n;
+            public static Number operator >>(Number num1, int i)
+            {
+                return num1.n >> i;
+            }
+            public static Number operator >>(Number num1, int i)
+            {
+                return num1.n >> i;
+            }
+        }
+    }";
 
 		/// <summary>
 		/// No diagnostics expected to show up
 		/// </summary>
 		[TestMethod]
 		[DataRow("", DisplayName = "Empty"),
+		 DataRow(CorrectNumberOfIncrementDecrement, DisplayName = nameof(CorrectNumberOfIncrementDecrement)),
 		 DataRow(CorrectNumberOfPlusMinus, DisplayName = nameof(CorrectNumberOfPlusMinus)),
-		 DataRow(CorrectNumberOfMultiplyDivide, DisplayName = nameof(CorrectNumberOfMultiplyDivide))]
+		 DataRow(CorrectNumberOfMultiplyDivide, DisplayName = nameof(CorrectNumberOfMultiplyDivide)),
+		 DataRow(CorrectNumberOfGreaterLessThan, DisplayName = nameof(CorrectNumberOfGreaterLessThan)),
+		 DataRow(CorrectNumberOfRightLeftShift, DisplayName = nameof(CorrectNumberOfRightLeftShift))]
 		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
 		{
 			VerifyCSharpDiagnostic(testCode);
@@ -82,8 +162,11 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		/// Diagnostics expected to show up
 		/// </summary>
 		[TestMethod]
-		[DataRow(WrongNumberOfPlusMinus, DiagnosticIds.AlignNumberOfPlusAndMinusOperators , DisplayName = nameof(WrongNumberOfPlusMinus)),
-		 DataRow(WrongNumberOfMultiplyDivide, DiagnosticIds.AlignNumberOfMultiplyAndDivideOperators, DisplayName = nameof(WrongNumberOfMultiplyDivide))]
+		[DataRow(WrongNumberOfIncrementDecrement, DiagnosticIds.AlignNumberOfIncrementAndDecrementOperators, DisplayName = nameof(WrongNumberOfIncrementDecrement)), 
+		 DataRow(WrongNumberOfPlusMinus, DiagnosticIds.AlignNumberOfPlusAndMinusOperators , DisplayName = nameof(WrongNumberOfPlusMinus)),
+		 DataRow(WrongNumberOfMultiplyDivide, DiagnosticIds.AlignNumberOfMultiplyAndDivideOperators, DisplayName = nameof(WrongNumberOfMultiplyDivide)),
+		DataRow(WrongNumberOfGreaterLessThan, DiagnosticIds.AlignNumberOfGreaterAndLessThanOperators, DisplayName = nameof(WrongNumberOfGreaterLessThan)),
+		DataRow(WrongNumberOfRightLeftShift, DiagnosticIds.AlignNumberOfShiftRightAndLeftOperators, DisplayName = nameof(WrongNumberOfRightLeftShift))]
 		public void WhenMismatchOfPlusMinusDiagnosticIsRaised(string testCode, DiagnosticIds diagnosticId) {
 			var expected = DiagnosticResultHelper.Create(diagnosticId);
 			VerifyCSharpDiagnostic(testCode, expected);

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AlignOperatorsCountAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AlignOperatorsCountAnalyzerTest.cs
@@ -72,6 +72,20 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
             }
         }
     }";
+		private const string CorrectNumberOfGreaterLessThanOrEqual = @"
+    namespace AssignmentInConditionUnitTests {
+        public class Number {
+			private int n;
+            public static bool operator >=(Number num1, Number num2)
+            {
+                return num1.n > num2.n;
+            }
+            public static bool operator <=(Number num1, Number num2)
+            {
+                return num1.n < num2.n;
+            }
+        }
+    }";
 		private const string CorrectNumberOfRightLeftShift = @"
     namespace AssignmentInConditionUnitTests {
         public class Number {
@@ -128,6 +142,16 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
             }
         }
     }";
+		private const string WrongNumberOfGreaterLessThanOrEqual = @"
+    namespace AssignmentInConditionUnitTests {
+        public class Number {
+			private int n;
+            public static bool operator <=(Number num1, Number num2)
+            {
+                return num1.n < num2.n;
+            }
+        }
+    }";
 		private const string WrongNumberOfRightLeftShift = @"
     namespace AssignmentInConditionUnitTests {
         public class Number {
@@ -152,6 +176,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		 DataRow(CorrectNumberOfPlusMinus, DisplayName = nameof(CorrectNumberOfPlusMinus)),
 		 DataRow(CorrectNumberOfMultiplyDivide, DisplayName = nameof(CorrectNumberOfMultiplyDivide)),
 		 DataRow(CorrectNumberOfGreaterLessThan, DisplayName = nameof(CorrectNumberOfGreaterLessThan)),
+		 DataRow(CorrectNumberOfGreaterLessThanOrEqual, DisplayName = nameof(CorrectNumberOfGreaterLessThanOrEqual)),
 		 DataRow(CorrectNumberOfRightLeftShift, DisplayName = nameof(CorrectNumberOfRightLeftShift))]
 		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
 		{
@@ -165,8 +190,9 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		[DataRow(WrongNumberOfIncrementDecrement, DiagnosticIds.AlignNumberOfIncrementAndDecrementOperators, DisplayName = nameof(WrongNumberOfIncrementDecrement)), 
 		 DataRow(WrongNumberOfPlusMinus, DiagnosticIds.AlignNumberOfPlusAndMinusOperators , DisplayName = nameof(WrongNumberOfPlusMinus)),
 		 DataRow(WrongNumberOfMultiplyDivide, DiagnosticIds.AlignNumberOfMultiplyAndDivideOperators, DisplayName = nameof(WrongNumberOfMultiplyDivide)),
-		DataRow(WrongNumberOfGreaterLessThan, DiagnosticIds.AlignNumberOfGreaterAndLessThanOperators, DisplayName = nameof(WrongNumberOfGreaterLessThan)),
-		DataRow(WrongNumberOfRightLeftShift, DiagnosticIds.AlignNumberOfShiftRightAndLeftOperators, DisplayName = nameof(WrongNumberOfRightLeftShift))]
+		 DataRow(WrongNumberOfGreaterLessThan, DiagnosticIds.AlignNumberOfGreaterAndLessThanOperators, DisplayName = nameof(WrongNumberOfGreaterLessThan)),
+		 DataRow(WrongNumberOfGreaterLessThanOrEqual, DiagnosticIds.AlignNumberOfGreaterAndLessThanOrEqualOperators, DisplayName = nameof(WrongNumberOfGreaterLessThanOrEqual)),
+		 DataRow(WrongNumberOfRightLeftShift, DiagnosticIds.AlignNumberOfShiftRightAndLeftOperators, DisplayName = nameof(WrongNumberOfRightLeftShift))]
 		public void WhenMismatchOfPlusMinusDiagnosticIsRaised(string testCode, DiagnosticIds diagnosticId) {
 			var expected = DiagnosticResultHelper.Create(diagnosticId);
 			VerifyCSharpDiagnostic(testCode, expected);


### PR DESCRIPTION
Extend the existing Analyzer to count pairs of:
- `>` and `<`
- `>=` and `<=`
- `>>` and `<<`
- `++` and `--`

The compiler will add the compound operators: `+=`, `-=` etc