### PR TITLE
feat: enhance PH2006- support folder in namespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -135,7 +135,8 @@ dotnet_diagnostic.IDE0250.severity = error
 dotnet_diagnostic.IDE1005.severity = error
 dotnet_diagnostic.IDE1006.severity = error
 
+dotnet_code_quality.PH2006.folder_in_namespace = true
+dotnet_code_quality.PH2028.company_name = Koninklijke Philips N.V.
 dotnet_code_quality.PH2075.assembly_version = 1.0.3.0
 dotnet_code_quality.PH2079.namespace_prefix = Philips.CodeAnalysis
-dotnet_code_quality.PH2028.company_name = Koninklijke Philips N.V.
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/NamespaceMatchAssemblyAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/NamespaceMatchAssemblyAnalyzer.cs
@@ -16,7 +16,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 	{
 		private const string Title = @"Namespace matches File Path";
 		private const string MessageFormat = @"Namespace, File Path, Assembly, and Project must all match";
-		private const string Description = @"In order to prevent pollution of namespaces, and maintainability of namespaces, the File Path, Assembly, Project, and Namespace must all match";
+		private const string Description = @"In order to prevent pollution of namespaces, and maintainability of namespaces, the File Path, Assembly, Project, and Namespace must all match. To include subfolders in the namespace, add 'dotnet_code_quality.PH2006.folder_in_namespace = true' to the .editorconfig.";
 		private const string Category = Categories.Naming;
 
 		private static readonly DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.NamespaceMatchAssembly), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/NamespaceMatchAssemblyAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/NamespaceMatchAssemblyAnalyzer.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -20,16 +21,31 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 
 		private static readonly DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.NamespaceMatchAssembly), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
+		private readonly GeneratedCodeAnalysisFlags _generatedCodeFlags;
+		private AdditionalFilesHelper _additionalFilesHelper;
+		private bool _folderInNamespace;
+		private bool _configInitialized;
+
+		public NamespaceMatchAssemblyAnalyzer()
+			: this(GeneratedCodeAnalysisFlags.None, null)
+		{ }
+
+		public NamespaceMatchAssemblyAnalyzer(GeneratedCodeAnalysisFlags generatedCodeFlags, AdditionalFilesHelper additionalFilesHelper)
+		{
+			_generatedCodeFlags = generatedCodeFlags;
+			_additionalFilesHelper = additionalFilesHelper;
+		}
+
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 		public override void Initialize(AnalysisContext context)
 		{
-			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.ConfigureGeneratedCodeAnalysis(_generatedCodeFlags);
 			context.EnableConcurrentExecution();
 			context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.NamespaceDeclaration);
 		}
 
-		private static void Analyze(SyntaxNodeAnalysisContext context)
+		private void Analyze(SyntaxNodeAnalysisContext context)
 		{
 			GeneratedCodeDetector generatedCodeDetector = new();
 			if (generatedCodeDetector.IsGeneratedCode(context))
@@ -41,10 +57,23 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 			string myNamespace = namespaceDeclaration.Name.ToString();
 			string myFilePath = context.Node.SyntaxTree.FilePath;
 
-			// Check file path
-			if (IsFilePartOfPath(myNamespace, myFilePath))
+			InitializeConfiguration(context);
+
+			if (_folderInNamespace)
 			{
-				return;
+				// Does the namespace exactly match the trailing folders?
+				if (DoesFilePathEndWithNamespace(myNamespace, myFilePath))
+				{
+					return;
+				}
+			}
+			else
+			{
+				// Does the namespace exactly match one of the folders in the path?
+				if (IsNamespacePartOfPath(myNamespace, myFilePath))
+				{
+					return;
+				}
 			}
 
 			// TODO: Check assembly name, see issue #174
@@ -53,19 +82,35 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 			context.ReportDiagnostic(diagnostic);
 		}
 
