### PR TITLE
fix: tweak AvoidInvocationAsArgument

### DIFF
--- a/Philips.CodeAnalysis.Common/AdditionalFilesHelper.cs
+++ b/Philips.CodeAnalysis.Common/AdditionalFilesHelper.cs
@@ -45,7 +45,8 @@ namespace Philips.CodeAnalysis.Common
 				StringComparer comparer = StringComparer.OrdinalIgnoreCase;
 				if (comparer.Equals(fileName, exceptionsFile))
 				{
-					return Convert(additionalFile.GetText());
+					var text = additionalFile.GetText();
+					return Convert(text);
 				}
 			}
 			return new HashSet<string>();
@@ -75,7 +76,8 @@ namespace Philips.CodeAnalysis.Common
 
 		private string GetRawValue(string settingKey)
 		{
-			var analyzerConfigOptions = _options.AnalyzerConfigOptionsProvider.GetOptions(_compilation.SyntaxTrees.First());
+			var tree = _compilation.SyntaxTrees.First();
+			var analyzerConfigOptions = _options.AnalyzerConfigOptionsProvider.GetOptions(tree);
 
 #nullable enable
 			if (analyzerConfigOptions.TryGetValue(settingKey, out string? value))

--- a/Philips.CodeAnalysis.Common/AllowedSymbols.cs
+++ b/Philips.CodeAnalysis.Common/AllowedSymbols.cs
@@ -43,8 +43,8 @@ namespace Philips.CodeAnalysis.Common
 		{
 			if (line.StartsWith("~"))
 			{
-				var symbols =
-					DocumentationCommentId.GetSymbolsForDeclarationId(line.Substring(1), compilation);
+				var id = line.Substring(1);
+				var symbols = DocumentationCommentId.GetSymbolsForDeclarationId(id, compilation);
 				if (!symbols.IsDefaultOrEmpty)
 				{
 					foreach (var symbol in symbols)

--- a/Philips.CodeAnalysis.DuplicateCodeAnalyzer/AvoidDuplicateCodeAnalyzer.cs
+++ b/Philips.CodeAnalysis.DuplicateCodeAnalyzer/AvoidDuplicateCodeAnalyzer.cs
@@ -73,7 +73,8 @@ namespace Philips.CodeAnalysis.DuplicateCodeAnalyzer
 				StringComparer comparer = StringComparer.OrdinalIgnoreCase;
 				if (comparer.Equals(fileName, AllowedFileName))
 				{
-					return LoadAllowedMethods(additionalFile.GetText(), compilation);
+					var allowedMethods = additionalFile.GetText();
+					return LoadAllowedMethods(allowedMethods, compilation);
 				}
 			}
 			return new HashSet<ISymbol>();
@@ -240,7 +241,8 @@ namespace Philips.CodeAnalysis.DuplicateCodeAnalyzer
 				if (!location.SourceSpan.IntersectsWith(existingEvidenceLocation.SourceSpan))
 				{
 					string shapeDetails = GetShapeDetails(token);
-					string reference = ToPrettyReference(existingEvidenceLocation.GetLineSpan());
+					var existingEvidenceLineSpan = existingEvidenceLocation.GetLineSpan();
+					string reference = ToPrettyReference(existingEvidenceLineSpan);
 
 					_diagnostics.Add(Diagnostic.Create(Rule, location, new List<Location>() { existingEvidenceLocation }, reference, shapeDetails));
 
@@ -547,7 +549,8 @@ namespace Philips.CodeAnalysis.DuplicateCodeAnalyzer
 
 		public virtual LocationEnvelope GetLocationEnvelope()
 		{
-			return new LocationEnvelope(_syntaxToken.GetLocation());
+			var location = _syntaxToken.GetLocation();
+			return new LocationEnvelope(location);
 		}
 
 		public virtual SyntaxTree GetSyntaxTree()
@@ -676,7 +679,8 @@ namespace Philips.CodeAnalysis.DuplicateCodeAnalyzer
 				int start = firstToken.GetLocationEnvelope().Contents().SourceSpan.Start;
 				int end = lastToken.GetLocationEnvelope().Contents().SourceSpan.End;
 				TextSpan textSpan = TextSpan.FromBounds(start, end);
-				Location location = Location.Create(firstToken.GetSyntaxTree(), textSpan);
+				var firstTokenSyntax = firstToken.GetSyntaxTree();
+				Location location = Location.Create(firstTokenSyntax, textSpan);
 
 				cache = new LocationEnvelope(location);
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
@@ -58,7 +58,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 
 			if (!first.Any())
 			{
-				CreateDiagnostic(context, node.GetLocation());
+				var location = node.GetLocation();
+				CreateDiagnostic(context, location);
 				return;
 			}
 
@@ -76,7 +77,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 			bool isCorrectStatement = CheckCopyrightStatement(context, copyrightSyntax);
 			if (!isCorrectStatement)
 			{
-				CreateDiagnostic(context, copyrightSyntax.GetLocation());
+				var location = copyrightSyntax.GetLocation();
+				CreateDiagnostic(context, location);
 				return;
 			}
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/XmlDocumentationShouldAddValueAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/XmlDocumentationShouldAddValueAnalyzer.cs
@@ -135,7 +135,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 
 				if (string.IsNullOrWhiteSpace(content))
 				{
-					Diagnostic diagnostic = Diagnostic.Create(EmptyRule, xmlElement.GetLocation());
+					var location = xmlElement.GetLocation();
+					Diagnostic diagnostic = Diagnostic.Create(EmptyRule, location);
 					context.ReportDiagnostic(diagnostic);
 					continue;
 				}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidArrayListCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidArrayListCodeFixProvider.cs
@@ -73,10 +73,9 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			{
 				var parameterType = SyntaxFactory.ParseTypeName("int")
 					.WithAdditionalAnnotations(RenameAnnotation.Create(), annotation);
-				var list = CreateGenericTypeSyntax("List", parameterType);
+				var list = CreateGenericTypeSyntax("List", parameterType).WithTriviaFrom(existingType).WithAdditionalAnnotations(Formatter.Annotation);
 
-				root = root.ReplaceNode(existingType,
-					list.WithTriviaFrom(existingType).WithAdditionalAnnotations(Formatter.Annotation));
+				root = root.ReplaceNode(existingType, list);
 			}
 
 			return root;

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidEmptyStatementBlocksAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidEmptyStatementBlocksAnalyzer.cs
@@ -44,7 +44,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 		private void AnalyzeEmptyStatement(SyntaxNodeAnalysisContext context)
 		{
-			Diagnostic diagnostic = Diagnostic.Create(StatementRule, context.Node.GetLocation());
+			var resultOfGetLocation = context.Node.GetLocation();
+			Diagnostic diagnostic = Diagnostic.Create(StatementRule, resultOfGetLocation);
 			context.ReportDiagnostic(diagnostic);
 		}
 
@@ -78,7 +79,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			// Empty catch blocks are a different type of code smell.
 			if (blockSyntax.Parent is CatchClauseSyntax)
 			{
-				Diagnostic emptyCatchDiagnostic = Diagnostic.Create(CatchRule, blockSyntax.GetLocation());
+				var resultOfGetLocation = blockSyntax.GetLocation();
+				Diagnostic emptyCatchDiagnostic = Diagnostic.Create(CatchRule, resultOfGetLocation);
 				context.ReportDiagnostic(emptyCatchDiagnostic);
 				return;
 			}
@@ -95,7 +97,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 				return;
 			}
 
-			Diagnostic diagnostic = Diagnostic.Create(BlockRule, blockSyntax.GetLocation());
+			var location = blockSyntax.GetLocation();
+			Diagnostic diagnostic = Diagnostic.Create(BlockRule, location);
 			context.ReportDiagnostic(diagnostic);
 		}
 	}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidEmptyTypeInitializerCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidEmptyTypeInitializerCodeFixProvider.cs
@@ -51,7 +51,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		{
 			SyntaxNode rootNode = await document.GetSyntaxRootAsync(c).ConfigureAwait(false);
 
-			var newCtor = ctor.WithLeadingTrivia(ctor.GetLeadingTrivia().Where(x => !(x.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia) || x.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia))).ToArray());
+			var leadingTrivia = ctor.GetLeadingTrivia().Where(x => !(x.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia) || x.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia))).ToArray();
+			var newCtor = ctor.WithLeadingTrivia(leadingTrivia);
 
 			rootNode = rootNode.ReplaceNode(ctor, newCtor);
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidInvocationAsArgument.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidInvocationAsArgument.cs
@@ -3,6 +3,7 @@
 using System.Collections.Immutable;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -48,7 +49,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			}
 
 			// If it's calling ToString(), let it go. (ToStrings() cognitive load isn't excessive, and lots of violations)
