### PR TITLE
feat: Introduce AvoidOverridingWithNewKeywordAnalyzer

### DIFF
--- a/Philips.CodeAnalysis.Common/DiagnosticIds.cs
+++ b/Philips.CodeAnalysis.Common/DiagnosticIds.cs
@@ -104,5 +104,6 @@ namespace Philips.CodeAnalysis.Common
 		AlignNumberOfShiftRightAndLeftOperators = 2109,
 		AlignNumberOfIncrementAndDecrementOperators = 2110,
 		ReduceCognitiveLoad = 2111,
+		AvoidOverridingWithNewKeyword = 2112,
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidOverridingWithNewKeywordAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidOverridingWithNewKeywordAnalyzer.cs
@@ -12,12 +12,12 @@ using Philips.CodeAnalysis.Common;
 namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 {
 	/// <summary>
-	/// Diagnostic for inconsistent number of operators in a class.
+	/// Diagnostic of overriding methods or properties with the new keyword.
 	/// </summary>
 	[DiagnosticAnalyzer(LanguageNames.CSharp)]
 	public class AvoidOverridingWithNewKeywordAnalyzer : DiagnosticAnalyzer
 	{
-		private const string Title = "Avoid overriding methods or porperties with the new keyword.";
+		private const string Title = "Avoid overriding methods or properties with the new keyword.";
 		private const string MessageFormat = "Avoid overriding {0} with the new keyword.";
 		private const string Description = "Overriding with the new keyword gives unexpected behavior for the callers of the overridden method or property.";
 		private const string Category = Categories.Maintainability;
@@ -75,7 +75,6 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 			var method = (MethodDeclarationSyntax)context.Node;
 			
-
 			if (method.Modifiers.Any(SyntaxKind.NewKeyword))
 			{
 				var location = method.Identifier.GetLocation();

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidOverridingWithNewKeywordAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidOverridingWithNewKeywordAnalyzer.cs
@@ -1,0 +1,86 @@
+﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
+{
+	/// <summary>
+	/// Diagnostic for inconsistent number of operators in a class.
+	/// </summary>
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class AvoidOverridingWithNewKeywordAnalyzer : DiagnosticAnalyzer
+	{
+		private const string Title = "Avoid overriding methods or porperties with the new keyword.";
+		private const string MessageFormat = "Avoid overriding {0} with the new keyword.";
+		private const string Description = "Overriding with the new keyword gives unexpected behavior for the callers of the overridden method or property.";
+		private const string Category = Categories.Maintainability;
+
+		private static readonly DiagnosticDescriptor Rule =
+			new(
+				Helper.ToDiagnosticId(DiagnosticIds.AvoidOverridingWithNewKeyword),
+				Title,
+				MessageFormat,
+				Category,
+				DiagnosticSeverity.Error,
+				isEnabledByDefault: true,
+				description: Description
+			);
+
+		/// <summary>
+		/// <inheritdoc cref="DiagnosticAnalyzer"/>
+		/// </summary>
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		/// <summary>
+		/// <inheritdoc cref="DiagnosticAnalyzer"/>
+		/// </summary>
+		public override void Initialize(AnalysisContext context)
+		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.EnableConcurrentExecution();
+			context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.MethodDeclaration);
+			context.RegisterSyntaxNodeAction(AnalyzeProperty, SyntaxKind.PropertyDeclaration);
+		}
+
+		private void AnalyzeProperty(SyntaxNodeAnalysisContext context)
+		{
+			GeneratedCodeDetector generatedCodeDetector = new();
+			if(generatedCodeDetector.IsGeneratedCode(context))
+			{
+				return;
+			}
+
+			var property = (PropertyDeclarationSyntax)context.Node;
+
+			if (property.Modifiers.Any(SyntaxKind.NewKeyword))
+			{
+				var location = property.Identifier.GetLocation();
+				context.ReportDiagnostic(Diagnostic.Create(Rule, location, property.Identifier.Text));
+			}
+		}
+		private void AnalyzeMethod(SyntaxNodeAnalysisContext context)
+		{
+			GeneratedCodeDetector generatedCodeDetector = new();
+			if (generatedCodeDetector.IsGeneratedCode(context))
+			{
+				return;
+			}
+
+			var method = (MethodDeclarationSyntax)context.Node;
+			
+
+			if (method.Modifiers.Any(SyntaxKind.NewKeyword))
+			{
+				var location = method.Identifier.GetLocation();
+				context.ReportDiagnostic(Diagnostic.Create(Rule, location, method.Identifier.Text));
+			}
+		}
+	}
+}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -90,6 +90,7 @@
       * Introduce PH2109: Align number of &gt;&gt; and &lt;&lt; operators.
       * Introduce PH2110: Align number of ++ and -- operators.
       * Introduce PH2111: Reduce Cognitive Load
+      * Introduce PH2112: Avoid overriding with new keyword.
     </PackageReleaseNotes>
 	  <Copyright>© 2019-2023 Koninklijke Philips N.V.</Copyright>
 	  <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -62,3 +62,4 @@
 | PH2109  | Align number of >> and << operators          | Align the number of operators >> and <<, as these are often used in combination with each other. |
 | PH2110  | Align number of ++ and -- operators          | Align the number of operators ++ and --, as these are often used in combination with each other. |
 | PH2111  | Reduce Cognitive Load                        | Reduce the number of nested blocks, logical cases, and negations in this method. |
+| PH2112  | Avoid overridde with new keyword             | Overriding with the new keyword gives unexpected behavior for the callers of the overridden method or property. |

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidOverrideWithNewKeywordAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidOverrideWithNewKeywordAnalyzerTest.cs
@@ -1,0 +1,108 @@
+﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Philips.CodeAnalysis.Common;
+using Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability;
+
+namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
+{
+	[TestClass]
+	public class AvoidOverridingWithNewKeywordAnalyzerTest : DiagnosticVerifier
+	{
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		{
+			return new AvoidOverridingWithNewKeywordAnalyzer();
+		}
+
+		
+		private const string Correct = @"
+namespace MultiLineConditionUnitTests
+{
+    public class Other
+    {
+        public virtual void VirtualMethod()
+        {
+        }
+    }
+    public class Program : Other
+    {
+        public override void VirtualMethod() 
+        {
+        }
+    }
+}
+";
+
+		private const string WrongMethod = @"
+namespace MultiLineConditionUnitTests
+{
+    public class Other
+    {
+        public void VirtualMethod()
+        {
+        }
+    }
+    public class Program : Other
+    {
+        public new void VirtualMethod() 
+        {
+        }
+    }
+}
+";
+
+		private const string WrongProperty = @"
+namespace MultiLineConditionUnitTests
+{
+    public class Other
+    {
+        public int VirtualProperty
+        {
+            get {
+                return 0;
+            }
+        }
+    }
+    public class Program : Other
+    {
+        public new int VirtualProperty 
+        {
+            get {
+                return 1;
+            }
+        }
+    }
+}
+";
+
+		[DataTestMethod]
+		[DataRow(Correct, DisplayName = nameof(Correct))]
+		public void OverrideVirtualDoesNotTriggersDiagnostics(string input)
+		{
+
+			VerifyCSharpDiagnostic(input);
+		}
+
+		[DataTestMethod]
+		[DataRow(WrongMethod, DisplayName = nameof(WrongMethod)), 
+		 DataRow(WrongProperty, DisplayName = nameof(WrongProperty))]
+		public void OverrideWithNewKeywordTriggersDiagnostics(string input)
+		{
+			var expected = DiagnosticResultHelper.Create(DiagnosticIds.AvoidOverridingWithNewKeyword,
+				new Regex("Avoid overriding Virtual.* with the new keyword."));
+			VerifyCSharpDiagnostic(input, expected);
+		}
+
+		/// <summary>
+		/// No diagnostics expected to show up 
+		/// </summary>
+		[TestMethod]
+		[DataRow(WrongMethod, "Dummy.Designer", DisplayName = "OutOfScopeSourceFile")]
+		public void WhenSourceFileIsOutOfScopeNoDiagnosticIsTriggered(string testCode, string filePath)
+		{
+			VerifyCSharpDiagnostic(testCode, filePath);
+		}
+	}
+}


### PR DESCRIPTION
Overriding with the new keyword gives unexpected behavior for the callers of the overridden method or property. It is a code smell.

This checks rule [7@404](https://tics.tiobe.com/viewerCS/index.php?ID=2318&CSTD=Rule) of the Philips C# Coding Standard