-		private static bool IsFilePartOfPath(string ns, string path)
+		private bool IsNamespacePartOfPath(string namespact, string path)
 		{
-			string[] nodes = path.Split('/', '\\');
-
+			string[] nodes = path.Split(Path.DirectorySeparatorChar);
 			for (int i = nodes.Length - 2; i > 0; i--)  // Exclude file.cs (i.e., the end) and the drive (i.e., the start).  Start from back to succeed quickly.
 			{
-				if (string.Equals(nodes[i], ns, StringComparison.OrdinalIgnoreCase))
+				if (string.Equals(nodes[i], namespact, StringComparison.OrdinalIgnoreCase))
 				{
 					return true;
 				}
 			}
-
 			return false;
+		}
+
+		private bool DoesFilePathEndWithNamespace(string ns, string path)
+		{
+			string folder = Path.GetDirectoryName(path);
+			string allowedNamespace = folder.Replace(Path.DirectorySeparatorChar, '.');
+			return allowedNamespace.EndsWith(ns, StringComparison.OrdinalIgnoreCase);
+		}
+
+		private void InitializeConfiguration(SyntaxNodeAnalysisContext context)
+		{
+			if (!_configInitialized)
+			{
+				_additionalFilesHelper ??= new AdditionalFilesHelper(context.Options, context.Compilation);
+				string folderInNamespace = _additionalFilesHelper.GetValueFromEditorConfig(Rule.Id, @"folder_in_namespace");
+				_ = bool.TryParse(folderInNamespace, out _folderInNamespace);
+				_configInitialized = true;
+			}
 		}
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/NamespaceMatchAssemblyAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/NamespaceMatchAssemblyAnalyzer.cs
@@ -82,12 +82,12 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 			context.ReportDiagnostic(diagnostic);
 		}
 