-			if ((argumentExpressionSyntax.Expression as MemberAccessExpressionSyntax)?.Name.Identifier.Text == "ToString")
+			string methodName = (argumentExpressionSyntax.Expression as MemberAccessExpressionSyntax)?.Name.Identifier.Text;
+			if (methodName is "ToString" or "ToArray" or "ToList")
 			{
 				return;
 			}
@@ -84,7 +86,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 				}
 			}
 
-			Diagnostic diagnostic = Diagnostic.Create(Rule, argumentSyntax.GetLocation(), argumentSyntax.ToString());
+			var location = argumentSyntax.GetLocation();
+			Diagnostic diagnostic = Diagnostic.Create(Rule, location, argumentSyntax.ToString());
 			context.ReportDiagnostic(diagnostic);
 		}
 	}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidPragmaAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidPragmaAnalyzer.cs
@@ -24,7 +24,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			new DiagnosticDescriptor(Helper.ToDiagnosticId(DiagnosticIds.AvoidPragma), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description),
 		};
 
-		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rules.ToArray()); } }
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { var rulesArray = Rules.ToArray(); return ImmutableArray.Create(rulesArray); } }
 
 		public override void Initialize(AnalysisContext context)
 		{
@@ -47,7 +47,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			}
 
 			CSharpSyntaxNode violation = pragma;
-			Diagnostic diagnostic = Diagnostic.Create(Rules[0], violation.GetLocation());
+			var location = violation.GetLocation();
+			Diagnostic diagnostic = Diagnostic.Create(Rules[0], location);
 			context.ReportDiagnostic(diagnostic);
 		}
 	}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidPrivateKeyPropertyAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidPrivateKeyPropertyAnalyzer.cs
@@ -43,7 +43,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 			if (typeSymbol != null && typeSymbol.Name.Equals(ObjectType, System.StringComparison.Ordinal))
 			{
-				Diagnostic diagnostic = Diagnostic.Create(Rule, memberAccessExpressionSyntax.GetLocation());
+				var location = memberAccessExpressionSyntax.GetLocation();
+				Diagnostic diagnostic = Diagnostic.Create(Rule, location);
 				context.ReportDiagnostic(diagnostic);
 			}
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidPublicMemberVariableAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidPublicMemberVariableAnalyzer.cs
@@ -59,7 +59,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 					return;
 				}
 
-				Diagnostic diagnostic = Diagnostic.Create(Rule, fieldDeclaration.GetLocation());
+				var location = fieldDeclaration.GetLocation();
+				Diagnostic diagnostic = Diagnostic.Create(Rule, location);
 				context.ReportDiagnostic(diagnostic);
 			}
 		}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidStaticClassesAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidStaticClassesAnalyzer.cs
@@ -91,8 +91,9 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			var declaredSymbol = context.SemanticModel.GetDeclaredSymbol(classDeclarationSyntax);
 
 			// We need to let it go if it's white-listed (i.e., legacy)
+			var item = declaredSymbol.ToDisplayString();
 			if (_exceptions.Any(str => str.EndsWith(@"." + classDeclarationSyntax.Identifier.ValueText)) &&
-				_exceptions.Contains(declaredSymbol.ToDisplayString()))
+				_exceptions.Contains(item))
 			{
 				return;
 			}
@@ -107,7 +108,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 				File.AppendAllText(@"StaticClasses.Allowed.GENERATED.txt", context.SemanticModel.GetDeclaredSymbol(classDeclarationSyntax).ToDisplayString() + Environment.NewLine);
 			}
 
-			Diagnostic diagnostic = Diagnostic.Create(AvoidStaticClassesAnalyzer.Rule, classDeclarationSyntax.Modifiers.First(t => t.Kind() == SyntaxKind.StaticKeyword).GetLocation());
+			var location = classDeclarationSyntax.Modifiers.First(t => t.Kind() == SyntaxKind.StaticKeyword).GetLocation();
+			Diagnostic diagnostic = Diagnostic.Create(AvoidStaticClassesAnalyzer.Rule, location);
 			context.ReportDiagnostic(diagnostic);
 		}
 	}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidStaticMethodAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidStaticMethodAnalyzer.cs
@@ -95,7 +95,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 				return;
 			}
 
-			Diagnostic diagnostic = Diagnostic.Create(Rule, methodDeclarationSyntax.Modifiers.First(t => t.Kind() == SyntaxKind.StaticKeyword).GetLocation());
+			var location = methodDeclarationSyntax.Modifiers.First(t => t.Kind() == SyntaxKind.StaticKeyword).GetLocation();
+			Diagnostic diagnostic = Diagnostic.Create(Rule, location);
 			context.ReportDiagnostic(diagnostic);
 		}
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidTaskResultAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidTaskResultAnalyzer.cs
@@ -56,7 +56,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 				if (propertySymbol.ContainingNamespace.Name == ContainingNamespace &&
 					propertySymbol.ContainingType.Name.Contains(ContainingType))
 				{
-					Diagnostic diagnostic = Diagnostic.Create(Rule, propertySyntax.Name.GetLocation());
+					var location = propertySyntax.Name.GetLocation();
+					Diagnostic diagnostic = Diagnostic.Create(Rule, location);
 					context.ReportDiagnostic(diagnostic);
 				}
 			}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidTaskResultCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidTaskResultCodeFixProvider.cs
@@ -53,8 +53,10 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		private async Task<Document> ReplaceWithAwait(Document document, MemberAccessExpressionSyntax resultExpression, CancellationToken cancellationToken)
 		{
 			SyntaxNode rootNode = await document.GetSyntaxRootAsync(cancellationToken);
+			var trivia = resultExpression.GetLeadingTrivia();
 			var newExpression = SyntaxFactory.AwaitExpression(resultExpression.Expression);
-			rootNode = rootNode.ReplaceNode(resultExpression, newExpression.WithLeadingTrivia(newExpression.GetLeadingTrivia())).WithAdditionalAnnotations(Formatter.Annotation);
+			var newExpressionWithLeadingTrivia = newExpression.WithLeadingTrivia(trivia);
+			rootNode = rootNode.ReplaceNode(resultExpression, newExpressionWithLeadingTrivia).WithAdditionalAnnotations(Formatter.Annotation);
 			return document.WithSyntaxRoot(rootNode);
 		}
 	}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidThreadSleepAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidThreadSleepAnalyzer.cs
@@ -49,7 +49,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 				if (Helper.HasAttribute(classAttributeList, context, MsTestFrameworkDefinitions.TestClassAttribute, out _) &&
 					(context.SemanticModel.GetSymbolInfo(memberAccessExpression).Symbol is IMethodSymbol memberSymbol) && memberSymbol.ToString().StartsWith("System.Threading.Thread"))
 				{
-					Diagnostic diagnostic = Diagnostic.Create(Rule, invocationExpression.GetLocation());
+					var location = invocationExpression.GetLocation();
+					Diagnostic diagnostic = Diagnostic.Create(Rule, location);
 					context.ReportDiagnostic(diagnostic);
 				}
 			}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidTryParseWithoutCultureAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidTryParseWithoutCultureAnalyzer.cs
@@ -66,7 +66,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 				if (member is IMethodSymbol method && HasCultureParameter(method))
 				{
 					// There is an overload that can accept culture as a parameter. Display an error.
-					Diagnostic diagnostic = Diagnostic.Create(Rule, invocationExpressionSyntax.GetLocation());
+					var location = invocationExpressionSyntax.GetLocation();
+					Diagnostic diagnostic = Diagnostic.Create(Rule, location);
 					context.ReportDiagnostic(diagnostic);
 					return;
 				}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidUnnecessaryWhereAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidUnnecessaryWhereAnalyzer.cs
@@ -86,7 +86,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			string strWhereSymbol = whereSymbol?.ToString();
 			if (strWhereSymbol != null && strWhereSymbol.StartsWith(@"System.Collections.Generic.IEnumerable"))
 			{ 
-				Diagnostic diagnostic = Diagnostic.Create(Rule, whereExpression.Name.Identifier.GetLocation(), expressionOfInterest.Name.Identifier.Text);
+				var location = whereExpression.Name.Identifier.GetLocation();
+				Diagnostic diagnostic = Diagnostic.Create(Rule, location, expressionOfInterest.Name.Identifier.Text);
 				context.ReportDiagnostic(diagnostic);
 			}
 		}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/CallExtensionMethodsAsInstanceMethodsCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/CallExtensionMethodsAsInstanceMethodsCodeFixProvider.cs
