### PR TITLE
feat: Avoid ArrayList Analyzer

### DIFF
--- a/Philips.CodeAnalysis.Common/DiagnosticIds.cs
+++ b/Philips.CodeAnalysis.Common/DiagnosticIds.cs
@@ -105,5 +105,6 @@ namespace Philips.CodeAnalysis.Common
 		AlignNumberOfIncrementAndDecrementOperators = 2110,
 		ReduceCognitiveLoad = 2111,
 		AvoidOverridingWithNewKeyword = 2112,
+		AvoidArrayList = 2116,
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidArrayListAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidArrayListAnalyzer.cs
@@ -1,0 +1,49 @@
+﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Xml.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class AvoidArrayListAnalyzer : DiagnosticAnalyzer
+	{
+		private const string Title = @"Don't use ArrayList, use List<T> instead";
+		private const string MessageFormat = @"Don't use ArrayList for variable {0}, use List<T> instead";
+		private const string Description = @"Usage of Arraylist is discouraged by Microsoft for performance reasons, use List<T> instead.";
+		private const string Category = Categories.Maintainability;
+
+		private static readonly DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidArrayList),
+			Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true,
+			description: Description);
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		private static readonly string ArrayListTypeName = "System.Collections.ArrayList";
+
+		public override void Initialize(AnalysisContext context)
+		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.EnableConcurrentExecution();
+			context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.VariableDeclaration);
+		}
+
+		private static void Analyze(SyntaxNodeAnalysisContext context)
+		{
+			var variable = (VariableDeclarationSyntax)context.Node;
+			var typeSymbol = context.SemanticModel.GetSymbolInfo(variable.Type).Symbol as INamedTypeSymbol;
+			if (typeSymbol?.ToString() == ArrayListTypeName)
+			{
+				var variableName = variable.Variables.First().Identifier.Text;
+				context.ReportDiagnostic(Diagnostic.Create(Rule, variable.Type.GetLocation(), variableName));
+			}
+		}
+	}
+}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidArrayListCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidArrayListCodeFixProvider.cs
@@ -18,7 +18,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AvoidArrayListAnalyzer)), Shared]
 	public class AvoidArrayListCodeFixProvider : CodeFixProvider
 	{
-		private const string Title = "Replaces ArrayList with List<T>";
+		private const string Title = "Replace ArrayList with List<T>";
 
 		public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticIds.AvoidArrayList));
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidArrayListCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidArrayListCodeFixProvider.cs
@@ -1,9 +1,8 @@
-﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
+﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
 
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -19,7 +18,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AvoidArrayListAnalyzer)), Shared]
 	public class AvoidArrayListCodeFixProvider : CodeFixProvider
 	{
-		private const string Title = "Call extension methods as if they were instance methods";
+		private const string Title = "Replaces ArrayList with List<T>";
 
 		public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticIds.AvoidArrayList));
 
@@ -48,7 +47,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		{
 			SyntaxNode root = await document.GetSyntaxRootAsync();
 
-			var variable = token.Parent.Parent as VariableDeclarationSyntax;
+			var variable = token.Parent?.Parent as VariableDeclarationSyntax;
 			var type = variable?.Type;
 
 			if (root != null && type != null)

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidArrayListCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidArrayListCodeFixProvider.cs
@@ -1,0 +1,71 @@
+﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Text;
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
+{
+	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AvoidArrayListAnalyzer)), Shared]
+	public class AvoidArrayListCodeFixProvider : CodeFixProvider
+	{
+		private const string Title = "Call extension methods as if they were instance methods";
+
+		public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticIds.AvoidArrayList));
+
+		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+		{
+			var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+			Diagnostic diagnostic = context.Diagnostics.First();
+			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
+
+			if (root != null)
+			{
+				SyntaxToken token = root.FindToken(diagnosticSpan.Start);
+
+				// Register a code action that will invoke the fix.
+				context.RegisterCodeFix(
+					CodeAction.Create(
+						title: Title,
+						createChangedDocument: c => SwapType(context.Document, token),
+						equivalenceKey: Title),
+					diagnostic);
+			}
+		}
+
+		private async Task<Document> SwapType(Document document, SyntaxToken token)
+		{
+			SyntaxNode root = await document.GetSyntaxRootAsync();
+
+			var variable = token.Parent.Parent as VariableDeclarationSyntax;
+			var type = variable?.Type;
+
+			if (root != null && type != null)
+			{
+				var list = SyntaxFactory.ParseTypeName("System.Collections.Generic.List<int>");
+				
+				root = root.ReplaceNode(type, list.WithTriviaFrom(type).WithAdditionalAnnotations(Formatter.Annotation));
+
+				return document.WithSyntaxRoot(root);
+			}
+
+			return document;
+		}
+
+		public sealed override FixAllProvider GetFixAllProvider()
+		{
+			return WellKnownFixAllProviders.BatchFixer;
+		}
+	}
+}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -91,6 +91,7 @@
       * Introduce PH2110: Align number of ++ and -- operators.
       * Introduce PH2111: Reduce Cognitive Load
       * Introduce PH2112: Avoid overriding with new keyword.
