### PR TITLE
fix: Allow magic numbers in enumerations

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidMagicNumbersAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidMagicNumbersAnalyzer.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 	{
 		private const string Title = @"Avoid inline magic numbers";
 		private const string MessageFormat = @"Avoid inline magic numbers";
-		private const string Description = @"Avoid inline magic number, define them as constant instead.";
+		private const string Description = @"Avoid inline magic number, define them as constant or include in an enumeration instead.";
 		private const string Category = Categories.Maintainability;
 
 		private static readonly DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidMagicNumbers),
@@ -49,6 +49,12 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			}
 
 			if (IsAllowedNumber(literal.Token.Text))
+			{
+				return;
+			}
+
+			// Magic number are allowed in enumerations, as they give meaning to the number.
+			if (literal.Ancestors().OfType<EnumMemberDeclarationSyntax>().Any())
 			{
 				return;
 			}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -68,4 +68,4 @@
 | PH2115  | Every Lambda expression on separate line     | Avoid putting multiple lambda statements on a single line for readability. |
 | PH2116  | Avoid ArrayList                              | Usage of Arraylist is discouraged by Microsoft for performance reasons, use List<T> instead. |
 | PH2117  | Avoid Unnecessary Where()                    | Move the predicate of the Where clause into the Any(), Count(), First(), Last(), or Single() clause |
-| PH2118  | Avoid inline magic numbers                   | Avoid inline magic number, define them as constant instead. |
+| PH2118  | Avoid inline magic numbers                   | Avoid inline magic number, define them as constant or include in an enumeration instead. |

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidMagicNumbersAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidMagicNumbersAnalyzerTest.cs
@@ -91,7 +91,15 @@ namespace DontUseMagicNumbersTests {
     }
 }";
 
-		private const string WrongInstanceField = @"
+		private const string CorrectInEnum = @"
+namespace DontUseMagicNumbersTests {
+    public enum NumberEnmeration {
+        None = 0,
+        Magic = 3
+    }
+}";
+
+        private const string WrongInstanceField = @"
 namespace DontUseMagicNumbersTests {
     public class Number {
         private int Magic = 5;
@@ -138,7 +146,8 @@ namespace DontUseMagicNumbersTests {
 		 DataRow(CorrectConst, DisplayName = nameof(CorrectConst)),
 		 DataRow(CorrectPowerOf10, DisplayName = nameof(CorrectPowerOf10)),
 		 DataRow(CorrectPowerOf2, DisplayName = nameof(CorrectPowerOf2)),
-		 DataRow(CorrectAngle, DisplayName = nameof(CorrectAngle))]
+		 DataRow(CorrectAngle, DisplayName = nameof(CorrectAngle)),
+		 DataRow(CorrectInEnum, DisplayName = nameof(CorrectInEnum))]
 		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
 		{
 			VerifyCSharpDiagnostic(testCode);


### PR DESCRIPTION
Magic number are totally fine to include in enumerations. In fact, this is a great way to give meaning and context to that magic number.