@@ -66,11 +66,14 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			ExpressionSyntax thisObject = invocation.ArgumentList.Arguments[0].Expression;
 			ArgumentListSyntax newArguments = SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(invocation.ArgumentList.Arguments.Skip(1).ToArray()));
 
-			MemberAccessExpressionSyntax newExpression = SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, thisObject, name.WithoutLeadingTrivia());
+			name = name.WithoutLeadingTrivia();
+			MemberAccessExpressionSyntax newExpression = SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, thisObject, name);
 
 			InvocationExpressionSyntax newInvocation = SyntaxFactory.InvocationExpression(newExpression, newArguments);
 
-			root = root.ReplaceNode(invocation, newInvocation.WithLeadingTrivia(invocation.GetLeadingTrivia()));
+			var trivia = invocation.GetLeadingTrivia();
+			var newInvocationWithLeadingTrivia = newInvocation.WithLeadingTrivia(trivia);
+			root = root.ReplaceNode(invocation, newInvocationWithLeadingTrivia);
 
 			return document.WithSyntaxRoot(root);
 		}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/LogExceptionAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/LogExceptionAnalyzer.cs
@@ -105,7 +105,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 			public void ReportParsingError(CompilationAnalysisContext context)
 			{
-				var loc = Location.Create(context.Compilation.SyntaxTrees.First(), TextSpan.FromBounds(0, 0));
+				var syntaxTree = context.Compilation.SyntaxTrees.First();
+				var loc = Location.Create(syntaxTree, TextSpan.FromBounds(0, 0));
 				context.ReportDiagnostic(Diagnostic.Create(InvalidSetupRule, loc, Rule.Id, LogMethodNames));
 			}
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/NoHardCodedPathsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/NoHardCodedPathsAnalyzer.cs
@@ -44,7 +44,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			// If the pattern matches the text value, report the diagnostic.
 			if (WindowsPattern.IsMatch(pathValue))
 			{
-				Diagnostic diagnostic = Diagnostic.Create(Rule, stringLiteralExpressionNode.GetLocation());
+				var location = stringLiteralExpressionNode.GetLocation();
+				Diagnostic diagnostic = Diagnostic.Create(Rule, location);
 				context.ReportDiagnostic(diagnostic);
 			}
 		}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/NoRegionsInMethodAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/NoRegionsInMethodAnalyzer.cs
@@ -40,13 +40,15 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			var descendants = node.DescendantNodes(node.Span, null, descendIntoTrivia: true);
 			foreach (RegionDirectiveTriviaSyntax regionDirective in descendants.OfType<RegionDirectiveTriviaSyntax>())
 			{
-				var diagnostic = Diagnostic.Create(Rule, regionDirective.GetLocation());
+				var location = regionDirective.GetLocation();
+				var diagnostic = Diagnostic.Create(Rule, location);
 				context.ReportDiagnostic(diagnostic);
 			}
 
 			foreach (EndRegionDirectiveTriviaSyntax endRegionDirective in descendants.OfType<EndRegionDirectiveTriviaSyntax>())
 			{
-				var diagnostic = Diagnostic.Create(Rule, endRegionDirective.GetLocation());
+				var location = endRegionDirective.GetLocation();
+				var diagnostic = Diagnostic.Create(Rule, location);
 				context.ReportDiagnostic(diagnostic);
 			}
 		}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/WinFormsInitializeComponentMustBeCalledOnceAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/WinFormsInitializeComponentMustBeCalledOnceAnalyzer.cs
@@ -34,7 +34,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		{
 			if (constructors.Length == 0)
 			{
-				Diagnostic diagnostic0 = Diagnostic.Create(Rule, classDeclaration.Identifier.GetLocation(), classDeclaration.Identifier.ToString(), 0);
+				var location = classDeclaration.Identifier.GetLocation();
+				Diagnostic diagnostic0 = Diagnostic.Create(Rule, location, classDeclaration.Identifier.ToString(), 0);
 				context.ReportDiagnostic(diagnostic0);
 				return;
 			}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/EnforceBoolNamingConventionAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/EnforceBoolNamingConventionAnalyzer.cs
@@ -40,7 +40,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 			new DiagnosticDescriptor(Helper.ToDiagnosticId(DiagnosticIds.EnforceBoolNamingConvention), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: false, description: Description),
 		};
 
-		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rules.ToArray()); } }
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { var items = Rules.ToArray(); return ImmutableArray.Create(items); } }
 
 		public override void Initialize(AnalysisContext context)
 		{
@@ -74,7 +74,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 				return;
 			}
 
-			Diagnostic diagnostic = Diagnostic.Create(Rules[0], foreachStatement.Identifier.GetLocation(), foreachStatement.Identifier.ValueText);
+			var location = foreachStatement.Identifier.GetLocation();
+			Diagnostic diagnostic = Diagnostic.Create(Rules[0], location, foreachStatement.Identifier.ValueText);
 			context.ReportDiagnostic(diagnostic);
 		}
 
@@ -144,7 +145,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 					continue;
 				}
 
-				Diagnostic diagnostic = Diagnostic.Create(Rules[0], syntax.Identifier.GetLocation(), syntax.Identifier.ValueText);
+				var location = syntax.Identifier.GetLocation();
+				Diagnostic diagnostic = Diagnostic.Create(Rules[0], location, syntax.Identifier.ValueText);
 				context.ReportDiagnostic(diagnostic);
 			}
 		}
@@ -176,7 +178,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 				return;
 			}
 
-			Diagnostic diagnostic = Diagnostic.Create(Rules[0], parameter.Identifier.GetLocation(), parameter.Identifier.ValueText);
+			var location = parameter.Identifier.GetLocation();
+			Diagnostic diagnostic = Diagnostic.Create(Rules[0], location, parameter.Identifier.ValueText);
 			context.ReportDiagnostic(diagnostic);
 		}
 
@@ -212,7 +215,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 				return;
 			}
 
-			Diagnostic diagnostic = Diagnostic.Create(Rules[0], property.Identifier.GetLocation(), property.Identifier.ValueText);
+			var location = property.Identifier.GetLocation();
+			Diagnostic diagnostic = Diagnostic.Create(Rules[0], location, property.Identifier.ValueText);
 			context.ReportDiagnostic(diagnostic);
 		}
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/NamespaceMatchAssemblyAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/NamespaceMatchAssemblyAnalyzer.cs
@@ -78,7 +78,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 
 			// TODO: Check assembly name, see issue #174
 
-			Diagnostic diagnostic = Diagnostic.Create(Rule, namespaceDeclaration.Name.GetLocation());
+			var location = namespaceDeclaration.Name.GetLocation();
+			Diagnostic diagnostic = Diagnostic.Create(Rule, location);
 			context.ReportDiagnostic(diagnostic);
 		}
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/NamespacePrefixAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/NamespacePrefixAnalyzer.cs
@@ -34,14 +34,15 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 
 			NamespaceDeclarationSyntax namespaceDeclaration = (NamespaceDeclarationSyntax)context.Node;
 			string myNamespace = namespaceDeclaration.Name.ToString();
+			var location = namespaceDeclaration.Name.GetLocation();
 			if (string.IsNullOrEmpty(expected_prefix))
 			{
-				Diagnostic diagnostic = Diagnostic.Create(RuleForEmptyPrefix, namespaceDeclaration.Name.GetLocation());
+				Diagnostic diagnostic = Diagnostic.Create(RuleForEmptyPrefix, location);
 				context.ReportDiagnostic(diagnostic);
 			}
 			else if (!myNamespace.StartsWith(expected_prefix))
 			{
-				Diagnostic diagnostic = Diagnostic.Create(RuleForIncorrectNamespace, namespaceDeclaration.Name.GetLocation());
+				Diagnostic diagnostic = Diagnostic.Create(RuleForIncorrectNamespace, location);
 				context.ReportDiagnostic(diagnostic);
 			}
 		}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/PassByRefAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/PassByRefAnalyzer.cs
@@ -116,7 +116,9 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 					return false;
 				}
 
-				flow = semanticModel.AnalyzeDataFlow(methodDeclarationSyntax.Body.Statements.First(), methodDeclarationSyntax.Body.Statements.Last());
+				var firstStatement = methodDeclarationSyntax.Body.Statements.First();
+				var lastStatement = methodDeclarationSyntax.Body.Statements.Last();
+				flow = semanticModel.AnalyzeDataFlow(firstStatement, lastStatement);
 			}
 			else if (methodDeclarationSyntax.ExpressionBody != null)
 			{

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/PositiveNamingAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/PositiveNamingAnalyzer.cs
@@ -48,7 +48,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 			{
 				if (!IsPositiveName(variable.Identifier.Text))
 				{
-					CreateDiagnostic(context, node.GetLocation());
+					var location = node.GetLocation();
+					CreateDiagnostic(context, location);
 				}
 			}
 		}
