### PR TITLE
feat: Introduce check for informational exceptions

### DIFF
--- a/Philips.CodeAnalysis.Common/DiagnosticIds.cs
+++ b/Philips.CodeAnalysis.Common/DiagnosticIds.cs
@@ -112,5 +112,6 @@ namespace Philips.CodeAnalysis.Common
 		AvoidUnnecessaryWhere = 2117,
 		AvoidMagicNumbers = 2118,
 		DocumentThrownExceptions = 2120,
+		ThrowInformationalExceptions = 2121,
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/DocumentThrownExceptionsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/DocumentThrownExceptionsAnalyzer.cs
@@ -43,6 +43,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 			string thrownExceptionName = null;
 			if(throwStatement.Expression is ObjectCreationExpressionSyntax exceptionCreation)
 			{
+				// Search of string arguments in the constructor invocation.
 				thrownExceptionName = (exceptionCreation.Type as IdentifierNameSyntax)?.Identifier.Text;
 				if(!HasStringArgument(context, exceptionCreation.ArgumentList))
 				{
@@ -104,24 +105,25 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 			const string stringTypeName = "String";
 			return attributeList.Arguments.Any(a =>
 			{
+				SyntaxNode node = null;
 				if (a.Expression is LiteralExpressionSyntax literal)
 				{
-					return context.SemanticModel.GetTypeInfo(literal).Type?.Name == stringTypeName;
+					node = literal;
 				}
 				else if (a.Expression is IdentifierNameSyntax identifierName)
 				{
-					return context.SemanticModel.GetTypeInfo(identifierName).Type?.Name == stringTypeName;
+					node = identifierName;
 				} 
-				else if (a.Expression is MemberAccessExpressionSyntax memberAccess)
-				{
-					return (context.SemanticModel.GetSymbolInfo(memberAccess).Symbol as IMethodSymbol)?.ReturnType.Name == stringTypeName;
-				}
 				else if(a.Expression is InvocationExpressionSyntax invocation)
 				{
-					return context.SemanticModel.GetTypeInfo(invocation).Type?.Name == stringTypeName;
+					node = invocation;
+				}
+				else
+				{
+					return false;
 				}
 
-				return false;
+				return context.SemanticModel.GetTypeInfo(node).Type?.Name == stringTypeName;
 			});
 		}
 	}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -99,6 +99,7 @@
       * Introduce PH2118: Avoid magic numbers.
       * PH2006 now supports folders in namespace
       * Introduce PH2120: Document thrown exceptions.
+      * Introduce PH2121: Throw informational exceptions.
     </PackageReleaseNotes>
 	  <Copyright>© 2019-2023 Koninklijke Philips N.V.</Copyright>
 	  <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -69,4 +69,5 @@
 | PH2116  | Avoid ArrayList                              | Usage of Arraylist is discouraged by Microsoft for performance reasons, use List<T> instead. |
 | PH2117  | Avoid Unnecessary Where()                    | Move the predicate of the Where clause into the Any(), Count(), First(), Last(), or Single() clause |
 | PH2118  | Avoid inline magic numbers                   | Avoid inline magic number, define them as constant or include in an enumeration instead. |
-| PH2120  | Document thrown exceptions                   | Be clear to your callers what exception can be thrown from your method by mentioning each of them in an <exception> element in the documentation of the method |
+| PH2120  | Document thrown exceptions                   | Be clear to your callers what exception can be thrown from your method by mentioning each of them in an <exception> element in the documentation of the method. |
+| PH2121  | Throw informational exceptions               | Specify context to a thrown exception, by using a constructor overload that sets the Message property. |

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/DocumentThrownExceptionsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/DocumentThrownExceptionsAnalyzerTest.cs
@@ -1,9 +1,5 @@
 ﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-
-using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/ThrowInformationalExceptionsTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/ThrowInformationalExceptionsTest.cs
@@ -11,7 +11,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Documentation
 	[TestClass]
 	public class ThrowInformationalExceptionsTest : DiagnosticVerifier
 	{
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new DocumentThrownExceptionsAnalyzer();
 		}
@@ -100,14 +100,14 @@ public class Foo
 		 DataRow(CorrectWithMethod, DisplayName = nameof(CorrectWithMethod))]
 		public void CorrectCodeShouldNotTriggerAnyDiagnostics(string testCode)
 		{
-			VerifyCSharpDiagnostic(testCode);
+			VerifyDiagnostic(testCode);
 		}
 
 		[DataTestMethod]
 		[DataRow(WrongNoArguments, DisplayName = nameof(WrongNoArguments))]
 		public void MissingOrWrongDocumentationShouldTriggerDiagnostic(string testCode)
 		{
-			VerifyCSharpDiagnostic(testCode, DiagnosticResultHelper.Create(DiagnosticIds.ThrowInformationalExceptions));
+			VerifyDiagnostic(testCode, DiagnosticResultHelper.Create(DiagnosticIds.ThrowInformationalExceptions));
 		}
 	}
 }

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/ThrowInformationalExceptionsTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/ThrowInformationalExceptionsTest.cs
@@ -41,6 +41,19 @@ public class Foo
 }
 ";
 