-		private bool IsNamespacePartOfPath(string namespact, string path)
+		private bool IsNamespacePartOfPath(string ns, string path)
 		{
 			string[] nodes = path.Split(Path.DirectorySeparatorChar);
 			for (int i = nodes.Length - 2; i > 0; i--)  // Exclude file.cs (i.e., the end) and the drive (i.e., the start).  Start from back to succeed quickly.
 			{
-				if (string.Equals(nodes[i], namespact, StringComparison.OrdinalIgnoreCase))
+				if (string.Equals(nodes[i], ns, StringComparison.OrdinalIgnoreCase))
 				{
 					return true;
 				}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/PassByRefAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/PassByRefAnalyzer.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Philips.CodeAnalysis.Common;
 
-namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
+namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 {
 	[DiagnosticAnalyzer(LanguageNames.CSharp)]
 	public class PassByRefAnalyzer : DiagnosticAnalyzer

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -97,6 +97,7 @@
       * Introduce PH2116: Avoid ArrayList, use List&lt;T&gt; instead.
       * Introduce PH2117: Avoid unnecessary Where.
       * Introduce PH2118: Avoid magic numbers.
+      * PH2006 now supports folders in namespace
     </PackageReleaseNotes>
 	  <Copyright>© 2019-2023 Koninklijke Philips N.V.</Copyright>
 	  <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -1,7 +1,7 @@
 | Rule ID | Title                                        | Description                                                  |
 | ------- | -------------------------------------------- | ------------------------------------------------------------ |
 | PH2001  | Avoid empty XML Summary comments             | Summary XML comments for classes, methods, etc. must be non-empty or non-existent. |
-| PH2006  | Match namespace, path, assembly, and project | The File Path, Assembly, Project, and Namespace must all match |
+| PH2006  | Match namespace, path, assembly, and project | The File Path, Assembly, Project, and Namespace must all match. To include folders in the namespace, add `dotnet_code_quality.PH2006.folder_in_namespace = true` to the .editorconfig.|
 | PH2020  | Avoid Thread.Sleep                           | This method is a code smell.                                 |
 | PH2021  | Avoid inline new                             | Do not inline the constructor call.  Instead, create a local variable or a field for the temporary instance. |
 | PH2026  | Avoid SuppressMessage attribute              | SuppressMessage results in violations of codified coding guidelines.|

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/PassByRefAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/PassByRefAnalyzerTest.cs
@@ -4,7 +4,7 @@ using System;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Philips.CodeAnalysis.Common;
-using Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability;
+using Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming;
 
 namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 {

--- a/Philips.CodeAnalysis.Test/Maintainability/Naming/NamespaceMatchAssemblyAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Naming/NamespaceMatchAssemblyAnalyzerTest.cs
@@ -1,22 +1,22 @@
 ﻿// © 2022 Koninklijke Philips N.V. See License.md in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
+using System.IO;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using Philips.CodeAnalysis.Common;
 using Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming;
 
 namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 {
 	[TestClass]
-	public class NamespaceMatchAssemblyAnalyzerTest : DiagnosticVerifier
+	public class NamespaceMatchAssemblyAnalyzerUseFolderTest : DiagnosticVerifier
 	{
-
-		#region Non-Public Data Members
-
-		private const string ClassString = @"
+		public const string ClassString = @"
 			using System;
 			using System.Globalization;
 			namespace {0}
@@ -30,31 +30,28 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 			}}
 			";
 
-		#endregion
-
-		#region Non-Public Properties/Methods
-		private DiagnosticResultLocation GetBaseDiagnosticLocation(string path, int rowOffset = 0, int columnOffset = 0)
+		public static DiagnosticResultLocation GetBaseDiagnosticLocation(string path, int rowOffset = 0, int columnOffset = 0)
 		{
 			return new DiagnosticResultLocation(path + ".cs", 4 + rowOffset, 14 + columnOffset);
 		}
 
 		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
 		{
-			return new NamespaceMatchAssemblyAnalyzer();
+			Mock<AdditionalFilesHelper> _mockAdditionalFilesHelper = new(new AnalyzerOptions(ImmutableArray.Create<AdditionalText>()), null);
+			_mockAdditionalFilesHelper.Setup(c => c.GetValueFromEditorConfig(It.IsAny<string>(), It.IsAny<string>())).Returns("true");
+			return new NamespaceMatchAssemblyAnalyzer(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics, _mockAdditionalFilesHelper.Object);
 		}
 
-		#endregion
-
-
-		#region Test Methods
 		[DataTestMethod]
-		[DataRow("Philips.Test", "C:\\development\\Philips.Production\\code\\MyTest")]
-		[DataRow("Philips.CodeAnalysis.Test", "C:\\Philips.CodeAnalysis.Production\\MyAnalyzer")]
-		[DataRow("Philips.CodeAnalysis.Test", "C:\\Philips.CodeAnalysis.TestFramework\\MyHelper")]
-		public void ReportIncorrectNamespaceMatch(string prefix, string path)
+		[DataRow("Philips.Test", "C:\\development\\Philips.Production\\code\\MyTest.cs")]
+		[DataRow("Philips.CodeAnalysis.Test", "C:\\Philips.CodeAnalysis.Production\\MyAnalyzer.cs")]
+		[DataRow("Philips.CodeAnalysis.Test", "C:\\Philips.CodeAnalysis.TestFramework\\MyHelper.cs")]
+		[DataRow("Philips.Test", "C:\\development\\Philips.Test\\code\\MyTest.cs", DisplayName="Namespace Match, Folder Does not")]
+		[DataRow("Philips.CodeAnalysis.Test", "C:\\Philips.CodeAnalysis.Test\\src\\MyTest.cs", DisplayName = "Namespace Match, Folder Does not")]
+		public void ReportIncorrectNamespaceMatch(string ns, string path)
 		{
-
-			string code = string.Format(ClassString, prefix);
+			path = path.Replace('\\', Path.DirectorySeparatorChar);
+			string code = string.Format(ClassString, ns);
 			DiagnosticResult expected = new()
 			{
 				Id = Helper.ToDiagnosticId(DiagnosticIds.NamespaceMatchAssembly),
@@ -70,14 +67,61 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 		}
 
 		[DataTestMethod]
-		[DataRow("Philips.Test", "C:\\development\\Philips.Test\\code\\MyTest")]
-		[DataRow("Philips.CodeAnalysis.Test", "C:\\Philips.CodeAnalysis.Test\\MyTest")]
-		public void DoNotReportANamespaceMatchError(string ns, string path)
+		[DataRow("Philips.CodeAnalysis.Test.Maintainability", "C:\\Philips.CodeAnalysis.Test\\Maintainability\\blah.cs", DisplayName = "Folder Match Included 1")]
+		[DataRow("Philips.CodeAnalysis.Test.Maintainability", "C:\\repos\\Philips.CodeAnalysis.Test\\Maintainability\\blah.cs", DisplayName = "Folder Match Included 2")]
+		[DataRow("Philips.CodeAnalysis.Test.Maintainability.Foo", "C:\\repos\\Philips.CodeAnalysis.Test\\Maintainability\\Foo\\blah.cs", DisplayName = "Folder Match Included 2")]
+		public void DoNotReportANamespaceSupersetMatch(string ns, string path)
 		{
+			path = path.Replace('\\', Path.DirectorySeparatorChar);
 			string code = string.Format(ClassString, ns);
 			VerifyCSharpDiagnostic(code, path, Array.Empty<DiagnosticResult>());
 		}
-
-		#endregion
 	}
+
+	[TestClass]
+	public class NamespaceMatchAssemblyAnalyzerNoFolderTest : DiagnosticVerifier
+	{
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		{
+			Mock<AdditionalFilesHelper> _mockAdditionalFilesHelper = new(new AnalyzerOptions(ImmutableArray.Create<AdditionalText>()), null);
+			_mockAdditionalFilesHelper.Setup(c => c.GetValueFromEditorConfig(It.IsAny<string>(), It.IsAny<string>())).Returns("false");
+			return new NamespaceMatchAssemblyAnalyzer(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics, _mockAdditionalFilesHelper.Object);
+		}
+
+		[DataTestMethod]
+		[DataRow("Philips.Test", "C:\\development\\Philips.Production\\code\\MyTest.cs")]
+		[DataRow("Philips.CodeAnalysis.Test", "C:\\Philips.CodeAnalysis.Production\\MyAnalyzer.cs")]
+		[DataRow("Philips.CodeAnalysis.Test", "C:\\Philips.CodeAnalysis.TestFramework\\MyHelper.cs")]
+		[DataRow("Philips.CodeAnalysis.Test.Maintainability", "C:\\Philips.CodeAnalysis.Test\\Maintainability\\blah.cs", DisplayName = "Folder Match Included 1")]
+		[DataRow("Philips.CodeAnalysis.Test.Maintainability", "C:\\repos\\Philips.CodeAnalysis.Test\\Maintainability\\blah.cs", DisplayName = "Folder Match Included 2")]
+		[DataRow("Philips.CodeAnalysis.Test.Maintainability.Foo", "C:\\repos\\Philips.CodeAnalysis.Test\\Maintainability\\Foo\\blah.cs", DisplayName = "Folder Match Included 2")]
+		public void ReportIncorrectNamespaceMatch(string ns, string path)
+		{
+			path = path.Replace('\\', Path.DirectorySeparatorChar);
+			string code = string.Format(NamespaceMatchAssemblyAnalyzerUseFolderTest.ClassString, ns);
+			DiagnosticResult expected = new()
+			{
+				Id = Helper.ToDiagnosticId(DiagnosticIds.NamespaceMatchAssembly),
+				Message = new Regex(".+ "),
+				Severity = DiagnosticSeverity.Error,
+				Locations = new[]
+				{
+					NamespaceMatchAssemblyAnalyzerUseFolderTest.GetBaseDiagnosticLocation(path, 0,0)
+				}
+			};
+
+			VerifyCSharpDiagnostic(code, path, expected);
+		}
+
+		[DataTestMethod]
+		[DataRow("Philips.Test", "C:\\development\\Philips.Test\\code\\MyTest.cs", DisplayName = "Namespace Match, Folder Does not")]
+		[DataRow("Philips.CodeAnalysis.Test", "C:\\Philips.CodeAnalysis.Test\\src\\MyTest.cs", DisplayName = "Namespace Match, Folder Does not")]
+		public void DoNotReportANamespaceSupersetMatch(string ns, string path)
+		{
+			path = path.Replace('\\', Path.DirectorySeparatorChar);
+			string code = string.Format(NamespaceMatchAssemblyAnalyzerUseFolderTest.ClassString, ns);
+			VerifyCSharpDiagnostic(code, path, Array.Empty<DiagnosticResult>());
+		}
+	}
+
 }


### PR DESCRIPTION
Add a new option to .editorconfig for PH2006 called `folder_in_namespace`. When true, the files' sub-folders in the file hierarchy must be included in the namespace.

For example, when true, this is allowed:
`namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability`
and this is not:
`namespace Philips.CodeAnalysis.MaintainabilityAnalyzers`

For backwards compatibility, default is false. In this mode, regardless of subfolder's, this is allowed:
`namespace Philips.CodeAnalysis.MaintainabilityAnalyzers`
and this is not:
`namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability`