@@ -64,7 +65,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 
 			if (!IsPositiveName(node.Identifier.Text))
 			{
-				CreateDiagnostic(context, node.GetLocation());
+				var location = node.GetLocation();
+				CreateDiagnostic(context, location);
 			}
 		}
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/VariableNamingConventionAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/VariableNamingConventionAnalyzer.cs
@@ -40,7 +40,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 			new DiagnosticDescriptor(Helper.ToDiagnosticId(DiagnosticIds.VariableNamingConventions), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: false, description: Description),
 		};
 
-		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rules.ToArray()); } }
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { var items = Rules.ToArray(); return ImmutableArray.Create(items); } }
 
 		public override void Initialize(AnalysisContext context)
 		{
@@ -68,7 +68,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 			}
 
 			CSharpSyntaxNode violation = foreachStatement;
-			Diagnostic diagnostic = Diagnostic.Create(Rules[0], violation.GetLocation(), foreachStatement.Identifier.ValueText);
+			var location = violation.GetLocation();
+			Diagnostic diagnostic = Diagnostic.Create(Rules[0], location, foreachStatement.Identifier.ValueText);
 			context.ReportDiagnostic(diagnostic);
 		}
 
@@ -135,7 +136,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 				}
 
 				CSharpSyntaxNode violation = variableDeclaration;
-				Diagnostic diagnostic = Diagnostic.Create(Rules[0], violation.GetLocation(), syntax.Identifier.ValueText);
+				var location = violation.GetLocation();
+				Diagnostic diagnostic = Diagnostic.Create(Rules[0], location, syntax.Identifier.ValueText);
 				context.ReportDiagnostic(diagnostic);
 			}
 		}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidMultipleLambdasOnSingleLineCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidMultipleLambdasOnSingleLineCodeFixProvider.cs
@@ -92,7 +92,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 			}
 			SyntaxTriviaList newTrivia = lastToken.TrailingTrivia.Add(SyntaxFactory.EndOfLine("\r\n"));
 
-			root = root.ReplaceNode(node, node.WithTrailingTrivia(newTrivia)).WithAdditionalAnnotations(Formatter.Annotation);
+			var newNode = node.WithTrailingTrivia(newTrivia);
+			root = root.ReplaceNode(node, newNode).WithAdditionalAnnotations(Formatter.Annotation);
 
 			return document.WithSyntaxRoot(root);
 		}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceRegionsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceRegionsAnalyzer.cs
@@ -85,7 +85,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 			{
 				if (RegionChecks.TryGetValue(pair.Key, out var functionToCall))
 				{
-					functionToCall(GetMembersOfRegion(members, pair.Value), pair.Value, context);
+					var membersOfRegion = GetMembersOfRegion(members, pair.Value);
+					functionToCall(membersOfRegion, pair.Value, context);
 				}
 			}
 
@@ -137,11 +138,13 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 					{
 						if (regionLocations.Remove(regionName))
 						{
-							CreateDiagnostic(region.DirectiveNameToken.GetLocation(), context, regionName, EnforceNonDupliateRegion);
+							var memberLocation = region.DirectiveNameToken.GetLocation();
+							CreateDiagnostic(memberLocation, context, regionName, EnforceNonDupliateRegion);
 						}
 						else
 						{
-							int lineNumber = GetMemberLineNumber(region.GetLocation());
+							var location = region.GetLocation();
+							int lineNumber = GetMemberLineNumber(location);
 
 							regionLocations.Add(regionName, new LocationRangeModel(lineNumber, lineNumber));
 							regionStartName = regionName;
@@ -152,7 +155,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 				{
 					if (regionLocations.TryGetValue(regionStartName, out LocationRangeModel value))
 					{
-						value.EndLine = GetMemberLineNumber(region.GetLocation());
+						var location = region.GetLocation();
+						value.EndLine = GetMemberLineNumber(location);
 						regionStartName = "";
 					}
 				}
@@ -187,7 +191,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 		/// <returns>true if member is inside the given region, else false</returns>
 		private static bool MemberPresentInRegion(MemberDeclarationSyntax member, LocationRangeModel locationRange)
 		{
-			int memberLocation = GetMemberLineNumber(member.GetLocation());
+			var location = member.GetLocation();
+			int memberLocation = GetMemberLineNumber(location);
 			return memberLocation > locationRange.StartLine && memberLocation < locationRange.EndLine;
 		}
 
@@ -282,13 +287,14 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 
 			if (shouldCheck)
 			{
+				var memberLocation = member.GetLocation();
 				if (!HasAccessModifier(modifiers))
 				{
-					CreateDiagnostic(member.GetLocation(), context, PublicInterfaceRegion, EnforceMemberLocation);
+					CreateDiagnostic(memberLocation, context, PublicInterfaceRegion, EnforceMemberLocation);
 				}
 				else if (!MemberIsPublic(modifiers))
 				{
-					CreateDiagnostic(member.GetLocation(), context, PublicInterfaceRegion, EnforceMemberLocation);
+					CreateDiagnostic(memberLocation, context, PublicInterfaceRegion, EnforceMemberLocation);
 				}
 				return;
 			}
@@ -299,7 +305,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 			}
 			else
 			{
-				CreateDiagnostic(member.GetLocation(), context, PublicInterfaceRegion, NonCheckedMember);
+				var memberLocation = member.GetLocation();
+				CreateDiagnostic(memberLocation, context, PublicInterfaceRegion, NonCheckedMember);
 			}
 		}
 
@@ -381,6 +388,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 					break;
 			}
 
+			var memberLocation = member.GetLocation();
 			if (shouldProcess)
 			{
 				if (!HasAccessModifier(modifiers))
@@ -389,7 +397,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 				}
 				else if (MemberIsPublic(modifiers))
 				{
-					CreateDiagnostic(member.GetLocation(), context, NonPublicPropertiesAndMethodsRegion, EnforceMemberLocation);
+					CreateDiagnostic(memberLocation, context, NonPublicPropertiesAndMethodsRegion, EnforceMemberLocation);
 				}
 				return;
 			}
@@ -404,10 +412,10 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 				case SyntaxKind.FieldDeclaration:
 				case SyntaxKind.EnumDeclaration:
 				case SyntaxKind.DelegateDeclaration:
-					CreateDiagnostic(member.GetLocation(), context, NonPublicPropertiesAndMethodsRegion, EnforceMemberLocation);
+					CreateDiagnostic(memberLocation, context, NonPublicPropertiesAndMethodsRegion, EnforceMemberLocation);
 					break;
 				default:
-					CreateDiagnostic(member.GetLocation(), context, NonPublicPropertiesAndMethodsRegion, NonCheckedMember);
+					CreateDiagnostic(memberLocation, context, NonPublicPropertiesAndMethodsRegion, NonCheckedMember);
 					break;
 			}
 		}
@@ -455,6 +463,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 					break;
 			}
 
+			var memberLocation = member.GetLocation();
 			if (shouldProcess)
 			{
 				if (!HasAccessModifier(modifiers))
@@ -463,7 +472,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 				}
 				else if (MemberIsPublic(modifiers))
 				{
-					CreateDiagnostic(member.GetLocation(), context, NonPublicDataMembersRegion, EnforceMemberLocation);
+					CreateDiagnostic(memberLocation, context, NonPublicDataMembersRegion, EnforceMemberLocation);
 				}
 				return;
 			}
@@ -484,10 +493,10 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 				case SyntaxKind.ClassDeclaration:
 				case SyntaxKind.IndexerDeclaration:
 				case SyntaxKind.DestructorDeclaration:
-					CreateDiagnostic(member.GetLocation(), context, NonPublicDataMembersRegion, EnforceMemberLocation);
+					CreateDiagnostic(memberLocation, context, NonPublicDataMembersRegion, EnforceMemberLocation);
 					break;
 				default:
-					CreateDiagnostic(member.GetLocation(), context, NonPublicDataMembersRegion, NonCheckedMember);
+					CreateDiagnostic(memberLocation, context, NonPublicDataMembersRegion, NonCheckedMember);
 					break;
 			}
 		}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EveryLinqStatementOnSeparateLineCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EveryLinqStatementOnSeparateLineCodeFixProvider.cs
@@ -59,7 +59,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 			SyntaxToken lastToken = clause.GetLastToken();
 			SyntaxTriviaList newTrivia = lastToken.TrailingTrivia.Add(SyntaxFactory.EndOfLine("\r\n"));
 