+		private const string CorrectWithMethod = @"
+public class Foo
+{
+    /// <summary> Helpful text. </summary>
+    /// <exception cref=""ArgumentException"">
+    public void MethodA()
+    {
+        throw new ArgumentException(Foo.GetExceptionMessage());
+    }
+    private static string GetExceptionMessage() { return ""Error""; }
+}
+";
+
         private const string CorrectWithLocalVar = @"
 public class Foo
 {
@@ -83,7 +96,8 @@ public class Foo
 		[DataRow(CorrectWithLiteral, DisplayName = nameof(CorrectWithLiteral)),
 		 DataRow(CorrectWithLocalVar, DisplayName = nameof(CorrectWithLocalVar)),
 		 DataRow(CorrectWithNameOf, DisplayName = nameof(CorrectWithNameOf)),
-		 DataRow(CorrectWithProperty, DisplayName = nameof(CorrectWithProperty))]
+		 DataRow(CorrectWithProperty, DisplayName = nameof(CorrectWithProperty)),
+		 DataRow(CorrectWithMethod, DisplayName = nameof(CorrectWithMethod))]
 		public void CorrectCodeShouldNotTriggerAnyDiagnostics(string testCode)
 		{
 			VerifyCSharpDiagnostic(testCode);

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/ThrowInformationalExceptionsTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/ThrowInformationalExceptionsTest.cs
@@ -1,0 +1,99 @@
+﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Philips.CodeAnalysis.Common;
+using Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation;
+
+namespace Philips.CodeAnalysis.Test.Maintainability.Documentation
+{
+	[TestClass]
+	public class ThrowInformationalExceptionsTest : DiagnosticVerifier
+	{
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		{
+			return new DocumentThrownExceptionsAnalyzer();
+		}
+
+		private const string CorrectWithLiteral = @"
+public class Foo
+{
+    /// <summary> Helpful text. </summary>
+    /// <exception cref=""ArgumentException"">
+    public void MethodA()
+    {
+        throw new ArgumentException(""Error"");
+    }
+}
+";
+
+		private const string CorrectWithProperty = @"
+public class Foo
+{
+    /// <summary> Helpful text. </summary>
+    /// <exception cref=""ArgumentException"">
+    public void MethodA()
+    {
+        throw new ArgumentException(ExceptionMessage);
+    }
+    private string ExceptionMessage { get; }
+}
+";
+
+        private const string CorrectWithLocalVar = @"
+public class Foo
+{
+    /// <summary> Helpful text. </summary>
+    /// <exception cref=""ArgumentException"">
+    public void MethodA()
+    {
+        string message = ""Error"";
+        throw new ArgumentException(message);
+    }
+}
+";
+
+        private const string CorrectWithNameOf = @"
+public class Foo
+{
+    /// <summary> Helpful text. </summary>
+    /// <exception cref=""ArgumentException"">
+    public void MethodA(int num)
+    {
+        throw new ArgumentException(nameof(num));
+    }
+}
+";
+
+        private const string WrongNoArguments = @"
+public class Foo
+{
+    /// <summary> Helpful text. </summary>
+    /// <exception cref=""ArgumentException"">
+    public void MethodA()
+    {
+        throw new ArgumentException();
+    }
+}
+";
+
+
+        [DataTestMethod]
+		[DataRow(CorrectWithLiteral, DisplayName = nameof(CorrectWithLiteral)),
+		 DataRow(CorrectWithLocalVar, DisplayName = nameof(CorrectWithLocalVar)),
+		 DataRow(CorrectWithNameOf, DisplayName = nameof(CorrectWithNameOf)),
+		 DataRow(CorrectWithProperty, DisplayName = nameof(CorrectWithProperty))]
+		public void CorrectCodeShouldNotTriggerAnyDiagnostics(string testCode)
+		{
+			VerifyCSharpDiagnostic(testCode);
+		}
+
+		[DataTestMethod]
+		[DataRow(WrongNoArguments, DisplayName = nameof(WrongNoArguments))]
+		public void MissingOrWrongDocumentationShouldTriggerDiagnostic(string testCode)
+		{
+			VerifyCSharpDiagnostic(testCode, DiagnosticResultHelper.Create(DiagnosticIds.ThrowInformationalExceptions));
+		}
+	}
+}


### PR DESCRIPTION
This additional check in the existing `DocumentThrownExceptionsAnalyzer` checks rule [8@108](https://tics.tiobe.com/viewerCS/?ID=111&CSTD=Rule) of the Philips C# Coding Standard