### PR TITLE
feat: Introduce 2 rules on substitution numbers

### DIFF
--- a/Philips.CodeAnalysis.Common/DiagnosticIds.cs
+++ b/Philips.CodeAnalysis.Common/DiagnosticIds.cs
@@ -108,5 +108,7 @@ namespace Philips.CodeAnalysis.Common
 		MergeIfStatements = 2113,
 		AvoidEmptyStatement = 2114,
 		AvoidArrayList = 2116,
+		AlignNumberOfArgumentsStringFormats = 2117,
+		SubstitutionsShouldBeAscending = 2118,
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/NoNestedStringFormatsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/NoNestedStringFormatsAnalyzer.cs
@@ -33,8 +33,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 		private const string Category = Categories.Maintainability;
 
-		private static readonly Regex _formatRegex = new(@"^\{\d+\}$", RegexOptions.Compiled);
-		private static readonly Regex _substitutionRegex = new(@"\{(\d+)\}");
+		private static readonly Regex _formatRegex = new(@"^\{\d+\}$", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+		private static readonly Regex _substitutionRegex = new(@"\{(\d+)\}", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 
 		private static readonly DiagnosticDescriptor NestedRule = new(Helper.ToDiagnosticId(DiagnosticIds.NoNestedStringFormats), NestedStringFormatTitle, NestedStringFormatMessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: NestedStringFormatDescription);
 		private static readonly DiagnosticDescriptor UnnecessaryRule = new(Helper.ToDiagnosticId(DiagnosticIds.NoUnnecessaryStringFormats), UnnecessaryStringFormatTitle, UnnecessaryStringFormatMessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: UnnecessaryStringFormatDescription);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -94,7 +94,9 @@
       * Introduce PH2113: Merge If Statements
       * Introduce PH2114: Avoid empty statement.
       * Introduce PH2116: Avoid ArrayList, use List&lt;T&gt; instead.
-    </PackageReleaseNotes>
+      * Introduce PH2117: Same number of substitutions.
+      * Introduce PH2118: Don't skip a substitution numbers.
+	</PackageReleaseNotes>
 	  <Copyright>© 2019-2023 Koninklijke Philips N.V.</Copyright>
 	  <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -66,3 +66,5 @@
 | PH2113  | Merge If Statements                          | Nested If statements lacking else clauses and containing the same body can be safely merged to reduce cognitive load |
 | PH2114  | Avoid empty statement                        | Avoid empty statements. |
 | PH2116  | Avoid ArrayList                              | Usage of Arraylist is discouraged by Microsoft for performance reasons, use List<T> instead. |
+| PH2117  | Same number of substitutions                 | Align the number substitutions ("{0}") with the number of arguments of string.Format. |
+| PH2118  | Don't skip a substitution numbers            | Substitution numbers in string.Format should not skip a number. |


### PR DESCRIPTION
Inspired by rule [10@406](https://tics.tiobe.com/viewerCS/?ID=133&CSTD=Rule) of the Philips C# Coding Standard.

The number of substitutions should align with the number of arguments. 
And substitution number must not skip a number, as this leaves a argument unused.

For performance reasons I have added these to the `NoNestedStringFormatAnalyzer`. Let me know if I should now rename this Analyzer.