-			root = root.ReplaceNode(clause, clause.WithTrailingTrivia(newTrivia)).WithAdditionalAnnotations(Formatter.Annotation);
+			var clauseWithTrivia = clause.WithTrailingTrivia(newTrivia);
+			root = root.ReplaceNode(clause, clauseWithTrivia).WithAdditionalAnnotations(Formatter.Annotation);
 
 			return document.WithSyntaxRoot(root);
 		}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/PreventUnnecessaryRangeChecksCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/PreventUnnecessaryRangeChecksCodeFixProvider.cs
@@ -61,7 +61,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 
 			if (ifBlock is BlockSyntax block)
 			{
-				replaceNode = block.Statements[0].WithLeadingTrivia(node.GetLeadingTrivia());
+				var trivia = node.GetLeadingTrivia();
+				replaceNode = block.Statements[0].WithLeadingTrivia(trivia);
 			}
 
 			root = root.ReplaceNode(node, replaceNode).WithAdditionalAnnotations(Formatter.Annotation);
@@ -93,7 +94,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 			}
 			var newLine = SyntaxFactory.SyntaxTrivia(SyntaxKind.WhitespaceTrivia, Environment.NewLine);
 
-			replaceNode = replaceNode.WithTrailingTrivia(trailingTrivia.Insert(0, newLine));
+			var trivia = trailingTrivia.Insert(0, newLine);
+			replaceNode = replaceNode.WithTrailingTrivia(trivia);
 
 			root = root.ReplaceNode(node, replaceNode).WithAdditionalAnnotations(Formatter.Annotation);
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/DereferenceNullAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/DereferenceNullAnalyzer.cs
@@ -39,7 +39,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
 
 		private static void Report(SyntaxNodeAnalysisContext context, IdentifierNameSyntax identifier)
 		{
-			var diagnostic = Diagnostic.Create(Rule, identifier.GetLocation(), identifier.Identifier.ValueText);
+			var location = identifier.GetLocation();
+			var diagnostic = Diagnostic.Create(Rule, location, identifier.Identifier.ValueText);
 			context.ReportDiagnostic(diagnostic);
 		}
 
@@ -92,7 +93,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
 			if (blockOfInterest.Statements.Contains(ourStatement))
 			{
 				statementOfInterestIndex = blockOfInterest.Statements.IndexOf(ourStatement) + offset;
-				return (blockOfInterest.Statements.ElementAt(statementOfInterestIndex), statementOfInterestIndex);
+				var statementOfInterest = blockOfInterest.Statements.ElementAt(statementOfInterestIndex);
+				return (statementOfInterest, statementOfInterestIndex);
 			}
 
 			// the statement of interest is nested within another statement

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualAnalyzer.cs
@@ -59,7 +59,8 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 			if (arg1Literal || arg0Null)
 			{
-				Diagnostic diagnostic = Diagnostic.Create(Rule, invocationExpressionSyntax.GetLocation());
+				var location = invocationExpressionSyntax.GetLocation();
+				Diagnostic diagnostic = Diagnostic.Create(Rule, location);
 				return new[] { diagnostic };
 			}
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualLiteralAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualLiteralAnalyzer.cs
@@ -53,7 +53,8 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			TypeInfo actualType = context.SemanticModel.GetTypeInfo(actual.Expression);
 
 			Conversion conversion = context.SemanticModel.Compilation.ClassifyConversion(actualType.Type, expectedType.Type);
-			return conversion.IsNullable ? null : (IEnumerable<Diagnostic>)(new[] { Diagnostic.Create(Rule, invocationExpressionSyntax.GetLocation()) });
+			var location = invocationExpressionSyntax.GetLocation();
+			return conversion.IsNullable ? null : (IEnumerable<Diagnostic>)(new[] { Diagnostic.Create(Rule, location) });
 		}
 
 		private bool IsLiteral(ExpressionSyntax expression)

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualLiteralCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualLiteralCodeFixProvider.cs
@@ -78,8 +78,9 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			}
 
 			InvocationExpressionSyntax newInvocation = ConvertToInvocation(((MemberAccessExpressionSyntax)invocationExpression.Expression).Name, literalExpected.Expression, actual.Expression, message?.Expression);
-
-			root = root.ReplaceNode(invocationExpression, newInvocation.WithLeadingTrivia(invocationExpression.GetLeadingTrivia()));
+			var trivia = invocationExpression.GetLeadingTrivia();
+			var newInvocationWithTrivia = newInvocation.WithLeadingTrivia(trivia);
+			root = root.ReplaceNode(invocationExpression, newInvocationWithTrivia);
 
 			return document.WithSyntaxRoot(root);
 		}

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualTypesMatchAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualTypesMatchAnalyzer.cs
@@ -80,7 +80,8 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 			if (!context.SemanticModel.Compilation.ClassifyConversion(ti2.Type, ti1.Type).IsImplicit)
 			{
-				Diagnostic diagnostic = Diagnostic.Create(Rule, mds.GetLocation(), ti1.Type.ToString(), ti2.Type.ToString());
+				var location = mds.GetLocation();
+				Diagnostic diagnostic = Diagnostic.Create(Rule, location, ti1.Type.ToString(), ti2.Type.ToString());
 				context.ReportDiagnostic(diagnostic);
 			}
 		}

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueAnalyzer.cs
@@ -25,6 +25,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 		protected override Diagnostic Check(SyntaxNodeAnalysisContext context, SyntaxNode node, ExpressionSyntax test, bool isIsTrue)
 		{
 			var kind = test.Kind();
+			var location = node.GetLocation();
 			switch (kind)
 			{
 				case SyntaxKind.LogicalNotExpression:
@@ -34,17 +35,17 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 				case SyntaxKind.LogicalAndExpression:
 					if (isIsTrue)
 					{
-						return Diagnostic.Create(IsEqualRule, node.GetLocation());
+						return Diagnostic.Create(IsEqualRule, location);
 					}
 					return null;
 				case SyntaxKind.EqualsExpression:
 				case SyntaxKind.NotEqualsExpression:
-					return Diagnostic.Create(IsEqualRule, node.GetLocation());
+					return Diagnostic.Create(IsEqualRule, location);
 				case SyntaxKind.InvocationExpression:
 					//they are calling a function.  Don't let them calls .Equals or something like that.
 					if (CheckForEqualityFunction(context, (InvocationExpressionSyntax)test))
 					{
-						return Diagnostic.Create(IsEqualRule, node.GetLocation());
+						return Diagnostic.Create(IsEqualRule, location);
 					}
 					return null;
 				case SyntaxKind.IdentifierName:

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueLiteralAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueLiteralAnalyzer.cs
@@ -24,7 +24,8 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 		protected override Diagnostic Check(SyntaxNodeAnalysisContext context, SyntaxNode node, ExpressionSyntax test, bool isIsTrue)
 		{
-			return !Helper.IsLiteralTrueFalse(test) ? null : Diagnostic.Create(IsTrueRule, test.GetLocation());
+			var location = test.GetLocation();
+			return !Helper.IsLiteralTrueFalse(test) ? null : Diagnostic.Create(IsTrueRule, location);
 		}
 	}
 }

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AvoidAssertConditionalAccessAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AvoidAssertConditionalAccessAnalyzer.cs
@@ -46,7 +46,8 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			{
 				if (syntax.DescendantNodes().Any(x => x.Kind() == SyntaxKind.ConditionalAccessExpression))
 				{
-					Diagnostic diagnostic = Diagnostic.Create(Rule, syntax.GetLocation());
+					var location = syntax.GetLocation();
+					Diagnostic diagnostic = Diagnostic.Create(Rule, location);
 					yield return diagnostic;
 				}
 			}

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AvoidAttributeAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AvoidAttributeAnalyzer.cs
@@ -119,7 +119,8 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 		{
 			var builder = ImmutableArray.CreateBuilder<DiagnosticDescriptor>();
 
-			builder.AddRange(attributes.SelectMany(x => x.Value).Select(x => x.Rule));
+			var items = attributes.SelectMany(x => x.Value).Select(x => x.Rule);
+			builder.AddRange(items);
 
 			return builder.ToImmutable();
 		}

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AvoidMsFakes.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AvoidMsFakes.cs
@@ -44,7 +44,8 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			if (expression.ToString().Contains(@"ShimsContext.Create"))
 			{
 				CSharpSyntaxNode violation = expression;
-				Diagnostic diagnostic = Diagnostic.Create(Rule, violation.GetLocation());
+				var location = violation.GetLocation();
+				Diagnostic diagnostic = Diagnostic.Create(Rule, location);
 				context.ReportDiagnostic(diagnostic);
 			}
 		}