+      * Introduce PH2116: Avoid ArrayList, use List&lt;T&gt; instead.
     </PackageReleaseNotes>
 	  <Copyright>© 2019-2023 Koninklijke Philips N.V.</Copyright>
 	  <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -63,3 +63,4 @@
 | PH2110  | Align number of ++ and -- operators          | Align the number of operators ++ and --, as these are often used in combination with each other. |
 | PH2111  | Reduce Cognitive Load                        | Reduce the number of nested blocks, logical cases, and negations in this method. |
 | PH2112  | Avoid overridde with new keyword             | Overriding with the new keyword gives unexpected behavior for the callers of the overridden method or property. |
+| PH2116  | Avoid ArrayList                              | Usage of Arraylist is discouraged by Microsoft for performance reasons, use List<T> instead. |

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidArrayListAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidArrayListAnalyzerTest.cs
@@ -1,0 +1,124 @@
+﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Philips.CodeAnalysis.Common;
+using Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability;
+
+namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
+{
+	/// <summary>
+	/// Test class for <see cref="AvoidArrayListAnalyzer"/>.
+	/// </summary>
+	[TestClass]
+	public class AvoidArrayListAnalyzerTest : CodeFixVerifier
+	{
+		private const string CorrectField = @"
+using System.Collections.Generic;
+namespace AvoidArrayListTests {
+    public class Number {
+        private List<int> nn;
+    }
+}";
+
+		private const string CorrectLocal = @"
+using System.Collections.Generic;
+namespace AvoidArrayListTests {
+    public class Number {
+        public Number() {
+            List<int> nn;
+        }
+    }
+}";
+
+		private const string WrongField = @"
+using System.Collections;
+namespace AvoidArrayListTests {
+    public class Number {
+		private ArrayList nn;
+    }
+}";
+		private const string FixedField = @"
+using System.Collections;
+namespace AvoidArrayListTests {
+    public class Number {
+		private System.Collections.Generic.List<int> nn;
+    }
+}";
+
+		private const string WrongFieldFullNamespace = @"
+namespace AvoidArrayListTests {
+    public class Number {
+		private System.Collections.ArrayList nn;
+    }
+}";
+
+		private const string WrongLocal = @"
+using System.Collections;
+namespace AvoidArrayListTests {
+    public class Number {
+        public Number() {
+            ArrayList nn;
+        }
+    }
+}";
+		private const string FixedLocal = @"
+using System.Collections;
+namespace AvoidArrayListTests {
+    public class Number {
+        public Number() {
+            System.Collections.Generic.List<int> nn;
+        }
+    }
+}";
+
+		/// <summary>
+		/// No diagnostics expected to show up
+		/// </summary>
+		[TestMethod]
+		[DataRow("", DisplayName = "Empty"),
+		 DataRow(CorrectField, DisplayName = nameof(CorrectField)),
+		 DataRow(CorrectLocal, DisplayName = nameof(CorrectLocal))]
+		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
+		{
+			VerifyCSharpDiagnostic(testCode);
+		}
+
+		/// <summary>
+		/// Diagnostics expected to show up
+		/// </summary>
+		[TestMethod]
+		[DataRow(WrongField, FixedField, DisplayName = nameof(WrongField)), 
+		 DataRow(WrongFieldFullNamespace, null, DisplayName = nameof(WrongFieldFullNamespace)),
+		 DataRow(WrongLocal, FixedLocal, DisplayName = nameof(WrongLocal))]
+		public void WhenMismatchOfPlusMinusDiagnosticIsRaised(string testCode, string fixedCode) {
+			var expected = DiagnosticResultHelper.Create(DiagnosticIds.AvoidArrayList);
+			VerifyCSharpDiagnostic(testCode, expected);
+			if (fixedCode != null)
+			{
+				VerifyCSharpFix(testCode, fixedCode, allowNewCompilerDiagnostics:true);
+			}
+		}
+
+		/// <summary>
+		/// No diagnostics expected to show up 
+		/// </summary>
+		[TestMethod]
+		[DataRow("File.g", DisplayName = "OutOfScopeSourceFile")]
+		public void WhenSourceFileIsOutOfScopeNoDiagnosticIsTriggered(string filePath)
+		{
+			VerifyCSharpDiagnostic(WrongLocal, filePath);
+		}
+
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() {
+			return new AvoidArrayListAnalyzer();
+		}
+
+		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		{
+			return new AvoidArrayListCodeFixProvider();
+		}
+	}
+}


### PR DESCRIPTION
Usage of Arraylist is discouraged by Microsoft for performance reasons, use List<T> instead.
Includes a crude `CodeFixProvider`

This checks rule [12@106](https://tics.tiobe.com/viewerCS/index.php?ID=2118&CSTD=Rule) of the Philips C# Coding Standard