--- a/Philips.CodeAnalysis.MsTestAnalyzers/ExpectedExceptionAttributeAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/ExpectedExceptionAttributeAnalyzer.cs
@@ -45,7 +45,8 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			{
 				if (attribute.Name.ToString().Contains(@"ExpectedException"))
 				{
-					Diagnostic diagnostic = Diagnostic.Create(Rule, attribute.GetLocation());
+					var location = attribute.GetLocation();
+					Diagnostic diagnostic = Diagnostic.Create(Rule, location);
 					context.ReportDiagnostic(diagnostic);
 					return;
 				}

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestClassPublicMethodShouldBeTestMethodAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestClassPublicMethodShouldBeTestMethodAnalyzer.cs
@@ -83,7 +83,8 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 			if (!isAllowedToBePublic)
 			{
-				Diagnostic diagnostic = Diagnostic.Create(Rule, methodDeclaration.GetLocation());
+				var location = methodDeclaration.GetLocation();
+				Diagnostic diagnostic = Diagnostic.Create(Rule, location);
 				context.ReportDiagnostic(diagnostic);
 			}
 		}

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestContextAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestContextAnalyzer.cs
@@ -85,7 +85,8 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			}
 
 			// if not, report a diagnostic error
-			Diagnostic diagnostic = Diagnostic.Create(Rule, context.Node.GetLocation());
+			var location = context.Node.GetLocation();
+			Diagnostic diagnostic = Diagnostic.Create(Rule, location);
 			context.ReportDiagnostic(diagnostic);
 			return;
 		}

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestHasCategoryAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestHasCategoryAnalyzer.cs
@@ -54,7 +54,8 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 				if (!Helper.HasAttribute(attributeLists, context, MsTestFrameworkDefinitions.TestCategoryAttribute, out Location categoryLocation, out AttributeArgumentSyntax argumentSyntax))
 				{
-					Diagnostic diagnostic = Diagnostic.Create(Rule, methodDeclaration.Identifier.GetLocation());
+					var location = methodDeclaration.Identifier.GetLocation();
+					Diagnostic diagnostic = Diagnostic.Create(Rule, location);
 					context.ReportDiagnostic(diagnostic);
 					return;
 				}

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestHasCategoryCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestHasCategoryCodeFixProvider.cs
@@ -81,7 +81,8 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			AttributeListSyntax attributeList = SyntaxFactory.AttributeList(
 				SyntaxFactory.SingletonSeparatedList<AttributeSyntax>(attribute));
 
-			MethodDeclarationSyntax newMethod = method.WithAttributeLists(method.AttributeLists.Add(attributeList));
+			attributeLists = method.AttributeLists.Add(attributeList);
+			MethodDeclarationSyntax newMethod = method.WithAttributeLists(attributeLists);
 
 			SyntaxNode newRoot = rootNode.ReplaceNode(method, newMethod);
 			Document newDocument = document.WithSyntaxRoot(newRoot);

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodNameAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodNameAnalyzer.cs
@@ -74,7 +74,8 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 					if (!string.IsNullOrEmpty(invalidPrefix))
 					{
-						Diagnostic diagnostic = Diagnostic.Create(Rule, token.GetLocation(), invalidPrefix);
+						var location = token.GetLocation();
+						Diagnostic diagnostic = Diagnostic.Create(Rule, location, invalidPrefix);
 						context.ReportDiagnostic(diagnostic);
 						return;
 					}

--- a/Philips.CodeAnalysis.SecurityAnalyzers/AvoidPasswordAnalyzer.cs
+++ b/Philips.CodeAnalysis.SecurityAnalyzers/AvoidPasswordAnalyzer.cs
@@ -42,8 +42,8 @@ namespace Philips.CodeAnalysis.SecurityAnalyzers
 		{
 			if (context.Node is PropertyDeclarationSyntax propertyDeclarationSyntax)
 			{
-				Diagnose(propertyDeclarationSyntax.Identifier.ValueText,
-					propertyDeclarationSyntax.GetLocation(), context.ReportDiagnostic);
+				var location = propertyDeclarationSyntax.GetLocation();
+				Diagnose(propertyDeclarationSyntax.Identifier.ValueText, location, context.ReportDiagnostic);
 			}
 		}
 
@@ -51,8 +51,8 @@ namespace Philips.CodeAnalysis.SecurityAnalyzers
 		{
 			if (context.Node is MethodDeclarationSyntax methodDeclarationSyntax)
 			{
-				Diagnose(methodDeclarationSyntax.Identifier.ValueText,
-					methodDeclarationSyntax.GetLocation(), context.ReportDiagnostic);
+				var location = methodDeclarationSyntax.GetLocation();
+				Diagnose(methodDeclarationSyntax.Identifier.ValueText,location, context.ReportDiagnostic);
 			}
 		}
 
@@ -62,8 +62,8 @@ namespace Philips.CodeAnalysis.SecurityAnalyzers
 			{
 				foreach (var variable in fieldDeclarationSyntax.Declaration.Variables)
 				{
-					Diagnose(variable.Identifier.ValueText,
-						fieldDeclarationSyntax.GetLocation(), context.ReportDiagnostic);
+					var location = fieldDeclarationSyntax.GetLocation();
+					Diagnose(variable.Identifier.ValueText, location, context.ReportDiagnostic);
 				}
 			}
 		}
@@ -75,7 +75,8 @@ namespace Philips.CodeAnalysis.SecurityAnalyzers
 			var comments = root.DescendantTrivia().Where((t) => t.IsKind(SyntaxKind.SingleLineCommentTrivia) || t.IsKind(SyntaxKind.MultiLineCommentTrivia));
 			foreach (SyntaxTrivia comment in comments)
 			{
-				Diagnose(comment.ToString(), comment.GetLocation(), context.ReportDiagnostic);
+				var location = comment.GetLocation();
+				Diagnose(comment.ToString(), location, context.ReportDiagnostic);
 			}
 		}
 

--- a/Philips.CodeAnalysis.Test/DuplicateCode/AvoidDuplicateCodeTest.cs
+++ b/Philips.CodeAnalysis.Test/DuplicateCode/AvoidDuplicateCodeTest.cs
@@ -276,7 +276,8 @@ Foo.WhitelistedFunction
 		[DataRow("object obj = new object();", "Foo()")]
 		public void AvoidDuplicateCodeNoError(string method1, string method2)
 		{
-			VerifyNoDiagnostic(CreateFunctions(method1, method2));
+			var file = CreateFunctions(method1, method2);
+			VerifyNoDiagnostic(file);
 		}
 
 		[DataTestMethod]
@@ -285,7 +286,8 @@ Foo.WhitelistedFunction
 		[DataRow("object obj = new object(); object obj2 = new object(); object obj3 = new object();", "Bar(); object obj = new object(); object obj2 = new object(); object obj3 = new object();")]
 		public void AvoidDuplicateCodeError(string method1, string method2)
 		{
-			VerifyDiagnostic(CreateFunctions(method1, method2));
+			var file = CreateFunctions(method1, method2);
+			VerifyDiagnostic(file);
 		}
 
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidStaticClassAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidStaticClassAnalyzerTest.cs
@@ -28,7 +28,8 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 				KnownWhitelistClassNamespace + "." + KnownWhitelistClassClassName
 			};
 			_mock.Setup(c => c.CreateCompilationAnalyzer(It.IsAny<HashSet<string>>(), It.IsAny<bool>())).Returns(new AvoidStaticClassesCompilationAnalyzer(exceptions, false));
-			VerifyNoDiagnostic(CreateFunction("static", KnownWhitelistClassNamespace, KnownWhitelistClassClassName));
+			var file = CreateFunction("static", KnownWhitelistClassNamespace, KnownWhitelistClassClassName);
+			VerifyNoDiagnostic(file);
 		}
 	}
 
@@ -88,34 +89,41 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		[TestMethod]
 		public void AvoidStaticClassesTest()
 		{
-			VerifyDiagnostic(CreateFunction("static"));
+			var file = CreateFunction("static");
+			VerifyDiagnostic(file);
 		}
 
 
 		[TestMethod]
 		public void AvoidStaticClassesShouldNotWhitelistWhenNamespaceUnmatchedTest()
 		{
-			VerifyDiagnostic(CreateFunction("static", "IAmSooooooNotWhitelisted", KnownWhitelistClassClassName));
+			var file = CreateFunction("static", "IAmSooooooNotWhitelisted", KnownWhitelistClassClassName);
+			VerifyDiagnostic(file);
 		}
 
 		[TestMethod]
 		public void AvoidStaticClassesShouldWhitelistWildCardClassTest()
 		{
-			VerifyNoDiagnostic(CreateFunction("static", "IAmSooooooNotWhitelisted", KnownWildcardClassName));
-			VerifyNoDiagnostic(CreateFunction("static", "IAmSooooooNotWhitelisted", AnotherKnownWildcardClassName));
+			var file = CreateFunction("static", "IAmSooooooNotWhitelisted", KnownWildcardClassName);
+			VerifyNoDiagnostic(file);
+			var file2 = CreateFunction("static", "IAmSooooooNotWhitelisted", AnotherKnownWildcardClassName);
+			VerifyNoDiagnostic(file2);
 		}
 
 		[TestMethod]
 		public void AvoidStaticClassesShouldWhitelistExtensionClasses()
 		{
-			VerifyNoDiagnostic(CreateFunction("static", isExtension: true, hasNonExtensionMethods: false));
-			VerifyDiagnostic(CreateFunction("static", isExtension: true));
+			var noDiagnostic = CreateFunction("static", isExtension: true, hasNonExtensionMethods: false);
+			VerifyNoDiagnostic(noDiagnostic);
+			var methodHavingDiagnostic = CreateFunction("static", isExtension: true);
+			VerifyDiagnostic(methodHavingDiagnostic);
 		}
 
 		[TestMethod]
 		public void AvoidNoStaticClassesTest()
 		{
-			VerifyNoDiagnostic(CreateFunction(""));
+			var file = CreateFunction("");
+			VerifyNoDiagnostic(file);
 		}
 
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ProhibitDynamicKeywordAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ProhibitDynamicKeywordAnalyzerTest.cs
@@ -45,7 +45,8 @@ dynamic.StartsWith(""Y"", true, CultureInfo.CurrentCulture);
 				results.Add(DiagnosticResultHelper.Create(DiagnosticIds.DynamicKeywordProhibited));
 			}
 
-			VerifyCSharpDiagnostic(testCode, results.ToArray());
+			var expected = results.ToArray();
+			VerifyCSharpDiagnostic(testCode, expected);
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidInlineNewAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidInlineNewAnalyzerTest.cs
@@ -48,19 +48,22 @@ class Foo
 		[TestMethod]
 		public void DontInlineNewCall()
 		{
-			VerifyDiagnostic(CreateFunction("string str = new object().ToString()"));
+			var file = CreateFunction("string str = new object().ToString()");
+			VerifyDiagnostic(file);
 		}
 
 		[TestMethod]
 		public void NoErrorIfPlacedInLocal()
 		{
-			VerifyNoDiagnostic(CreateFunction("object obj = new object(); string str = obj.ToString();"));
+			var file = CreateFunction("object obj = new object(); string str = obj.ToString();");
+			VerifyNoDiagnostic(file);
 		}
 
 		[TestMethod]
 		public void NoErrorIfPlacedInField()
 		{
-			VerifyNoDiagnostic(CreateFunction("_obj = new object(); string str = _obj.ToString();"));
+			var file = CreateFunction("_obj = new object(); string str = _obj.ToString();");
+			VerifyNoDiagnostic(file);
 		}
 
 		[DataRow("new Foo()")]
@@ -68,50 +71,58 @@ class Foo
 		[DataTestMethod]
 		public void DontInlineNewCallCustomType(string newVarient)
 		{
-			VerifyDiagnostic(CreateFunction($"string str = {newVarient}.ToString()"));
+			var file = CreateFunction($"string str = {newVarient}.ToString()");
+			VerifyDiagnostic(file);
 		}
 
 		[TestMethod]
 		public void NoErrorIfPlacedInLocalCustomType()
 		{
-			VerifyNoDiagnostic(CreateFunction("object obj = new Foo(); string str = obj.ToString();"));
+			var file = CreateFunction("object obj = new Foo(); string str = obj.ToString();");
+			VerifyNoDiagnostic(file);
 		}
 
 		[TestMethod]
 		public void NoErrorIfPlacedInFieldCustomType()
 		{
-			VerifyNoDiagnostic(CreateFunction("_obj = new Foo(); string str = _obj.ToString();"));
+			var file = CreateFunction("_obj = new Foo(); string str = _obj.ToString();");
+			VerifyNoDiagnostic(file);
 		}
 
 
 		[TestMethod]
 		public void NoErrorIfPlacedInContainer()
 		{
-			VerifyNoDiagnostic(CreateFunction("var v = new List<object>(); v.Add(new object());"));
+			var file = CreateFunction("var v = new List<object>(); v.Add(new object());");
+			VerifyNoDiagnostic(file);
 		}
 
 		[TestMethod]
 		public void NoErrorIfReturned()
 		{
-			VerifyNoDiagnostic(CreateFunction("return new object();"));
+			var file = CreateFunction("return new object();");
+			VerifyNoDiagnostic(file);
 		}
 
 		[TestMethod]
 		public void ErrorIfReturned()
 		{
-			VerifyDiagnostic(CreateFunction("return new object().ToString();"));
+			var file = CreateFunction("return new object().ToString();");
+			VerifyDiagnostic(file);
 		}
 
 		[TestMethod]
 		public void NoErrorIfThrown()
 		{
-			VerifyNoDiagnostic(CreateFunction("throw new Exception();"));
+			var file = CreateFunction("throw new Exception();");
+			VerifyNoDiagnostic(file);
 		}
 
 		[TestMethod]
 		public void ErrorIfThrown()
 		{
-			VerifyDiagnostic(CreateFunction("throw new object().Foo;"));
+			var file = CreateFunction("throw new object().Foo;");
+			VerifyDiagnostic(file);
 		}
 
 		private void VerifyNoDiagnostic(string file)

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/PreferNamedTuplesAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/PreferNamedTuplesAnalyzerTest.cs
@@ -47,21 +47,24 @@ class Foo
 		[DataTestMethod]
 		public void NamedTuplesDontCauseErrors(string argument)
 		{
-			VerifyCSharpDiagnostic(CreateFunction(argument));
+			var source = CreateFunction(argument);
+			VerifyCSharpDiagnostic(source);
 		}
 
 		[DataRow("(int, int)")]
 		[DataTestMethod]
 		public void ErrorIfTupleElementsDoNotHaveNames(string argument)
 		{
-			VerifyCSharpDiagnostic(CreateFunction(argument), DiagnosticResultHelper.Create(DiagnosticIds.PreferTuplesWithNamedFields), DiagnosticResultHelper.Create(DiagnosticIds.PreferTuplesWithNamedFields));
+			var source = CreateFunction(argument);
+			VerifyCSharpDiagnostic(source, DiagnosticResultHelper.Create(DiagnosticIds.PreferTuplesWithNamedFields), DiagnosticResultHelper.Create(DiagnosticIds.PreferTuplesWithNamedFields));
 		}
 
 		[DataRow("(int Foo, int)")]
 		[DataTestMethod]
 		public void ErrorIfTupleElementDoesNotHaveName(string argument)
 		{
-			VerifyCSharpDiagnostic(CreateFunction(argument), DiagnosticResultHelper.Create(DiagnosticIds.PreferTuplesWithNamedFields));
+			var source = CreateFunction(argument);
+			VerifyCSharpDiagnostic(source, DiagnosticResultHelper.Create(DiagnosticIds.PreferTuplesWithNamedFields));
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/PreferTupleFieldNamesAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/PreferTupleFieldNamesAnalyzerTest.cs
@@ -58,7 +58,8 @@ class Foo
 				results = DiagnosticResultHelper.CreateArray(DiagnosticIds.PreferUsingNamedTupleField);
 			}
 
-			VerifyCSharpDiagnostic(CreateFunction(argument), results);
+			var source = CreateFunction(argument);
+			VerifyCSharpDiagnostic(source, results);
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/DereferenceNullAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/DereferenceNullAnalyzerTest.cs
@@ -81,7 +81,8 @@ Instruction i = method.Body.Instructions[0];
 		[DataRow("string z = \"hi\"", "int t2 = y.Length")]
 		public void DereferenceNullAsExpressionFindingTest(string content1, string content2)
 		{
-			string testCode = string.Format(GetTemplate(), content1, content2);
+			var format = GetTemplate();
+			string testCode = string.Format(format, content1, content2);
 			var expected = DiagnosticResultHelper.CreateArray(DiagnosticIds.DereferenceNull);
 			VerifyCSharpDiagnostic(testCode, expected);
 		}
@@ -100,7 +101,8 @@ Instruction i = method.Body.Instructions[0];
 		[DataRow("string z = \"hi\"", "int t2 = y?.Length")]
 		public void DereferenceNullAsExpressionNoFindingTest(string content1, string content2)
 		{
-			string testCode = string.Format(GetTemplate(), content1, content2);
+			var format = GetTemplate();
+			string testCode = string.Format(format, content1, content2);
 			VerifyCSharpDiagnostic(testCode, Array.Empty<DiagnosticResult>());
 		}
 

--- a/Philips.CodeAnalysis.Test/MsTest/AssertAreEqualTypesMatchAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AssertAreEqualTypesMatchAnalyzerTest.cs
@@ -45,7 +45,9 @@ namespace AssertAreEqualTypesMatchAnalyzerTest
 ";
 
 			string givenText = string.Format(baseline, arg1, arg2);
-			string expectedMessage = string.Format(AssertAreEqualTypesMatchAnalyzer.MessageFormat, GetWellKnownTypeName(arg1), GetWellKnownTypeName(arg2));
+			var arg1Type = GetWellKnownTypeName(arg1);
+			var arg2Type = GetWellKnownTypeName(arg2);
+			string expectedMessage = string.Format(AssertAreEqualTypesMatchAnalyzer.MessageFormat, arg1Type, arg2Type);
 
 			DiagnosticResult[] expected = new [] { new DiagnosticResult
 			{

--- a/Philips.CodeAnalysis.Test/MsTest/AvoidMsFakesAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AvoidMsFakesAnalyzerTest.cs
@@ -47,13 +47,15 @@ class Foo
 		[TestMethod]
 		public void AvoidMsFakesTest()
 		{
-			VerifyDiagnostic(CreateFunction("using (ShimsContext.Create()) {}"));
+			var file = CreateFunction("using (ShimsContext.Create()) {}");
+			VerifyDiagnostic(file);
 		}
 
 		[TestMethod]
 		public void AvoidMsFakesNotRelevantTest()
 		{
-			VerifyNoDiagnostic(CreateFunction("using (new MemoryStream()) {}"));
+			var file = CreateFunction("using (new MemoryStream()) {}");
+			VerifyNoDiagnostic(file);
 		}
 
 

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodNameAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodNameAnalyzerTest.cs
@@ -39,8 +39,10 @@ namespace TestMethodNameAnalyzerTest
 ";
 
 			string givenText = string.Format(baseline, name);
-			string expectedMessage = string.Format(TestMethodNameAnalyzer.MessageFormat, GetPrefix(name));
-			string fixedText = string.Format(baseline, FixName(name));
+			var prefix = GetPrefix(name);
+			string expectedMessage = string.Format(TestMethodNameAnalyzer.MessageFormat, prefix);
+			var fixedName = FixName(name);
+			string fixedText = string.Format(baseline, fixedName);
 
 			DiagnosticResult[] expected = new [] { new DiagnosticResult
 			{

--- a/Philips.CodeAnalysis.Test/Security/AvoidPasswordAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Security/AvoidPasswordAnalyzerTest.cs
@@ -36,7 +36,8 @@ class Foo
 		[DataRow(@"", "//  MyPassword")]
 		public void CheckPasswordTest(string content0, string content1)
 		{
-			string testCode = string.Format(GetTemplate(), content0, content1);
+			var format = GetTemplate();
+			string testCode = string.Format(format, content0, content1);
 			var expected = DiagnosticResultHelper.CreateArray(DiagnosticIds.AvoidPasswordField);
 			VerifyCSharpDiagnostic(testCode, expected);
 		}
@@ -49,7 +50,8 @@ class Foo
 		[DataRow(@"", "//  MyComment")]
 		public void CheckNoPasswordTest(string content0, string content1)
 		{
-			string testCode = string.Format(GetTemplate(), content0, content1);
+			var format = GetTemplate();
+			string testCode = string.Format(format, content0, content1);
 			VerifyCSharpDiagnostic(testCode, Array.Empty<DiagnosticResult>());
 		}
 	}

--- a/Philips.CodeAnalysis.Test/Verifiers/AssertDiagnosticVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/AssertDiagnosticVerifier.cs
@@ -20,13 +20,14 @@ namespace Philips.CodeAnalysis.Test
 		{
 			var test = _helper.GetText(methodBody, string.Empty, string.Empty);
 
-			VerifyCSharpDiagnostic(test, expectedDiagnosticIds.Select(expectedDiagnosticId =>
+			var expected = expectedDiagnosticIds.Select(expectedDiagnosticId =>
 				new DiagnosticResult()
 				{
 					Id = expectedDiagnosticId,
 					Severity = DiagnosticSeverity.Error,
 					Location = new DiagnosticResultLocation("Test0.cs", null, null),
-				}).ToArray());
+				}).ToArray();
+			VerifyCSharpDiagnostic(test, expected);
 		}
 
 		protected void VerifyNoError(string methodBody)

--- a/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
@@ -39,7 +39,8 @@ namespace Philips.CodeAnalysis.Test
 		/// <param name="expected"> DiagnosticResults that should appear after the analyzer is run on the source</param>
 		protected void VerifyCSharpDiagnostic(string source, string filenamePrefix, params DiagnosticResult[] expected)
 		{
-			VerifyDiagnostics(new[] { source }, filenamePrefix, LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), expected);
+			var analyzer = GetCSharpDiagnosticAnalyzer();
+			VerifyDiagnostics(new[] { source }, filenamePrefix, LanguageNames.CSharp, analyzer, expected);
 		}
 
 		/// <summary>
@@ -61,7 +62,8 @@ namespace Philips.CodeAnalysis.Test
 		/// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the source</param>
 		protected void VerifyBasicDiagnostic(string source, params DiagnosticResult[] expected)
 		{
-			VerifyDiagnostics(new[] { source }, null, LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), expected);
+			var analyzer = GetBasicDiagnosticAnalyzer();
+			VerifyDiagnostics(new[] { source }, null, LanguageNames.VisualBasic, analyzer, expected);
 		}
 
 		/// <summary>
@@ -72,7 +74,8 @@ namespace Philips.CodeAnalysis.Test
 		/// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
 		protected void VerifyCSharpDiagnostic(string[] sources, params DiagnosticResult[] expected)
 		{
-			VerifyDiagnostics(sources, null, LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), expected);
+			var analyzer = GetCSharpDiagnosticAnalyzer();
+			VerifyDiagnostics(sources, null, LanguageNames.CSharp, analyzer, expected);
 		}
 
 		/// <summary>
@@ -83,7 +86,8 @@ namespace Philips.CodeAnalysis.Test
 		/// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
 		protected void VerifyBasicDiagnostic(string[] sources, params DiagnosticResult[] expected)
 		{
-			VerifyDiagnostics(sources, null, LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), expected);
+			var analyzer = GetBasicDiagnosticAnalyzer();
+			VerifyDiagnostics(sources, null, LanguageNames.VisualBasic, analyzer, expected);
 		}
 
 		/// <summary>
@@ -117,7 +121,8 @@ namespace Philips.CodeAnalysis.Test
 
 			if (expectedCount != actualCount)
 			{
-				string diagnosticsOutput = actualResults.Any() ? FormatDiagnostics(analyzer, actualResults.ToArray()) : "    NONE.";
+				var diagnostics = actualResults.ToArray();
+				string diagnosticsOutput = actualResults.Any() ? FormatDiagnostics(analyzer, diagnostics) : "    NONE.";
 
 				Assert.IsTrue(false,
 					string.Format("Mismatch between number of diagnostics returned, expected \"{0}\" actual \"{1}\"\r\n\r\nDiagnostics:\r\n{2}\r\n", expectedCount, actualCount, diagnosticsOutput));
@@ -139,7 +144,8 @@ namespace Philips.CodeAnalysis.Test
 				}
 				else
 				{
-					VerifyDiagnosticLocation(analyzer, actual, actual.Location, expected.Locations.First());
+					var first = expected.Locations.First();
+					VerifyDiagnosticLocation(analyzer, actual, actual.Location, first);
 					var additionalLocations = actual.AdditionalLocations.ToArray();
 
 					if (additionalLocations.Length != expected.Locations.Length - 1)
@@ -170,7 +176,8 @@ namespace Philips.CodeAnalysis.Test
 							expected.Severity, actual.Severity, FormatDiagnostics(analyzer, actual)));
 				}
 
-				if (expected.Message != null && !expected.Message.IsMatch(actual.GetMessage()))
+				var input = actual.GetMessage();
+				if (expected.Message != null && !expected.Message.IsMatch(input))
 				{
 					Assert.IsTrue(false,
 						string.Format("Expected diagnostic message to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",


### PR DESCRIPTION
As a chore/refactor, I applied this CodeFixer to our codebase. Identified/implemented a few improvements:

* In addition to excluding ToString, also exclude ToArray and ToList.
* Instead of naming new variable resultOfFoo, if possible to determine from the SemanticModel, name it the name of the callee's parameter.
* Add CodeFixer support for when the violoation is within If and While statements.
