### PR TITLE
chore: Simplify test cde

### DIFF
--- a/Philips.CodeAnalysis.Test/Common/AllowedSymbolsTest.cs
+++ b/Philips.CodeAnalysis.Test/Common/AllowedSymbolsTest.cs
@@ -28,7 +28,7 @@ AllowedMethodName
 ~M:ANamespace.AType.AllowedMethod() // With comment on same line
 ";
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AllowedSymbolsTestAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Common/AllowedSymbolsTest.cs
+++ b/Philips.CodeAnalysis.Test/Common/AllowedSymbolsTest.cs
@@ -102,7 +102,7 @@ AllowedMethodName
 		public void NotAllowedSymbolShouldNotReportDiagnostics(string nsName, string typeName, string methodName)
 		{
 			var file = GenerateCodeFile(nsName, typeName, methodName);
-			VerifyCSharpDiagnostic(file, Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(file, Array.Empty<DiagnosticResult>());
 		}
 
 		private string GenerateCodeFile(string nsName, string typeName, string methodName)
@@ -113,7 +113,7 @@ AllowedMethodName
 
 		private void VerifyDiagnostic(string file)
 		{
-			VerifyCSharpDiagnostic(file,
+			VerifyDiagnostic(file,
 				new DiagnosticResult()
 				{
 					Id = AllowedSymbolsTestAnalyzer.Rule.Id,

--- a/Philips.CodeAnalysis.Test/Common/GeneratedCodeDetectorTest.cs
+++ b/Philips.CodeAnalysis.Test/Common/GeneratedCodeDetectorTest.cs
@@ -94,7 +94,7 @@ namespace Philips.CodeAnalysis.Test.Common
 		}
 		#endregion Helper Analyzer
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidWritingCodeAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Common/GeneratedCodeDetectorTest.cs
+++ b/Philips.CodeAnalysis.Test/Common/GeneratedCodeDetectorTest.cs
@@ -191,7 +191,7 @@ public class Foo
 
 			string input = @"public class Foo { public Foo(); public void Method(int i) { switch(i) { default: break;} } }";
 			DiagnosticResult[] expected = Array.Empty<DiagnosticResult>();
-			VerifyCSharpDiagnostic(input, fileNamePrefix, expected);
+			VerifyDiagnostic(input, fileNamePrefix, expected);
 		}
 
 		[DataRow(@"Foo")]
@@ -203,7 +203,7 @@ public class Foo
 			AvoidWritingCodeAnalyzer.ShouldAnalyzeTree = true;
 			string input = @"public class Foo { }";
 			DiagnosticResult[] expected = new[] { DiagnosticResultHelper.Create(DiagnosticIds.TestMethodName) };
-			VerifyCSharpDiagnostic(input, fileNamePrefix, expected);
+			VerifyDiagnostic(input, fileNamePrefix, expected);
 		}
 	}
 }

--- a/Philips.CodeAnalysis.Test/Common/GeneratedCodeDetectorTest.cs
+++ b/Philips.CodeAnalysis.Test/Common/GeneratedCodeDetectorTest.cs
@@ -121,7 +121,7 @@ public struct MyStruct {}
 public void Method(int i) { switch(i) { default: break;} }
 ";
 			DiagnosticResult[] expected = new[] { DiagnosticResultHelper.Create(DiagnosticIds.TestMethodName) };
-			VerifyCSharpDiagnostic(input, expected);
+			VerifyDiagnostic(input, expected);
 		}
 
 		[TestMethod]
@@ -136,7 +136,7 @@ public class Foo
   public Foo() { }
 }
 ";
-			VerifyCSharpDiagnostic(input);
+			VerifyDiagnostic(input);
 		}
 
 		[TestMethod]
@@ -148,7 +148,7 @@ public class Foo
 [System.CodeDom.Compiler.GeneratedCodeAttribute(""protoc"", null)]
 public struct Foo { }
 ";
-			VerifyCSharpDiagnostic(input);
+			VerifyDiagnostic(input);
 		}
 
 
@@ -173,7 +173,7 @@ public class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(input);
+			VerifyDiagnostic(input);
 		}
 
 

--- a/Philips.CodeAnalysis.Test/DuplicateCode/AvoidDuplicateCodeTest.cs
+++ b/Philips.CodeAnalysis.Test/DuplicateCode/AvoidDuplicateCodeTest.cs
@@ -19,7 +19,7 @@ Foo.AllowedInitializer(Bar)
 Foo.WhitelistedFunction
 ";
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidDuplicateCodeAnalyzer() { DefaultDuplicateTokenThreshold = 100 };
 		}

--- a/Philips.CodeAnalysis.Test/DuplicateCode/AvoidDuplicateCodeTest.cs
+++ b/Philips.CodeAnalysis.Test/DuplicateCode/AvoidDuplicateCodeTest.cs
@@ -352,12 +352,12 @@ class Foo
 
 		private void VerifyNoDiagnostic(string file)
 		{
-			VerifyCSharpDiagnostic(file);
+			base.VerifyDiagnostic(file);
 		}
 
 		private void VerifyDiagnostic(string file)
 		{
-			VerifyCSharpDiagnostic(file,
+			VerifyDiagnostic(file,
 				new DiagnosticResult()
 				{
 					Id = AvoidDuplicateCodeAnalyzer.Rule.Id,

--- a/Philips.CodeAnalysis.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/Philips.CodeAnalysis.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -43,12 +43,11 @@ namespace Philips.CodeAnalysis.Test
 		/// Given classes in the form of strings, their language, and an IDiagnosticAnalyzer to apply to it, return the diagnostics found in the string after converting it to a document.
 		/// </summary>
 		/// <param name="sources">Classes in the form of strings</param>
-		/// <param name="language">The language the source classes are in</param>
 		/// <param name="analyzer">The analyzer to be run on the sources</param>
 		/// <returns>An IEnumerable of Diagnostics that surfaced in the source code, sorted by Location</returns>
-		private Diagnostic[] GetSortedDiagnostics(string[] sources, string filenamePrefix, string language, DiagnosticAnalyzer analyzer)
+		private Diagnostic[] GetSortedDiagnostics(string[] sources, string filenamePrefix, DiagnosticAnalyzer analyzer)
 		{
-			var documents = GetDocuments(sources, filenamePrefix, language);
+			var documents = GetDocuments(sources, filenamePrefix);
 			return GetSortedDiagnosticsFromDocuments(analyzer, documents);
 		}
 
@@ -197,14 +196,9 @@ namespace Philips.CodeAnalysis.Test
 		/// <param name="sources">Classes in the form of strings</param>
 		/// <param name="language">The language the source code is in</param>
 		/// <returns>A Tuple containing the Documents produced from the sources and their TextSpans if relevant</returns>
-		private Document[] GetDocuments(string[] sources, string filenamePrefix, string language)
+		private Document[] GetDocuments(string[] sources, string filenamePrefix)
 		{
-			if (language is not LanguageNames.CSharp and not LanguageNames.VisualBasic)
-			{
-				throw new ArgumentException("Unsupported Language");
-			}
-
-			var project = CreateProject(sources, filenamePrefix, language);
+			var project = CreateProject(sources, filenamePrefix);
 			var documents = project.Documents.ToArray();
 
 			return documents;
@@ -218,7 +212,7 @@ namespace Philips.CodeAnalysis.Test
 		/// <returns>A Document created from the source string</returns>
 		protected Document CreateDocument(string source, string language = LanguageNames.CSharp)
 		{
-			return CreateProject(new[] { source }, language).Documents.First();
+			return CreateProject(new[] { source }).Documents.First();
 		}
 
 		protected virtual MetadataReference[] GetMetadataReferences()
@@ -247,7 +241,7 @@ namespace Philips.CodeAnalysis.Test
 		/// <param name="sources">Classes in the form of strings</param>
 		/// <param name="language">The language the source code is in</param>
 		/// <returns>A Project created out of the Documents created from the source strings</returns>
-		private Project CreateProject(string[] sources, string fileNamePrefix = null, string language = LanguageNames.CSharp)
+		private Project CreateProject(string[] sources, string fileNamePrefix = null)
 		{
 			bool isCustomPrefix = fileNamePrefix != null;
 			fileNamePrefix ??= DefaultFilePathPrefix;

--- a/Philips.CodeAnalysis.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/Philips.CodeAnalysis.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -187,16 +187,16 @@ namespace Philips.CodeAnalysis.Test
 			return diagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToArray();
 		}
 
-		#endregion
+        #endregion
 
-		#region Set up compilation and documents
-		/// <summary>
-		/// Given an array of strings as sources and a language, turn them into a project and return the documents and spans of it.
-		/// </summary>
-		/// <param name="sources">Classes in the form of strings</param>
-		/// <param name="language">The language the source code is in</param>
+        #region Set up compilation and documents
+        /// <summary>
+        /// Given an array of strings as sources and a language, turn them into a project and return the documents and spans of it.
+        /// </summary>
+        /// <param name="sources">Classes in the form of strings</param>
+        /// <param name="filenamePrefix">The name of the source file, without the extension</param>
 		/// <returns>A Tuple containing the Documents produced from the sources and their TextSpans if relevant</returns>
-		private Document[] GetDocuments(string[] sources, string filenamePrefix)
+        private Document[] GetDocuments(string[] sources, string filenamePrefix)
 		{
 			var project = CreateProject(sources, filenamePrefix);
 			var documents = project.Documents.ToArray();
@@ -238,12 +238,12 @@ namespace Philips.CodeAnalysis.Test
 		/// Create a project using the inputted strings as sources.
 		/// </summary>
 		/// <param name="sources">Classes in the form of strings</param>
-		/// <param name="language">The language the source code is in</param>
+		/// <param name="filenamePrefix">The name of the source file, without the extension</param>
 		/// <returns>A Project created out of the Documents created from the source strings</returns>
-		private Project CreateProject(string[] sources, string fileNamePrefix = null)
+		private Project CreateProject(string[] sources, string filenamePrefix = null)
 		{
-			bool isCustomPrefix = fileNamePrefix != null;
-			fileNamePrefix ??= DefaultFilePathPrefix;
+			bool isCustomPrefix = filenamePrefix != null;
+			filenamePrefix ??= DefaultFilePathPrefix;
 			string fileExt = CSharpDefaultFileExt;
 
 			var projectId = ProjectId.CreateNewId(debugName: TestProjectName);
@@ -290,7 +290,7 @@ namespace Philips.CodeAnalysis.Test
 			var additionalSourceCode = GetAdditionalSourceCode();
 			IEnumerable<(string name, string content)> data = sources.Select(x =>
 			{
-				var newFileName = string.Format("{0}{1}.{2}", fileNamePrefix, count == 0 ? (isCustomPrefix ? string.Empty : count.ToString()) : count.ToString(), fileExt);
+				var newFileName = string.Format("{0}{1}.{2}", filenamePrefix, count == 0 ? (isCustomPrefix ? string.Empty : count.ToString()) : count.ToString(), fileExt);
 
 				count++;
 

--- a/Philips.CodeAnalysis.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/Philips.CodeAnalysis.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -208,9 +208,8 @@ namespace Philips.CodeAnalysis.Test
 		/// Create a Document from a string through creating a project that contains it.
 		/// </summary>
 		/// <param name="source">Classes in the form of a string</param>
-		/// <param name="language">The language the source code is in</param>
 		/// <returns>A Document created from the source string</returns>
-		protected Document CreateDocument(string source, string language = LanguageNames.CSharp)
+		protected Document CreateDocument(string source)
 		{
 			return CreateProject(new[] { source }).Documents.First();
 		}

--- a/Philips.CodeAnalysis.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/Philips.CodeAnalysis.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -35,7 +35,6 @@ namespace Philips.CodeAnalysis.Test
 
 		internal static string DefaultFilePathPrefix = "Test";
 		internal static string CSharpDefaultFileExt = "cs";
-		internal static string VisualBasicDefaultExt = "vb";
 		internal static string TestProjectName = "TestProject";
 
 		#region  Get Diagnostics
@@ -252,13 +251,13 @@ namespace Philips.CodeAnalysis.Test
 		{
 			bool isCustomPrefix = fileNamePrefix != null;
 			fileNamePrefix ??= DefaultFilePathPrefix;
-			string fileExt = language == LanguageNames.CSharp ? CSharpDefaultFileExt : VisualBasicDefaultExt;
+			string fileExt = CSharpDefaultFileExt;
 
 			var projectId = ProjectId.CreateNewId(debugName: TestProjectName);
 
 			var solution = new AdhocWorkspace()
 				.CurrentSolution
-				.AddProject(projectId, TestProjectName, TestProjectName, language)
+				.AddProject(projectId, TestProjectName, TestProjectName, LanguageNames.CSharp)
 				.AddMetadataReference(projectId, CorlibReference)
 				.AddMetadataReference(projectId, SystemCoreReference)
 				.AddMetadataReference(projectId, CSharpSymbolsReference)

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/CopyrightPresentAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/CopyrightPresentAnalyzerTest.cs
@@ -116,7 +116,7 @@ class Foo
 				};
 			}
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[TestMethod]
@@ -134,7 +134,7 @@ class Foo
 
 			DiagnosticResult[] expected = new[] { DiagnosticResultHelper.Create(DiagnosticIds.CopyrightPresent) };
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[DataRow(@"")]
@@ -145,7 +145,7 @@ class Foo
 		{
 			DiagnosticResult[] expected = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(text, expected);
+			VerifyDiagnostic(text, expected);
 		}
 
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/CopyrightPresentAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/CopyrightPresentAnalyzerTest.cs
@@ -20,7 +20,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Documentation
 
 		private const string configuredCompanyName = @"Koninklijke Philips N.V.";
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new CopyrightPresentAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/CopyrightPresentAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/CopyrightPresentAnalyzerTest.cs
@@ -191,7 +191,7 @@ using System.Reflection;
 		{
 			DiagnosticResult[] expected = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(text, filenamePrefix, expected);
+			VerifyDiagnostic(text, filenamePrefix, expected);
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/DocumentThrownExceptionsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/DocumentThrownExceptionsAnalyzerTest.cs
@@ -175,7 +175,7 @@ public class Foo
 		 DataRow(CorrectRethrow, DisplayName = nameof(CorrectRethrow))]
 		public void CorrectCodeShouldNotTriggerAnyDiagnostics(string testCode)
 		{
-			VerifyCSharpDiagnostic(testCode);
+			VerifyDiagnostic(testCode);
 		}
 
 		[DataTestMethod]
@@ -187,7 +187,7 @@ public class Foo
 		 DataRow(WrongRethrow, DisplayName = nameof(WrongRethrow))]
 		public void MissingOrWrongDocumentationShouldTriggerDiagnostic(string testCode)
 		{
-			VerifyCSharpDiagnostic(testCode, DiagnosticResultHelper.Create(DiagnosticIds.DocumentThrownExceptions));
+			VerifyDiagnostic(testCode, DiagnosticResultHelper.Create(DiagnosticIds.DocumentThrownExceptions));
 		}
 	}
 }

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/DocumentThrownExceptionsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/DocumentThrownExceptionsAnalyzerTest.cs
@@ -15,7 +15,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Documentation
 	[TestClass]
 	public class DocumentThrownExceptionsAnalyzerTest : DiagnosticVerifier
 	{
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new DocumentThrownExceptionsAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/OrderPropertyAccessorsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/OrderPropertyAccessorsAnalyzerTest.cs
@@ -14,7 +14,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Documentation
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new OrderPropertyAccessorsAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/OrderPropertyAccessorsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/OrderPropertyAccessorsAnalyzerTest.cs
@@ -40,7 +40,7 @@ public class TestClass
 }}
 ";
 
-			VerifyCSharpDiagnostic(text, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.OrderPropertyAccessors) : Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(text, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.OrderPropertyAccessors) : Array.Empty<DiagnosticResult>());
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/XmlDocumentationShouldAddValueAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/XmlDocumentationShouldAddValueAnalyzerTest.cs
@@ -21,7 +21,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Documentation
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new XmlDocumentationShouldAddValueAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/XmlDocumentationShouldAddValueAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/XmlDocumentationShouldAddValueAnalyzerTest.cs
@@ -315,7 +315,7 @@ public class TestClass
 
 			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.CreateArray(DiagnosticIds.EmptyXmlComments));
 
-			VerifyCSharpFix(errorContent, fixedContent);
+			VerifyFix(errorContent, fixedContent);
 		}
 
 		[DataRow("event System.EventHandler Foo;")]
@@ -342,7 +342,7 @@ public class TestClass
 
 			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.CreateArray(DiagnosticIds.XmlDocumentationShouldAddValue));
 
-			VerifyCSharpFix(errorContent, fixedContent);
+			VerifyFix(errorContent, fixedContent);
 		}
 
 		[TestMethod]

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/XmlDocumentationShouldAddValueAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/XmlDocumentationShouldAddValueAnalyzerTest.cs
@@ -55,7 +55,7 @@ public class Foo
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, DiagnosticResultHelper.CreateArray(DiagnosticIds.EmptyXmlComments));
+			VerifyDiagnostic(content, DiagnosticResultHelper.CreateArray(DiagnosticIds.EmptyXmlComments));
 		}
 
 		[TestMethod]
@@ -68,7 +68,7 @@ public class Foo
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, DiagnosticResultHelper.CreateArray(DiagnosticIds.EmptyXmlComments));
+			VerifyDiagnostic(content, DiagnosticResultHelper.CreateArray(DiagnosticIds.EmptyXmlComments));
 		}
 
 		[TestMethod]
@@ -84,7 +84,7 @@ public class TestClass
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, DiagnosticResultHelper.CreateArray(DiagnosticIds.EmptyXmlComments));
+			VerifyDiagnostic(content, DiagnosticResultHelper.CreateArray(DiagnosticIds.EmptyXmlComments));
 		}
 
 		[TestMethod]
@@ -98,7 +98,7 @@ public class TestClass
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, DiagnosticResultHelper.CreateArray(DiagnosticIds.EmptyXmlComments));
+			VerifyDiagnostic(content, DiagnosticResultHelper.CreateArray(DiagnosticIds.EmptyXmlComments));
 		}
 
 		[TestMethod]
@@ -112,7 +112,7 @@ public class TestClass
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, DiagnosticResultHelper.CreateArray(DiagnosticIds.EmptyXmlComments));
+			VerifyDiagnostic(content, DiagnosticResultHelper.CreateArray(DiagnosticIds.EmptyXmlComments));
 		}
 
 		[TestMethod]
@@ -126,7 +126,7 @@ public class TestClass
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, DiagnosticResultHelper.CreateArray(DiagnosticIds.EmptyXmlComments));
+			VerifyDiagnostic(content, DiagnosticResultHelper.CreateArray(DiagnosticIds.EmptyXmlComments));
 		}
 
 		[TestMethod]
@@ -140,7 +140,7 @@ public enum TestEnumeration
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, DiagnosticResultHelper.CreateArray(DiagnosticIds.EmptyXmlComments));
+			VerifyDiagnostic(content, DiagnosticResultHelper.CreateArray(DiagnosticIds.EmptyXmlComments));
 		}
 
 		[DataRow("foo", true)]
@@ -159,7 +159,7 @@ public class Foo
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.XmlDocumentationShouldAddValue) : Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(content, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.XmlDocumentationShouldAddValue) : Array.Empty<DiagnosticResult>());
 		}
 
 		[DataRow("foo", true)]
@@ -184,7 +184,7 @@ public class TestClass
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.XmlDocumentationShouldAddValue) : Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(content, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.XmlDocumentationShouldAddValue) : Array.Empty<DiagnosticResult>());
 		}
 
 		[DataRow("foo", true)]
@@ -210,7 +210,7 @@ public class TestClass
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.XmlDocumentationShouldAddValue) : Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(content, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.XmlDocumentationShouldAddValue) : Array.Empty<DiagnosticResult>());
 		}
 
 
@@ -231,7 +231,7 @@ public class TestClass
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.XmlDocumentationShouldAddValue) : Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(content, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.XmlDocumentationShouldAddValue) : Array.Empty<DiagnosticResult>());
 		}
 
 		[DataRow("On Foo", true)]
@@ -252,7 +252,7 @@ public class TestClass
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.XmlDocumentationShouldAddValue) : Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(content, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.XmlDocumentationShouldAddValue) : Array.Empty<DiagnosticResult>());
 		}
 
 		[DataRow("On Foo", true)]
@@ -269,7 +269,7 @@ public enum Foo
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.XmlDocumentationShouldAddValue) : Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(content, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.XmlDocumentationShouldAddValue) : Array.Empty<DiagnosticResult>());
 		}
 
 		[DataRow("On Foo", true)]
@@ -286,7 +286,7 @@ public enum TestEnumeration
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.XmlDocumentationShouldAddValue) : Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(content, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.XmlDocumentationShouldAddValue) : Array.Empty<DiagnosticResult>());
 		}
 
 		[DataRow("event System.EventHandler Foo;")]
@@ -313,7 +313,7 @@ public class TestClass
 }}
 ";
 
-			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.CreateArray(DiagnosticIds.EmptyXmlComments));
+			VerifyDiagnostic(errorContent, DiagnosticResultHelper.CreateArray(DiagnosticIds.EmptyXmlComments));
 
 			VerifyFix(errorContent, fixedContent);
 		}
@@ -340,7 +340,7 @@ public class TestClass
 }}
 ";
 
-			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.CreateArray(DiagnosticIds.XmlDocumentationShouldAddValue));
+			VerifyDiagnostic(errorContent, DiagnosticResultHelper.CreateArray(DiagnosticIds.XmlDocumentationShouldAddValue));
 
 			VerifyFix(errorContent, fixedContent);
 		}
@@ -359,7 +359,7 @@ public class TestClass
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(content, Array.Empty<DiagnosticResult>());
 		}
 
 		[TestMethod]
@@ -378,7 +378,7 @@ public class TestClass
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(content, Array.Empty<DiagnosticResult>());
 		}
 
 		[TestMethod]
@@ -396,7 +396,7 @@ public class Foo
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, DiagnosticResultHelper.CreateArray(DiagnosticIds.XmlDocumentationShouldAddValue));
+			VerifyDiagnostic(content, DiagnosticResultHelper.CreateArray(DiagnosticIds.XmlDocumentationShouldAddValue));
 		}
 		#endregion
 	}

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/XmlDocumentationShouldAddValueAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/XmlDocumentationShouldAddValueAnalyzerTest.cs
@@ -26,7 +26,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Documentation
 			return new XmlDocumentationShouldAddValueAnalyzer();
 		}
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new XmlDocumentationCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AlignOperatorsCountAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AlignOperatorsCountAnalyzerTest.cs
@@ -234,7 +234,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		[DataRow("File.g", DisplayName = "OutOfScopeSourceFile")]
 		public void WhenSourceFileIsOutOfScopeNoDiagnosticIsTriggered(string filePath)
 		{
-			VerifyCSharpDiagnostic(WrongNumberOfPlusMinus, filePath);
+			VerifyDiagnostic(WrongNumberOfPlusMinus, filePath);
 		}
 
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer() {

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AlignOperatorsCountAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AlignOperatorsCountAnalyzerTest.cs
@@ -208,7 +208,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		 DataRow(CorrectNumberOfRightLeftShift, DisplayName = nameof(CorrectNumberOfRightLeftShift))]
 		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
 		{
-			VerifyCSharpDiagnostic(testCode);
+			VerifyDiagnostic(testCode);
 		}
 
 		/// <summary>
@@ -224,7 +224,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		 DataRow(WrongNumberOfRightLeftShift, DiagnosticIds.AlignNumberOfShiftRightAndLeftOperators, DisplayName = nameof(WrongNumberOfRightLeftShift))]
 		public void WhenMismatchOfPlusMinusDiagnosticIsRaised(string testCode, DiagnosticIds diagnosticId) {
 			var expected = DiagnosticResultHelper.Create(diagnosticId);
-			VerifyCSharpDiagnostic(testCode, expected);
+			VerifyDiagnostic(testCode, expected);
 		}
 
 		/// <summary>

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AlignOperatorsCountAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AlignOperatorsCountAnalyzerTest.cs
@@ -237,7 +237,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 			VerifyCSharpDiagnostic(WrongNumberOfPlusMinus, filePath);
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() {
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer() {
 			return new AlignOperatorsCountAnalyzer();
 		}
 	}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidArrayListAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidArrayListAnalyzerTest.cs
@@ -116,7 +116,7 @@ namespace AvoidArrayListTests {
 			return new AvoidArrayListAnalyzer();
 		}
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new AvoidArrayListCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidArrayListAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidArrayListAnalyzerTest.cs
@@ -98,7 +98,7 @@ namespace AvoidArrayListTests {
 			VerifyCSharpDiagnostic(testCode, expected);
 			if (fixedCode != null)
 			{
-				VerifyCSharpFix(testCode, fixedCode, allowNewCompilerDiagnostics:true);
+				VerifyFix(testCode, fixedCode, allowNewCompilerDiagnostics:true);
 			}
 		}
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidArrayListAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidArrayListAnalyzerTest.cs
@@ -112,7 +112,7 @@ namespace AvoidArrayListTests {
 			VerifyCSharpDiagnostic(WrongLocal, filePath);
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() {
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer() {
 			return new AvoidArrayListAnalyzer();
 		}
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidArrayListAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidArrayListAnalyzerTest.cs
@@ -83,7 +83,7 @@ namespace AvoidArrayListTests {
 		 DataRow(CorrectLocal, DisplayName = nameof(CorrectLocal))]
 		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
 		{
-			VerifyCSharpDiagnostic(testCode);
+			VerifyDiagnostic(testCode);
 		}
 
 		/// <summary>
@@ -95,7 +95,7 @@ namespace AvoidArrayListTests {
 		 DataRow(WrongLocal, FixedLocal, DisplayName = nameof(WrongLocal))]
 		public void WhenMismatchOfPlusMinusDiagnosticIsRaised(string testCode, string fixedCode) {
 			var expected = DiagnosticResultHelper.Create(DiagnosticIds.AvoidArrayList);
-			VerifyCSharpDiagnostic(testCode, expected);
+			VerifyDiagnostic(testCode, expected);
 			if (fixedCode != null)
 			{
 				VerifyFix(testCode, fixedCode, allowNewCompilerDiagnostics:true);

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidArrayListAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidArrayListAnalyzerTest.cs
@@ -109,7 +109,7 @@ namespace AvoidArrayListTests {
 		[DataRow("File.g", DisplayName = "OutOfScopeSourceFile")]
 		public void WhenSourceFileIsOutOfScopeNoDiagnosticIsTriggered(string filePath)
 		{
-			VerifyCSharpDiagnostic(WrongLocal, filePath);
+			VerifyDiagnostic(WrongLocal, filePath);
 		}
 
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer() {

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidAssignmentInConditionAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidAssignmentInConditionAnalyzerTest.cs
@@ -147,7 +147,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 			VerifyCSharpDiagnostic(Violation, filePath);
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() {
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer() {
 			return new AvoidAssignmentInConditionAnalyzer();
 		}
 	}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidAssignmentInConditionAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidAssignmentInConditionAnalyzerTest.cs
@@ -144,7 +144,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		[DataRow("File.g", DisplayName = "OutOfScopeSourceFile")]
 		public void WhenSourceFileIsOutOfScopeNoDiagnosticIsTriggered(string filePath)
 		{
-			VerifyCSharpDiagnostic(Violation, filePath);
+			VerifyDiagnostic(Violation, filePath);
 		}
 
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer() {

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidAssignmentInConditionAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidAssignmentInConditionAnalyzerTest.cs
@@ -123,7 +123,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		 DataRow(CorrectNullCoalescing, DisplayName = "CorrectNullCoalescing")]
 		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
 		{
-			VerifyCSharpDiagnostic(testCode);
+			VerifyDiagnostic(testCode);
 		}
 
 		/// <summary>
@@ -134,7 +134,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		 DataRow(ViolationTernary, DisplayName = "ViolationTernary")]
 		public void WhenDoingAssignmentInsideConditionDiagnosticIsRaised(string testCode) {
 			var expected = DiagnosticResultHelper.Create(DiagnosticIds.AvoidAssignmentInCondition);
-			VerifyCSharpDiagnostic(testCode, expected);
+			VerifyDiagnostic(testCode, expected);
 		}
 
 		/// <summary>

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidAsyncVoidAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidAsyncVoidAnalyzerTest.cs
@@ -135,7 +135,7 @@ class FooClass
 			throw new NotImplementedException();
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidAsyncVoidAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidAsyncVoidAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidAsyncVoidAnalyzerTest.cs
@@ -27,7 +27,7 @@ public class Tests
 	public {(isAsync ? "async" : string.Empty)} {returnType} Foo() {{ throw new Exception(); }}
 }}";
 
-			VerifyCSharpDiagnostic(code, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.AvoidAsyncVoid) : Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(code, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.AvoidAsyncVoid) : Array.Empty<DiagnosticResult>());
 		}
 
 
@@ -56,7 +56,7 @@ public class MyEventArgs : EventArgs
 }}}}
 ";
 
-			VerifyCSharpDiagnostic(correctTemplate, Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(correctTemplate, Array.Empty<DiagnosticResult>());
 		}
 
 		[TestMethod]
@@ -74,7 +74,7 @@ class FooClass
 }}}}
 ";
 
-			VerifyCSharpDiagnostic(correctTemplate, DiagnosticResultHelper.Create(DiagnosticIds.AvoidAsyncVoid));
+			VerifyDiagnostic(correctTemplate, DiagnosticResultHelper.Create(DiagnosticIds.AvoidAsyncVoid));
 		}
 
 		[TestMethod]
@@ -92,7 +92,7 @@ class FooClass
 }}}}
 ";
 
-			VerifyCSharpDiagnostic(correctTemplate, Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(correctTemplate, Array.Empty<DiagnosticResult>());
 		}
 
 		[DataRow(false, "Action<int> action = x => {{ Task.Yield(); return 4; }}")]
@@ -121,11 +121,11 @@ class FooClass
 ";
 			if (isError)
 			{
-				VerifyCSharpDiagnostic(correctTemplate, DiagnosticResultHelper.Create(DiagnosticIds.AvoidAsyncVoid));
+				VerifyDiagnostic(correctTemplate, DiagnosticResultHelper.Create(DiagnosticIds.AvoidAsyncVoid));
 			}
 			else
 			{
-				VerifyCSharpDiagnostic(correctTemplate);
+				VerifyDiagnostic(correctTemplate);
 			}
 		}
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidAsyncVoidAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidAsyncVoidAnalyzerTest.cs
@@ -130,7 +130,7 @@ class FooClass
 		}
 
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			throw new NotImplementedException();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidEmptyStatementBlockAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidEmptyStatementBlockAnalyzerTest.cs
@@ -68,7 +68,7 @@ class Foo
 ";
 
 			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidEmptyStatement));
-			VerifyCSharpFix(template, fixedCode);
+			VerifyFix(template, fixedCode);
 		}
 
 		[TestMethod]

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidEmptyStatementBlockAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidEmptyStatementBlockAnalyzerTest.cs
@@ -15,7 +15,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		{
 			return new AvoidEmptyStatementBlocksAnalyzer();
 		}
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new AvoidEmptyStatementBlocksCodeFixProvider();
 		}
@@ -23,7 +23,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		[TestMethod]
 		public void FixAllProviderTest()
 		{
-			Assert.AreEqual(WellKnownFixAllProviders.BatchFixer, GetCSharpCodeFixProvider().GetFixAllProvider());
+			Assert.AreEqual(WellKnownFixAllProviders.BatchFixer, GetCodeFixProvider().GetFixAllProvider());
 		}
 
 		[TestMethod]

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidEmptyStatementBlockAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidEmptyStatementBlockAnalyzerTest.cs
@@ -11,7 +11,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 	[TestClass]
 	public class AvoidEmptyStatementBlockAnalyzerTest : CodeFixVerifier
 	{
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidEmptyStatementBlocksAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidEmptyStatementBlockAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidEmptyStatementBlockAnalyzerTest.cs
@@ -39,7 +39,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidEmptyStatementBlock));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidEmptyStatementBlock));
 
 		}
 
@@ -67,7 +67,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidEmptyStatement));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidEmptyStatement));
 			VerifyFix(template, fixedCode);
 		}
 
@@ -88,7 +88,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidEmptyStatementBlock));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidEmptyStatementBlock));
 		}
 
 		[TestMethod]
@@ -104,7 +104,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidEmptyStatementBlock));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidEmptyStatementBlock));
 
 
 		}
@@ -123,7 +123,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 
 
 
@@ -141,7 +141,7 @@ class Foo
 	{ }
 }
 ";
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 		[TestMethod]
@@ -157,7 +157,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidEmptyStatementBlock));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidEmptyStatementBlock));
 		}
 
 		[TestMethod]
@@ -179,7 +179,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidEmptyCatchBlock));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidEmptyCatchBlock));
 		}
 
 
@@ -196,7 +196,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 
@@ -213,7 +213,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 
@@ -231,7 +231,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 		[TestMethod]
@@ -249,7 +249,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 		[TestMethod]
@@ -267,7 +267,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 
@@ -285,7 +285,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidEmptyStatementBlock));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidEmptyStatementBlock));
 		}
 
 	}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidEmptyTypeInitializerAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidEmptyTypeInitializerAnalyzerTest.cs
@@ -106,7 +106,7 @@ static Foo() {{ }}", summaryComment));
 			return new AvoidEmptyTypeInitializerCodeFixProvider();
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidEmptyTypeInitializer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidEmptyTypeInitializerAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidEmptyTypeInitializerAnalyzerTest.cs
@@ -101,7 +101,7 @@ static Foo() {{ }}", summaryComment));
 			VerifyCSharpFix(classContent, expected);
 		}
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new AvoidEmptyTypeInitializerCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidEmptyTypeInitializerAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidEmptyTypeInitializerAnalyzerTest.cs
@@ -37,7 +37,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 
 			DiagnosticResult[] results = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(classContent, results);
+			VerifyDiagnostic(classContent, results);
 		}
 
 		[DataRow("static", "", true)]
@@ -77,7 +77,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 				results = Array.Empty<DiagnosticResult>();
 			}
 
-			VerifyCSharpDiagnostic(classContent, results);
+			VerifyDiagnostic(classContent, results);
 		}
 
 		[DataRow("  /// <summary />")]

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidEmptyTypeInitializerAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidEmptyTypeInitializerAnalyzerTest.cs
@@ -98,7 +98,7 @@ static Foo() {{ }}", summaryComment));
 
 			string expected = string.Format(template, "  \r\n");
 
-			VerifyCSharpFix(classContent, expected);
+			VerifyFix(classContent, expected);
 		}
 
 		protected override CodeFixProvider GetCodeFixProvider()

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidInvocationAsArgumentTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidInvocationAsArgumentTest.cs
@@ -55,7 +55,7 @@ class Foo
 					}
 				};
 
-			VerifyCSharpDiagnostic(template, results);
+			VerifyDiagnostic(template, results);
 		}
 
 		[TestMethod]
@@ -87,7 +87,7 @@ class Foo
   }}
 }}
 ";
-			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
+			VerifyDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
 			VerifyFix(errorContent, fixedContent);
 		}
 
@@ -118,7 +118,7 @@ class Foo
   }}
 }}
 ";
-			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
+			VerifyDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
 			VerifyFix(errorContent, fixedContent);
 		}
 
@@ -149,7 +149,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
+			VerifyDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
 			VerifyFix(errorContent, fixedContent);
 		}
 
@@ -182,7 +182,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
+			VerifyDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
 			VerifyFix(errorContent, fixedContent);
 		}
 
@@ -215,7 +215,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
+			VerifyDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
 			VerifyFix(errorContent, fixedContent);
 		}
 
@@ -246,7 +246,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
+			VerifyDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
 			VerifyFix(errorContent, fixedContent);
 		}
 
@@ -277,7 +277,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
+			VerifyDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
 			VerifyFix(errorContent, fixedContent);
 		}
 
@@ -310,7 +310,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
+			VerifyDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
 			VerifyFix(errorContent, fixedContent);
 		}
 
@@ -344,7 +344,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
+			VerifyDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
 			VerifyFix(errorContent, fixedContent);
 		}
 
@@ -378,7 +378,7 @@ class Foo
   }
 }
 ";
-			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
+			VerifyDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
 			VerifyFix(errorContent, fixedContent);
 		}
 
@@ -408,7 +408,7 @@ class Foo
   }
 }
 ";
-			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
+			VerifyDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
 			VerifyFix(errorContent, fixedContent);
 		}
 
@@ -447,7 +447,7 @@ class Foo
   }
 }
 ";
-			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
+			VerifyDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
 			VerifyFix(errorContent, fixedContent);
 		}
 
@@ -464,7 +464,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
+			VerifyDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
 			//VerifyFix(errorContent, fixedContent);
 		}
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidInvocationAsArgumentTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidInvocationAsArgumentTest.cs
@@ -473,7 +473,7 @@ class Foo
 			return new AvoidInvocationAsArgumentCodeFixProvider();
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
         {
             return new AvoidInvocationAsArgumentAnalyzer();
         }

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidInvocationAsArgumentTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidInvocationAsArgumentTest.cs
@@ -468,7 +468,7 @@ class Foo
 			//VerifyCSharpFix(errorContent, fixedContent);
 		}
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new AvoidInvocationAsArgumentCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidInvocationAsArgumentTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidInvocationAsArgumentTest.cs
@@ -88,7 +88,7 @@ class Foo
 }}
 ";
 			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
-			VerifyCSharpFix(errorContent, fixedContent);
+			VerifyFix(errorContent, fixedContent);
 		}
 
 		[TestMethod]
@@ -119,7 +119,7 @@ class Foo
 }}
 ";
 			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
-			VerifyCSharpFix(errorContent, fixedContent);
+			VerifyFix(errorContent, fixedContent);
 		}
 
 		[TestMethod]
@@ -150,7 +150,7 @@ class Foo
 ";
 
 			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
-			VerifyCSharpFix(errorContent, fixedContent);
+			VerifyFix(errorContent, fixedContent);
 		}
 
 		[TestMethod]
@@ -183,7 +183,7 @@ class Foo
 ";
 
 			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
-			VerifyCSharpFix(errorContent, fixedContent);
+			VerifyFix(errorContent, fixedContent);
 		}
 
 		[TestMethod]
@@ -216,7 +216,7 @@ class Foo
 ";
 
 			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
-			VerifyCSharpFix(errorContent, fixedContent);
+			VerifyFix(errorContent, fixedContent);
 		}
 
 		[TestMethod]
@@ -247,7 +247,7 @@ class Foo
 ";
 
 			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
-			VerifyCSharpFix(errorContent, fixedContent);
+			VerifyFix(errorContent, fixedContent);
 		}
 
 		[TestMethod]
@@ -278,7 +278,7 @@ class Foo
 ";
 
 			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
-			VerifyCSharpFix(errorContent, fixedContent);
+			VerifyFix(errorContent, fixedContent);
 		}
 
 		[TestMethod]
@@ -311,7 +311,7 @@ class Foo
 ";
 
 			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
-			VerifyCSharpFix(errorContent, fixedContent);
+			VerifyFix(errorContent, fixedContent);
 		}
 
 
@@ -345,7 +345,7 @@ class Foo
 ";
 
 			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
-			VerifyCSharpFix(errorContent, fixedContent);
+			VerifyFix(errorContent, fixedContent);
 		}
 
 		[TestMethod]
@@ -379,7 +379,7 @@ class Foo
 }
 ";
 			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
-			VerifyCSharpFix(errorContent, fixedContent);
+			VerifyFix(errorContent, fixedContent);
 		}
 
 		[TestMethod]
@@ -409,7 +409,7 @@ class Foo
 }
 ";
 			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
-			VerifyCSharpFix(errorContent, fixedContent);
+			VerifyFix(errorContent, fixedContent);
 		}
 
 		[TestMethod]
@@ -448,7 +448,7 @@ class Foo
 }
 ";
 			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
-			VerifyCSharpFix(errorContent, fixedContent);
+			VerifyFix(errorContent, fixedContent);
 		}
 
 		[TestMethod]
@@ -465,7 +465,7 @@ class Foo
 ";
 
 			VerifyCSharpDiagnostic(errorContent, DiagnosticResultHelper.Create(DiagnosticIds.AvoidInvocationAsArgument));
-			//VerifyCSharpFix(errorContent, fixedContent);
+			//VerifyFix(errorContent, fixedContent);
 		}
 
 		protected override CodeFixProvider GetCodeFixProvider()

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidMagicNumbersAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidMagicNumbersAnalyzerTest.cs
@@ -173,7 +173,7 @@ namespace DontUseMagicNumbersTests {
 		[DataRow("File.g", DisplayName = "OutOfScopeSourceFile")]
 		public void WhenSourceFileIsOutOfScopeNoDiagnosticIsTriggered(string filePath)
 		{
-			VerifyCSharpDiagnostic(WrongLocal, filePath);
+			VerifyDiagnostic(WrongLocal, filePath);
 		}
 
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer() {

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidMagicNumbersAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidMagicNumbersAnalyzerTest.cs
@@ -176,7 +176,7 @@ namespace DontUseMagicNumbersTests {
 			VerifyCSharpDiagnostic(WrongLocal, filePath);
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() {
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer() {
 			return new AvoidMagicNumbersAnalyzer();
 		}
 	}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidMagicNumbersAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidMagicNumbersAnalyzerTest.cs
@@ -150,7 +150,7 @@ namespace DontUseMagicNumbersTests {
 		 DataRow(CorrectInEnum, DisplayName = nameof(CorrectInEnum))]
 		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
 		{
-			VerifyCSharpDiagnostic(testCode);
+			VerifyDiagnostic(testCode);
 		}
 
 		/// <summary>
@@ -163,7 +163,7 @@ namespace DontUseMagicNumbersTests {
 		 DataRow(WrongPropertyInitializer, DisplayName = nameof(WrongPropertyInitializer))]
 		public void WhenMismatchOfPlusMinusDiagnosticIsRaised(string testCode) {
 			var expected = DiagnosticResultHelper.Create(DiagnosticIds.AvoidMagicNumbers);
-			VerifyCSharpDiagnostic(testCode, expected);
+			VerifyDiagnostic(testCode, expected);
 		}
 
 		/// <summary>

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidOverrideWithNewKeywordAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidOverrideWithNewKeywordAnalyzerTest.cs
@@ -82,7 +82,7 @@ namespace MultiLineConditionUnitTests
 		public void OverrideVirtualDoesNotTriggersDiagnostics(string input)
 		{
 
-			VerifyCSharpDiagnostic(input);
+			VerifyDiagnostic(input);
 		}
 
 		[DataTestMethod]
@@ -92,7 +92,7 @@ namespace MultiLineConditionUnitTests
 		{
 			var expected = DiagnosticResultHelper.Create(DiagnosticIds.AvoidOverridingWithNewKeyword,
 				new Regex("Avoid overriding Virtual.* with the new keyword."));
-			VerifyCSharpDiagnostic(input, expected);
+			VerifyDiagnostic(input, expected);
 		}
 
 		/// <summary>

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidOverrideWithNewKeywordAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidOverrideWithNewKeywordAnalyzerTest.cs
@@ -102,7 +102,7 @@ namespace MultiLineConditionUnitTests
 		[DataRow(WrongMethod, "Dummy.Designer", DisplayName = "OutOfScopeSourceFile")]
 		public void WhenSourceFileIsOutOfScopeNoDiagnosticIsTriggered(string testCode, string filePath)
 		{
-			VerifyCSharpDiagnostic(testCode, filePath);
+			VerifyDiagnostic(testCode, filePath);
 		}
 	}
 }

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidOverrideWithNewKeywordAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidOverrideWithNewKeywordAnalyzerTest.cs
@@ -11,7 +11,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 	[TestClass]
 	public class AvoidOverridingWithNewKeywordAnalyzerTest : DiagnosticVerifier
 	{
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidOverridingWithNewKeywordAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidPragmaAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidPragmaAnalyzerTest.cs
@@ -72,7 +72,7 @@ class Foo
 ";
 			string givenText = string.Format(baseline, test);
 
-			VerifyCSharpDiagnostic(givenText, "Test.Designer");
+			VerifyDiagnostic(givenText, "Test.Designer");
 		}
 
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidPragmaAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidPragmaAnalyzerTest.cs
@@ -76,7 +76,7 @@ class Foo
 		}
 
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidPragmaAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidPragmaAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidPragmaAnalyzerTest.cs
@@ -38,7 +38,7 @@ class Foo
 				}
 			};
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[TestMethod]
@@ -54,7 +54,7 @@ class Foo
   }}
 }}
 ";
-			VerifyCSharpDiagnostic(text);
+			VerifyDiagnostic(text);
 		}
 
 		[DataTestMethod]

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidPrivateKeyPropertyAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidPrivateKeyPropertyAnalyzerTest.cs
@@ -72,7 +72,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 				}
 			};
 
-			VerifyCSharpDiagnostic(code, expected);
+			VerifyDiagnostic(code, expected);
 		}
 		#endregion
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidPrivateKeyPropertyAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidPrivateKeyPropertyAnalyzerTest.cs
@@ -40,7 +40,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		}
 
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidPrivateKeyPropertyAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidPublicMemberVariableAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidPublicMemberVariableAnalyzerTest.cs
@@ -19,7 +19,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidPublicMemberVariableAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidPublicMemberVariableAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidPublicMemberVariableAnalyzerTest.cs
@@ -65,7 +65,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 			{
 				results = Array.Empty<DiagnosticResult>();
 			}
-			VerifyCSharpDiagnostic(classContent, results);
+			VerifyDiagnostic(classContent, results);
 
 		}
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidStaticClassAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidStaticClassAnalyzerTest.cs
@@ -15,7 +15,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 	{
 		private readonly Mock<AvoidStaticClassesAnalyzer> _mock = new() { CallBase = true };
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return _mock.Object;
 		}
@@ -50,7 +50,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidStaticClassesAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidStaticClassAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidStaticClassAnalyzerTest.cs
@@ -129,12 +129,12 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 
 		protected void VerifyNoDiagnostic(string file)
 		{
-			VerifyCSharpDiagnostic(file);
+			base.VerifyDiagnostic(file);
 		}
 
 		private void VerifyDiagnostic(string file)
 		{
-			VerifyCSharpDiagnostic(file, new DiagnosticResult()
+			VerifyDiagnostic(file, new DiagnosticResult()
 			{
 				Id = AvoidStaticClassesAnalyzer.Rule.Id,
 				Message = new Regex(".+"),

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidStaticMethodAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidStaticMethodAnalyzerTest.cs
@@ -76,28 +76,28 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		public void AllowExternalCode()
 		{
 			string template = CreateFunction("static", externKeyword: "extern");
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 		[TestMethod]
 		public void IgnoreIfInStaticClass()
 		{
 			string template = CreateFunction("static", classStaticModifier: "static");
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 		[TestMethod]
 		public void OnlyCatchStaticMethods()
 		{
 			string template = CreateFunction("");
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 		[TestMethod]
 		public void AllowStaticMainMethod()
 		{
 			string template = CreateFunction("static", methodName: "Main");
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 		[TestMethod]
@@ -105,35 +105,35 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		{
 			string template = CreateFunction("static", localMethodModifier: "static");
 			// should still catch the local static method being used
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidStaticMethods));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidStaticMethods));
 		}
 
 		[TestMethod]
 		public void CatchIfUsesForeignStaticMethod()
 		{
 			string template = CreateFunction("static", foreignMethodModifier: "static");
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidStaticMethods));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidStaticMethods));
 		}
 
 		[TestMethod]
 		public void AllowStaticFactoryMethod()
 		{
 			string template = CreateFunction("static", factoryMethod: true);
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 		[TestMethod]
 		public void AllowStaticDynamicDataMethod()
 		{
 			string template = CreateFunction("static", returnType: "IEnumerable<object[]>");
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 		[TestMethod]
 		public void CatchPlainStaticMethod()
 		{
 			string template = CreateFunction("static");
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidStaticMethods));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidStaticMethods));
 
 			string fixedCode = CreateFunction(@"");
 			VerifyFix(template, fixedCode);

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidStaticMethodAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidStaticMethodAnalyzerTest.cs
@@ -14,7 +14,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 	[TestClass]
 	public class AvoidStaticMethodAnalyzerTest : CodeFixVerifier
 	{
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidStaticMethodAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidStaticMethodAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidStaticMethodAnalyzerTest.cs
@@ -19,7 +19,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 			return new AvoidStaticMethodAnalyzer();
 		}
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new AvoidStaticMethodCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidStaticMethodAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidStaticMethodAnalyzerTest.cs
@@ -136,7 +136,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.AvoidStaticMethods));
 
 			string fixedCode = CreateFunction(@"");
-			VerifyCSharpFix(template, fixedCode);
+			VerifyFix(template, fixedCode);
 		}
 	}
 }

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidSuppressMessageAttributeAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidSuppressMessageAttributeAnalyzerTest.cs
@@ -99,7 +99,7 @@ namespace WpfApp1 {
 			VerifyCSharpDiagnostic(givenText, DiagnosticResultHelper.Create(DiagnosticIds.AvoidSuppressMessage));
 		}
 		
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidSuppressMessageAttributeAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidSuppressMessageAttributeAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidSuppressMessageAttributeAnalyzerTest.cs
@@ -72,7 +72,7 @@ namespace WpfApp1 {
 }
 			";
 
-			VerifyCSharpDiagnostic(baseline, "BedPosOverlayWindow.g.i");
+			VerifyDiagnostic(baseline, "BedPosOverlayWindow.g.i");
 		}
 
 		[DataRow("NotWhitelistedFunction", "using System.Diagnostics.CodeAnalysis;", "SuppressMessage")]

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidSuppressMessageAttributeAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidSuppressMessageAttributeAnalyzerTest.cs
@@ -96,7 +96,7 @@ namespace WpfApp1 {
 				}}
 				";
 			string givenText = string.Format(baseline, usingStatement, attribute, functionName);
-			VerifyCSharpDiagnostic(givenText, DiagnosticResultHelper.Create(DiagnosticIds.AvoidSuppressMessage));
+			VerifyDiagnostic(givenText, DiagnosticResultHelper.Create(DiagnosticIds.AvoidSuppressMessage));
 		}
 		
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidTaskResultAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidTaskResultAnalyzerTest.cs
@@ -106,7 +106,7 @@ class FooClass
 			VerifyCSharpFix(before, after);
 		}
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new AvoidTaskResultCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidTaskResultAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidTaskResultAnalyzerTest.cs
@@ -32,7 +32,7 @@ class FooClass
 			string before = string.Format(template, @"task.Result");
 			string after = string.Format(template, @"await task");
 
-			VerifyCSharpDiagnostic(before, DiagnosticResultHelper.Create(DiagnosticIds.AvoidTaskResult));
+			VerifyDiagnostic(before, DiagnosticResultHelper.Create(DiagnosticIds.AvoidTaskResult));
 			VerifyFix(before, after);
 		}
 
@@ -52,7 +52,7 @@ class FooClass
 			string before = string.Format(template, @"new Task<int>(() => 4).Result");
 			string after = string.Format(template, @"await new Task<int>(() => 4)");
 
-			VerifyCSharpDiagnostic(before, DiagnosticResultHelper.Create(DiagnosticIds.AvoidTaskResult));
+			VerifyDiagnostic(before, DiagnosticResultHelper.Create(DiagnosticIds.AvoidTaskResult));
 			VerifyFix(before, after);
 		}
 
@@ -77,7 +77,7 @@ class FooClass
 			string before = string.Format(template, @"Foo(1).Result");
 			string after = string.Format(template, @"await Foo(1)");
 
-			VerifyCSharpDiagnostic(before, DiagnosticResultHelper.Create(DiagnosticIds.AvoidTaskResult));
+			VerifyDiagnostic(before, DiagnosticResultHelper.Create(DiagnosticIds.AvoidTaskResult));
 			VerifyFix(before, after);
 		}
 
@@ -102,7 +102,7 @@ class FooClass
 			string before = string.Format(template, @"this.Foo(1).Result");
 			string after = string.Format(template, @"await this.Foo(1)");
 
-			VerifyCSharpDiagnostic(before, DiagnosticResultHelper.Create(DiagnosticIds.AvoidTaskResult));
+			VerifyDiagnostic(before, DiagnosticResultHelper.Create(DiagnosticIds.AvoidTaskResult));
 			VerifyFix(before, after);
 		}
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidTaskResultAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidTaskResultAnalyzerTest.cs
@@ -33,7 +33,7 @@ class FooClass
 			string after = string.Format(template, @"await task");
 
 			VerifyCSharpDiagnostic(before, DiagnosticResultHelper.Create(DiagnosticIds.AvoidTaskResult));
-			VerifyCSharpFix(before, after);
+			VerifyFix(before, after);
 		}
 
 		[TestMethod]
@@ -53,7 +53,7 @@ class FooClass
 			string after = string.Format(template, @"await new Task<int>(() => 4)");
 
 			VerifyCSharpDiagnostic(before, DiagnosticResultHelper.Create(DiagnosticIds.AvoidTaskResult));
-			VerifyCSharpFix(before, after);
+			VerifyFix(before, after);
 		}
 
 
@@ -78,7 +78,7 @@ class FooClass
 			string after = string.Format(template, @"await Foo(1)");
 
 			VerifyCSharpDiagnostic(before, DiagnosticResultHelper.Create(DiagnosticIds.AvoidTaskResult));
-			VerifyCSharpFix(before, after);
+			VerifyFix(before, after);
 		}
 
 
@@ -103,7 +103,7 @@ class FooClass
 			string after = string.Format(template, @"await this.Foo(1)");
 
 			VerifyCSharpDiagnostic(before, DiagnosticResultHelper.Create(DiagnosticIds.AvoidTaskResult));
-			VerifyCSharpFix(before, after);
+			VerifyFix(before, after);
 		}
 
 		protected override CodeFixProvider GetCodeFixProvider()

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidTaskResultAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidTaskResultAnalyzerTest.cs
@@ -111,7 +111,7 @@ class FooClass
 			return new AvoidTaskResultCodeFixProvider();
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidTaskResultAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidThreadSleepTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidThreadSleepTest.cs
@@ -66,7 +66,7 @@ class Foo
 			return new AvoidThreadSleepAnalyzer();
 		}
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new AvoidThreadSleepCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidThreadSleepTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidThreadSleepTest.cs
@@ -61,7 +61,7 @@ class Foo
 		}
 
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidThreadSleepAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidThreadSleepTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidThreadSleepTest.cs
@@ -57,7 +57,7 @@ class Foo
 
 			VerifyCSharpDiagnostic(givenText, expected);
 
-			VerifyCSharpFix(givenText, fixedText, allowNewCompilerDiagnostics: true);
+			VerifyFix(givenText, fixedText, allowNewCompilerDiagnostics: true);
 		}
 
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidThreadSleepTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidThreadSleepTest.cs
@@ -55,7 +55,7 @@ class Foo
 				}
 			};
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 
 			VerifyFix(givenText, fixedText, allowNewCompilerDiagnostics: true);
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidTryParseWithoutCultureAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidTryParseWithoutCultureAnalyzerTest.cs
@@ -55,7 +55,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidTryParseWithoutCultureAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidTryParseWithoutCultureAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidTryParseWithoutCultureAnalyzerTest.cs
@@ -91,7 +91,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 				}
 			};
 
-			VerifyCSharpDiagnostic(code, expected);
+			VerifyDiagnostic(code, expected);
 		}
 
 		[DataTestMethod]
@@ -101,7 +101,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		public void DoNotFlagTryParseWithCultureForValueTypes(string s)
 		{
 			string code = string.Format(ClassString, s);
-			VerifyCSharpDiagnostic(code);
+			VerifyDiagnostic(code);
 		}
 
 		[DataTestMethod]
@@ -122,7 +122,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 				}
 			};
 
-			VerifyCSharpDiagnostic(code, expected);
+			VerifyDiagnostic(code, expected);
 		}
 
 		[DataTestMethod]
@@ -133,7 +133,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		{
 			string editorCode = string.Format(ClassString, s);
 			string code = string.Concat(editorCode, TestParserDefinition);
-			VerifyCSharpDiagnostic(code);
+			VerifyDiagnostic(code);
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidUnnecessaryWhereAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidUnnecessaryWhereAnalyzerTest.cs
@@ -47,7 +47,7 @@ class Foo
 }}
 ";
 			string testCode = string.Format(template, line);
-			VerifyCSharpDiagnostic(testCode, DiagnosticResultHelper.Create(DiagnosticIds.AvoidUnnecessaryWhere));
+			VerifyDiagnostic(testCode, DiagnosticResultHelper.Create(DiagnosticIds.AvoidUnnecessaryWhere));
 		}
 
 
@@ -80,7 +80,7 @@ class Foo
 }}
 ";
 			string testCode = string.Format(template, line);
-			VerifyCSharpDiagnostic(testCode);
+			VerifyDiagnostic(testCode);
 		}
 	}
 }

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidUnnecessaryWhereAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidUnnecessaryWhereAnalyzerTest.cs
@@ -18,7 +18,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 	[TestClass]
 	public class AvoidUnnecessaryWhereAnalyzerTest : DiagnosticVerifier
 	{
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidUnnecessaryWhereAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/CallExtensionMethodsAsInstanceMethodsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/CallExtensionMethodsAsInstanceMethodsAnalyzerTest.cs
@@ -65,7 +65,7 @@ public static class Program
 				result = new[] { DiagnosticResultHelper.Create(DiagnosticIds.ExtensionMethodsCalledLikeInstanceMethods) };
 			}
 
-			VerifyCSharpDiagnostic(text, result);
+			VerifyDiagnostic(text, result);
 
 			if (!string.IsNullOrEmpty(fixedText))
 			{
@@ -96,7 +96,7 @@ public static class Foo
 
 			DiagnosticResult[] result = new[] { DiagnosticResultHelper.Create(DiagnosticIds.ExtensionMethodsCalledLikeInstanceMethods) };
 
-			VerifyCSharpDiagnostic(text, result);
+			VerifyDiagnostic(text, result);
 
 			string newText = string.Format(Template, "obj.Bar(null)");
 			VerifyFix(text, newText);
@@ -129,7 +129,7 @@ public static class Foo
 
 			DiagnosticResult[] result = new[] { DiagnosticResultHelper.Create(DiagnosticIds.ExtensionMethodsCalledLikeInstanceMethods) };
 
-			VerifyCSharpDiagnostic(text, result);
+			VerifyDiagnostic(text, result);
 
 			string newText = string.Format(Template, "dict.RemoveByKeys(items)");
 			VerifyFix(text, newText);
@@ -300,7 +300,7 @@ public class Baz
 				result = new[] { DiagnosticResultHelper.Create(DiagnosticIds.ExtensionMethodsCalledLikeInstanceMethods) };
 			}
 
-			VerifyCSharpDiagnostic(template, result);
+			VerifyDiagnostic(template, result);
 		}
 	}
 }

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/CallExtensionMethodsAsInstanceMethodsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/CallExtensionMethodsAsInstanceMethodsAnalyzerTest.cs
@@ -13,7 +13,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 	[TestClass]
 	public class CallExtensionMethodsAsInstanceMethodsAnalyzerTest : CodeFixVerifier
 	{
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new CallExtensionMethodsAsInstanceMethodsAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/CallExtensionMethodsAsInstanceMethodsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/CallExtensionMethodsAsInstanceMethodsAnalyzerTest.cs
@@ -70,7 +70,7 @@ public static class Program
 			if (!string.IsNullOrEmpty(fixedText))
 			{
 				string newText = string.Format(Template, isExtensionMethod ? "this" : "", fixedText);
-				VerifyCSharpFix(text, newText);
+				VerifyFix(text, newText);
 			}
 		}
 
@@ -99,7 +99,7 @@ public static class Foo
 			VerifyCSharpDiagnostic(text, result);
 
 			string newText = string.Format(Template, "obj.Bar(null)");
-			VerifyCSharpFix(text, newText);
+			VerifyFix(text, newText);
 		}
 
 		[TestMethod]
@@ -132,7 +132,7 @@ public static class Foo
 			VerifyCSharpDiagnostic(text, result);
 
 			string newText = string.Format(Template, "dict.RemoveByKeys(items)");
-			VerifyCSharpFix(text, newText);
+			VerifyFix(text, newText);
 		}
 
 		[DataRow(@"

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/CallExtensionMethodsAsInstanceMethodsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/CallExtensionMethodsAsInstanceMethodsAnalyzerTest.cs
@@ -18,7 +18,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 			return new CallExtensionMethodsAsInstanceMethodsAnalyzer();
 		}
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new CallExtensionMethodsAsInstanceMethodsCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/DisallowDisposeRegistrationCodeFixProviderTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/DisallowDisposeRegistrationCodeFixProviderTest.cs
@@ -42,7 +42,7 @@ class Foo
 
 			string expectedText = givenText.Replace(@"+=", @"-=");
 
-			VerifyCSharpFix(givenText, expectedText);
+			VerifyFix(givenText, expectedText);
 		}
 
 		protected override CodeFixProvider GetCodeFixProvider()

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/DisallowDisposeRegistrationCodeFixProviderTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/DisallowDisposeRegistrationCodeFixProviderTest.cs
@@ -50,7 +50,7 @@ class Foo
 			return new DisallowDisposeRegistrationCodeFixProvider();
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new DisallowDisposeRegistrationAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/DisallowDisposeRegistrationCodeFixProviderTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/DisallowDisposeRegistrationCodeFixProviderTest.cs
@@ -38,7 +38,7 @@ class Foo
 					new DiagnosticResultLocation("Test0.cs", 7, 5)
 				}
 			};
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 
 			string expectedText = givenText.Replace(@"+=", @"-=");
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/DisallowDisposeRegistrationCodeFixProviderTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/DisallowDisposeRegistrationCodeFixProviderTest.cs
@@ -45,7 +45,7 @@ class Foo
 			VerifyCSharpFix(givenText, expectedText);
 		}
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new DisallowDisposeRegistrationCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/DontLockNewObjectAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/DontLockNewObjectAnalyzerTest.cs
@@ -14,7 +14,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new DontLockNewObjectAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/DontLockNewObjectAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/DontLockNewObjectAnalyzerTest.cs
@@ -41,7 +41,7 @@ public class Foo
 }}
 ";
 
-			VerifyCSharpDiagnostic(text, expectedError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.DontLockNewObject) : Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(text, expectedError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.DontLockNewObject) : Array.Empty<DiagnosticResult>());
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/EnforceFileVersionIsSameAsPackageVersionAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/EnforceFileVersionIsSameAsPackageVersionAnalyzerTest.cs
@@ -45,11 +45,11 @@ class FooClass
 
 			if (hasDiagnostic)
 			{
-				VerifyCSharpDiagnostic(code, DiagnosticResultHelper.Create(DiagnosticIds.EnforceFileVersionIsSameAsPackageVersion));
+				VerifyDiagnostic(code, DiagnosticResultHelper.Create(DiagnosticIds.EnforceFileVersionIsSameAsPackageVersion));
 			}
 			else
 			{
-				VerifyCSharpDiagnostic(code);
+				VerifyDiagnostic(code);
 			}
 		}
 
@@ -72,7 +72,7 @@ class FooClass
 }}}}
 ";
 
-			VerifyCSharpDiagnostic(code);
+			VerifyDiagnostic(code);
 		}
 
 		[TestMethod]
@@ -91,7 +91,7 @@ class FooClass
 }}}}
 ";
 
-			VerifyCSharpDiagnostic(code);
+			VerifyDiagnostic(code);
 		}
 
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/EnforceFileVersionIsSameAsPackageVersionAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/EnforceFileVersionIsSameAsPackageVersionAnalyzerTest.cs
@@ -94,7 +94,7 @@ class FooClass
 			VerifyCSharpDiagnostic(code);
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new EnforceFileVersionIsSameAsPackageVersionAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/LockObjectsMustBeReadonlyAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/LockObjectsMustBeReadonlyAnalyzerTest.cs
@@ -41,7 +41,7 @@ class Foo
 				result = new[] { DiagnosticResultHelper.Create(DiagnosticIds.LocksShouldBeReadonly) };
 			}
 
-			VerifyCSharpDiagnostic(string.Format(template, field), result);
+			VerifyDiagnostic(string.Format(template, field), result);
 		}
 
 		[DataRow("object foo", false)]
@@ -64,7 +64,7 @@ class Foo
 				result = new[] { DiagnosticResultHelper.Create(DiagnosticIds.LocksShouldBeReadonly) };
 			}
 
-			VerifyCSharpDiagnostic(string.Format(template, field), result);
+			VerifyDiagnostic(string.Format(template, field), result);
 		}
 
 		[DataRow("object foo", false)]
@@ -92,7 +92,7 @@ class Foo
 				result = new[] { DiagnosticResultHelper.Create(DiagnosticIds.LocksShouldBeReadonly) };
 			}
 
-			VerifyCSharpDiagnostic(string.Format(template, field), result);
+			VerifyDiagnostic(string.Format(template, field), result);
 		}
 
 		[TestMethod]
@@ -111,7 +111,7 @@ class Foo
 ";
 			var result = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(string.Format(template), result);
+			VerifyDiagnostic(string.Format(template), result);
 		}
 
 		[TestMethod]
@@ -130,7 +130,7 @@ class Foo
 ";
 			var result = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(string.Format(template), result);
+			VerifyDiagnostic(string.Format(template), result);
 		}
 
 		[TestMethod]
@@ -155,7 +155,7 @@ class Foo
 				error,
 			};
 
-			VerifyCSharpDiagnostic(string.Format(template), result);
+			VerifyDiagnostic(string.Format(template), result);
 		}
 	}
 }

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/LockObjectsMustBeReadonlyAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/LockObjectsMustBeReadonlyAnalyzerTest.cs
@@ -12,7 +12,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 	[TestClass]
 	public class LockObjectsMustBeReadonlyAnalyzerTest : DiagnosticVerifier
 	{
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new LockObjectsMustBeReadonlyAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/LogExceptionAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/LogExceptionAnalyzerTest.cs
@@ -124,7 +124,7 @@ public class Program {
 		/// <summary>
 		/// <inheritdoc cref="DiagnosticVerifier"/>
 		/// </summary>
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new LogExceptionAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/LogExceptionAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/LogExceptionAnalyzerTest.cs
@@ -118,7 +118,7 @@ public class Program {
 		[DataRow(Missing, "Dummy.g", DisplayName = "OutOfScopeSourceFile")]
 		public void WhenSourceFileIsOutOfScopeNoDiagnosticIsTriggered(string testCode, string filePath)
 		{
-			VerifyCSharpDiagnostic(testCode, filePath);
+			VerifyDiagnostic(testCode, filePath);
 		}
 
 		/// <summary>

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/LogExceptionAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/LogExceptionAnalyzerTest.cs
@@ -97,7 +97,7 @@ public class Program {
 			DataRow(CorrectVerboseTracer, DisplayName = "CorrectVerboseTracer")]
 		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
 		{
-			VerifyCSharpDiagnostic(testCode);
+			VerifyDiagnostic(testCode);
 		}
 
 		/// <summary>
@@ -108,7 +108,7 @@ public class Program {
 		public void WhenExceptionIsNotLoggedDiagnosticIsTriggered(string testCode)
 		{
 			var expected = DiagnosticResultHelper.Create(DiagnosticIds.LogException); 
-			VerifyCSharpDiagnostic(testCode, expected);
+			VerifyDiagnostic(testCode, expected);
 		}
 
 		/// <summary>

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/LogExceptionAnalyzerTest2.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/LogExceptionAnalyzerTest2.cs
@@ -41,7 +41,7 @@ public class Program {
 		public void WhenExceptionIsNotLoggedDiagnosticIsTriggered(string testCode)
 		{
 			var expected = DiagnosticResultHelper.Create(DiagnosticIds.LogException);
-			VerifyCSharpDiagnostic(testCode, expected);
+			VerifyDiagnostic(testCode, expected);
 		}
 
 		/// <summary>

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/LogExceptionAnalyzerTest2.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/LogExceptionAnalyzerTest2.cs
@@ -47,7 +47,7 @@ public class Program {
 		/// <summary>
 		/// <inheritdoc cref="DiagnosticVerifier"/>
 		/// </summary>
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new LogExceptionAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/MergeIfStatementsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/MergeIfStatementsAnalyzerTest.cs
@@ -76,7 +76,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 			    }}";
 
 			string testCode = string.Format(testCodeTemplate, test);
-			VerifyCSharpDiagnostic(testCode);
+			VerifyDiagnostic(testCode);
 		}
 
 		[DataTestMethod]
@@ -100,7 +100,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 			string fixedCode = string.Format(testCodeTemplate, fixedTest);
 
 			var expectedDiagnostic = DiagnosticResultHelper.Create(DiagnosticIds.MergeIfStatements);
-			VerifyCSharpDiagnostic(testCode, expectedDiagnostic);
+			VerifyDiagnostic(testCode, expectedDiagnostic);
 			VerifyFix(testCode, fixedCode);
 		}
 	}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/MergeIfStatementsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/MergeIfStatementsAnalyzerTest.cs
@@ -101,7 +101,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 
 			var expectedDiagnostic = DiagnosticResultHelper.Create(DiagnosticIds.MergeIfStatements);
 			VerifyCSharpDiagnostic(testCode, expectedDiagnostic);
-			VerifyCSharpFix(testCode, fixedCode);
+			VerifyFix(testCode, fixedCode);
 		}
 	}
 }

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/MergeIfStatementsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/MergeIfStatementsAnalyzerTest.cs
@@ -44,7 +44,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 	[TestClass]
 	public class MergeIfStatementsAnalyzerTest : CodeFixVerifier
 	{
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new MergeIfStatementsCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/MergeIfStatementsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/MergeIfStatementsAnalyzerTest.cs
@@ -35,7 +35,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 					}
 			    }";
 
-			VerifyCSharpDiagnostic(testCode, "Test.Designer");
+			VerifyDiagnostic(testCode, "Test.Designer");
 		}
 	}
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/MergeIfStatementsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/MergeIfStatementsAnalyzerTest.cs
@@ -14,7 +14,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 	[TestClass]
 	public class MergeIfStatementsAnalyzerGeneratedCodeTest : DiagnosticVerifier
 	{
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new MergeIfStatementsAnalyzer(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
 		}
@@ -49,7 +49,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 			return new MergeIfStatementsCodeFixProvider();
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new MergeIfStatementsAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoHardCodedPathsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoHardCodedPathsAnalyzerTest.cs
@@ -28,7 +28,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
 
 		}
 
@@ -45,7 +45,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
 
 		}
 
@@ -63,7 +63,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
 
 		}
 
@@ -91,7 +91,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
 
 		}
 
@@ -109,7 +109,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
 
 		}
 
@@ -127,7 +127,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoHardcodedPaths));
 
 		}
 
@@ -146,7 +146,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 
@@ -164,7 +164,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 		[TestMethod]
@@ -181,7 +181,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 		[TestMethod]
@@ -197,7 +197,7 @@ class foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 		[TestMethod]
@@ -216,7 +216,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 
 		}
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoHardCodedPathsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoHardCodedPathsAnalyzerTest.cs
@@ -10,7 +10,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 	[TestClass]
 	public class NoHardCodedPathsAnalyzerTest : DiagnosticVerifier
 	{
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new NoHardCodedPathsAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoNestedStringFormatsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoNestedStringFormatsAnalyzerTest.cs
@@ -9,7 +9,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 	[TestClass]
 	public class NoNestedStringFormatsAnalyzerTest : DiagnosticVerifier
 	{
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new NoNestedStringFormatsAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoNestedStringFormatsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoNestedStringFormatsAnalyzerTest.cs
@@ -28,7 +28,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoNestedStringFormats));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoNestedStringFormats));
 		}
 
 		[TestMethod]
@@ -45,7 +45,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoNestedStringFormats));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoNestedStringFormats));
 		}
 
 		[TestMethod]
@@ -67,7 +67,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoNestedStringFormats));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoNestedStringFormats));
 		}
 
 		[TestMethod]
@@ -85,7 +85,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
 		}
 
 		[TestMethod]
@@ -114,7 +114,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
 		}
 
 		[DataRow("{0}")]
@@ -143,7 +143,7 @@ class Foo
 }}
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
 		}
 
 		[TestMethod]
@@ -161,7 +161,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
 		}
 
 		[TestMethod]
@@ -179,7 +179,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 		[TestMethod]
@@ -205,7 +205,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
 		}
 
 
@@ -225,7 +225,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
 		}
 
 		[TestMethod]
@@ -251,7 +251,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
 		}
 
 		[TestMethod]
@@ -281,7 +281,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
 		}
 
 		[TestMethod]
@@ -307,7 +307,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
 		}
 
 		[TestMethod]
@@ -333,7 +333,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
 		}
 
 		[TestMethod]
@@ -360,7 +360,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
 		}
 
 		[TestMethod]
@@ -386,7 +386,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
 		}
 
 		[TestMethod]
@@ -418,7 +418,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
 		}
 
 		[DataRow("\"{0}\"", ", errorMessage", true)]
@@ -463,7 +463,7 @@ class Foo
 				expected = new[] { DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats) };
 			}
 
-			VerifyCSharpDiagnostic(string.Format(template, format, args), expected);
+			VerifyDiagnostic(string.Format(template, format, args), expected);
 		}
 
 		[DataRow("$\"{0}\"")]
@@ -488,7 +488,7 @@ class Foo
 	}}
 }}
 ";
-			VerifyCSharpDiagnostic(string.Format(template, format));
+			VerifyDiagnostic(string.Format(template, format));
 		}
 
 		[TestMethod]
@@ -516,7 +516,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 
@@ -536,7 +536,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 		[TestMethod]
@@ -553,7 +553,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 		[TestMethod]
@@ -570,7 +570,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 		[DataRow(@"$""{Environment.NewLine}""")]
@@ -590,7 +590,7 @@ class Foo
 }}
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.NoUnnecessaryStringFormats));
 		}
 
 		[DataRow(@"$""{Test()}""")]
@@ -616,7 +616,7 @@ class Foo
 }}
 ";
 
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 	}
 }

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoProtectedFieldsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoProtectedFieldsAnalyzerTest.cs
@@ -40,7 +40,7 @@ class Foo {{ {0} string _foo; }}
 
 			DiagnosticResult[] expected = isError ? new[] { DiagnosticResultHelper.Create(DiagnosticIds.NoProtectedFields) } : Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(string.Format(template, modifiers), expected);
+			VerifyDiagnostic(string.Format(template, modifiers), expected);
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoProtectedFieldsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoProtectedFieldsAnalyzerTest.cs
@@ -21,7 +21,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 
 		#region Public Interface
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new NoProtectedFieldsAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoRegionsInMethodAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoRegionsInMethodAnalyzerTest.cs
@@ -10,7 +10,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 	public class NoRegionsInMethodAnalyzerTest : DiagnosticVerifier
 	{
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 
 			return new NoRegionsInMethodAnalyzer();

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoRegionsInMethodAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoRegionsInMethodAnalyzerTest.cs
@@ -122,12 +122,12 @@ Class C{
 
 		private void VerifyNoDiagnostic(string file)
 		{
-			VerifyCSharpDiagnostic(file);
+			VerifyDiagnostic(file);
 		}
 
 		private void VerifyDiagnostic(string file, int line)
 		{
-			VerifyCSharpDiagnostic(file, new DiagnosticResult()
+			VerifyDiagnostic(file, new DiagnosticResult()
 			{
 				Id = NoRegionsInMethodAnalyzer.Rule.Id,
 				Message = new Regex(".*"),

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/PassByRefAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/PassByRefAnalyzerTest.cs
@@ -37,7 +37,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, isWrittenTo ? Array.Empty<DiagnosticResult>() : DiagnosticResultHelper.CreateArray(DiagnosticIds.AvoidPassByReference));
+			VerifyDiagnostic(content, isWrittenTo ? Array.Empty<DiagnosticResult>() : DiagnosticResultHelper.CreateArray(DiagnosticIds.AvoidPassByReference));
 		}
 
 		[DataRow(true)]
@@ -62,7 +62,7 @@ public class TestClass
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, isWrittenTo ? Array.Empty<DiagnosticResult>() : DiagnosticResultHelper.CreateArray(DiagnosticIds.AvoidPassByReference));
+			VerifyDiagnostic(content, isWrittenTo ? Array.Empty<DiagnosticResult>() : DiagnosticResultHelper.CreateArray(DiagnosticIds.AvoidPassByReference));
 		}
 
 		[DataRow(true)]
@@ -85,7 +85,7 @@ public class TestClass : IData
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(content, Array.Empty<DiagnosticResult>());
 		}
 
 		[DataTestMethod]
@@ -106,7 +106,7 @@ public class TestClass : Data
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(content, Array.Empty<DiagnosticResult>());
 		}
 
 		[DataRow(true)]
@@ -121,7 +121,7 @@ public class TestClass : Data
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, isWrittenTo ? Array.Empty<DiagnosticResult>() : DiagnosticResultHelper.CreateArray(DiagnosticIds.AvoidPassByReference));
+			VerifyDiagnostic(content, isWrittenTo ? Array.Empty<DiagnosticResult>() : DiagnosticResultHelper.CreateArray(DiagnosticIds.AvoidPassByReference));
 		}
 
 		[TestMethod]
@@ -144,7 +144,7 @@ public class TestClass : Data
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(content, Array.Empty<DiagnosticResult>());
 		}
 
 		[DataRow(": Foo", false)]
@@ -162,7 +162,7 @@ public class TestClass {baseClass}
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.AvoidPassByReference) : Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(content, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.AvoidPassByReference) : Array.Empty<DiagnosticResult>());
 		}
 
 		[DataRow(": Foo", "i = 0", false)]
@@ -183,7 +183,7 @@ public class TestClass {baseClass}
 }}
 ";
 
-			VerifyCSharpDiagnostic(content, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.AvoidPassByReference) : Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(content, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.AvoidPassByReference) : Array.Empty<DiagnosticResult>());
 		}
 
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/PassByRefAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/PassByRefAnalyzerTest.cs
@@ -187,7 +187,7 @@ public class TestClass {baseClass}
 		}
 
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new PassByRefAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/PreventUseOfGotoAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/PreventUseOfGotoAnalyzerTest.cs
@@ -30,7 +30,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.GotoNotAllowed));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.GotoNotAllowed));
 		}
 
 		[TestMethod]
@@ -49,7 +49,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.GotoNotAllowed), DiagnosticResultHelper.Create(DiagnosticIds.GotoNotAllowed));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.GotoNotAllowed), DiagnosticResultHelper.Create(DiagnosticIds.GotoNotAllowed));
 		}
 
 		[TestMethod]
@@ -71,7 +71,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.GotoNotAllowed));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.GotoNotAllowed));
 		}
 
 		[TestMethod]
@@ -93,7 +93,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.GotoNotAllowed));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.GotoNotAllowed));
 		}
 	}
 }

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/PreventUseOfGotoAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/PreventUseOfGotoAnalyzerTest.cs
@@ -10,7 +10,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 	[TestClass]
 	public class PreventUseOfGotoAnalyzerTest : DiagnosticVerifier
 	{
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new PreventUseOfGotoAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ProhibitDynamicKeywordAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ProhibitDynamicKeywordAnalyzerTest.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new ProhibitDynamicKeywordAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ProhibitDynamicKeywordAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ProhibitDynamicKeywordAnalyzerTest.cs
@@ -46,7 +46,7 @@ dynamic.StartsWith(""Y"", true, CultureInfo.CurrentCulture);
 			}
 
 			var expected = results.ToArray();
-			VerifyCSharpDiagnostic(testCode, expected);
+			VerifyDiagnostic(testCode, expected);
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ReduceCognitiveLoadAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ReduceCognitiveLoadAnalyzerTest.cs
@@ -48,7 +48,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, "Test.Designer");
+			VerifyDiagnostic(template, "Test.Designer");
 		}
 
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ReduceCognitiveLoadAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ReduceCognitiveLoadAnalyzerTest.cs
@@ -63,7 +63,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 		[TestMethod]
@@ -78,7 +78,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(2)));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(2)));
 		}
 
 		[TestMethod]
@@ -93,7 +93,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(3)));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(3)));
 		}
 
 		[TestMethod]
@@ -108,7 +108,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(2)));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(2)));
 		}
 
 		[TestMethod]
@@ -123,7 +123,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(3)));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(3)));
 		}
 
 		[TestMethod]
@@ -138,7 +138,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(3)));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(3)));
 		}
 
 		[TestMethod]
@@ -153,7 +153,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(3)));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(3)));
 		}
 
 		[TestMethod]
@@ -168,7 +168,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(3)));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(3)));
 		}
 
 		[TestMethod]
@@ -187,7 +187,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(4)));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(4)));
 		}
 
 		[TestMethod]
@@ -208,7 +208,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(6)));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(6)));
 		}
 
 		[TestMethod]
@@ -231,7 +231,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(8)));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(8)));
 		}
 
 
@@ -253,7 +253,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(5)));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(5)));
 		}
 
 		[TestMethod]
@@ -318,7 +318,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(34)));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(34)));
 		}
 
 
@@ -380,7 +380,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(26)));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(26)));
 		}
 
 		[TestMethod]
@@ -428,7 +428,7 @@ class Foo
 		return document;
 	}
 }";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(40)));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(40)));
 		}
 	}
 
@@ -466,7 +466,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 		[TestMethod]
@@ -493,7 +493,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, new Regex("Load of 27 ")));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, new Regex("Load of 27 ")));
 		}
 
 	}
@@ -532,7 +532,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 		[TestMethod]
@@ -559,7 +559,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, new Regex("Load of 27 ")));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, new Regex("Load of 27 ")));
 		}
 
 	}
@@ -595,7 +595,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 		[TestMethod]
@@ -622,7 +622,7 @@ class Foo
 	}
 }
 ";
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, new Regex("Load of 27 ")));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, new Regex("Load of 27 ")));
 		}
 
 	}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ReduceCognitiveLoadAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ReduceCognitiveLoadAnalyzerTest.cs
@@ -25,7 +25,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 			return new Regex($"Load of {expectedLoad} ");
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			Mock<AdditionalFilesHelper> _mockAdditionalFilesHelper = new(new AnalyzerOptions(ImmutableArray.Create<AdditionalText>()), null);
 			_mockAdditionalFilesHelper.Setup(c => c.GetValueFromEditorConfig(It.IsAny<string>(), It.IsAny<string>())).Returns("1");
@@ -435,7 +435,7 @@ class Foo
 	[TestClass]
 	public class ReduceCognitiveLoadAnalyzerInvalidInitializationTest : DiagnosticVerifier
 	{
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			const string InvalidMaxLoad = @"1000";
 			Mock<AdditionalFilesHelper> _mockAdditionalFilesHelper = new(new AnalyzerOptions(ImmutableArray.Create<AdditionalText>()), null);
@@ -501,7 +501,7 @@ class Foo
 	[TestClass]
 	public class ReduceCognitiveLoadAnalyzerInvalidInitializationTest2 : DiagnosticVerifier
 	{
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			const string InvalidMaxLoad = @"0";
 			Mock<AdditionalFilesHelper> _mockAdditionalFilesHelper = new(new AnalyzerOptions(ImmutableArray.Create<AdditionalText>()), null);
@@ -567,7 +567,7 @@ class Foo
 	[TestClass]
 	public class ReduceCognitiveLoadAnalyzerDefaultInitializationTest : DiagnosticVerifier
 	{
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new ReduceCognitiveLoadAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ServiceContractAreAnnotatedWithOperationContractAttributeAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ServiceContractAreAnnotatedWithOperationContractAttributeAnalyzerTest.cs
@@ -34,7 +34,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		{
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 			{
-				VerifyCSharpDiagnostic(source, null, expected);
+				VerifyDiagnostic(source, null, expected);
 			}
 		}
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ServiceContractAreAnnotatedWithOperationContractAttributeAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ServiceContractAreAnnotatedWithOperationContractAttributeAnalyzerTest.cs
@@ -30,7 +30,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 			return new[] { MetadataReference.CreateFromFile(@"C:\WINDOWS\Microsoft.Net\assembly\GAC_MSIL\System.ServiceModel\v4.0_4.0.0.0__b77a5c561934e089\System.ServiceModel.dll") };
 		}
 
-		private void VerifyCSharpDiagnosticOnWindows(string source, params DiagnosticResult[] expected)
+		private void VerifyDiagnosticOnWindows(string source, params DiagnosticResult[] expected)
 		{
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 			{
@@ -49,7 +49,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 public interface IFoo { }
 ";
 
-			VerifyCSharpDiagnosticOnWindows(text);
+			VerifyDiagnosticOnWindows(text);
 		}
 
 		[TestMethod]
@@ -60,7 +60,7 @@ public interface IFoo { }
 public interface IFoo { }
 ";
 
-			VerifyCSharpDiagnosticOnWindows(text);
+			VerifyDiagnosticOnWindows(text);
 		}
 
 		[TestMethod]
@@ -75,7 +75,7 @@ public interface IFoo
 }
 ";
 
-			VerifyCSharpDiagnosticOnWindows(text);
+			VerifyDiagnosticOnWindows(text);
 		}
 
 		[TestMethod]
@@ -89,7 +89,7 @@ public interface IFoo
 }
 ";
 
-			VerifyCSharpDiagnosticOnWindows(text, new[]
+			VerifyDiagnosticOnWindows(text, new[]
 			{
 				new DiagnosticResult()
 				{
@@ -118,7 +118,7 @@ public interface IFoo
 }
 ";
 
-			VerifyCSharpDiagnosticOnWindows(text, new[]
+			VerifyDiagnosticOnWindows(text, new[]
 			{
 				new DiagnosticResult()
 				{

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ServiceContractAreAnnotatedWithOperationContractAttributeAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ServiceContractAreAnnotatedWithOperationContractAttributeAnalyzerTest.cs
@@ -19,7 +19,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new ServiceContractAreAnnotatedWithOperationContractAttributeAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ThrowInnerExceptionAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ThrowInnerExceptionAnalyzerTest.cs
@@ -143,7 +143,7 @@ namespace InnerExceptionUnitTest {
 		[DataRow(ThrowOther, "Dummy.Designer", DisplayName = "OutOfScopeSourceFile")]
 		public void WhenSourceFileIsOutOfScopeNoDiagnosticIsTriggered(string testCode, string filePath)
 		{
-			VerifyCSharpDiagnostic(testCode, filePath);
+			VerifyDiagnostic(testCode, filePath);
 		}
 
 		/// <summary>

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ThrowInnerExceptionAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ThrowInnerExceptionAnalyzerTest.cs
@@ -149,7 +149,7 @@ namespace InnerExceptionUnitTest {
 		/// <summary>
 		/// <inheritdoc cref="DiagnosticVerifier"/>
 		/// </summary>
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new ThrowInnerExceptionAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ThrowInnerExceptionAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ThrowInnerExceptionAnalyzerTest.cs
@@ -122,7 +122,7 @@ namespace InnerExceptionUnitTest {
 			DataRow(HttpResponseSeparate, DisplayName = "HttpResponseSeparate")]
 		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
 		{
-			VerifyCSharpDiagnostic(testCode);
+			VerifyDiagnostic(testCode);
 		}
 
 		/// <summary>
@@ -133,7 +133,7 @@ namespace InnerExceptionUnitTest {
 		public void WhenInnerExceptionIsMissingDiagnosticIsTriggered(string testCode)
 		{
 			var expected = DiagnosticResultHelper.Create(DiagnosticIds.ThrowInnerException);
-			VerifyCSharpDiagnostic(testCode, expected);
+			VerifyDiagnostic(testCode, expected);
 		}
 
 		/// <summary>

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/WinFormsInitializeComponentMustBeCalledOnceAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/WinFormsInitializeComponentMustBeCalledOnceAnalyzerTest.cs
@@ -313,7 +313,7 @@ class ContainerControl
 		public void WinFormsInitialComponentMustBeCalledOnceAnalyzerIgnoreDesignerFile()
 		{
 			string code = CreateCode(@"", @"");
-			VerifyCSharpDiagnostic(code, @"Test.Designer");
+			VerifyDiagnostic(code, @"Test.Designer");
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/WinFormsInitializeComponentMustBeCalledOnceAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/WinFormsInitializeComponentMustBeCalledOnceAnalyzerTest.cs
@@ -189,7 +189,7 @@ class ContainerControl
 		/// <param name="file"></param>
 		private void VerifyNoDiagnostic(string file)
 		{
-			VerifyCSharpDiagnostic(file);
+			VerifyDiagnostic(file);
 		}
 
 		/// <summary>
@@ -200,7 +200,7 @@ class ContainerControl
 		{
 			DiagnosticResult diagnosticResult = GetDiagnosticResult(11, 16);
 			DiagnosticResult[] expected = new DiagnosticResult[] { diagnosticResult };
-			VerifyCSharpDiagnostic(file, expected);
+			VerifyDiagnostic(file, expected);
 		}
 
 		/// <summary>
@@ -211,7 +211,7 @@ class ContainerControl
 		{
 			DiagnosticResult diagnosticResult = GetDiagnosticResult(15, 3);
 			DiagnosticResult[] expected = new DiagnosticResult[] { diagnosticResult };
-			VerifyCSharpDiagnostic(file, expected);
+			VerifyDiagnostic(file, expected);
 		}
 
 		/// <summary>
@@ -223,7 +223,7 @@ class ContainerControl
 			DiagnosticResult diagnosticResult1 = GetDiagnosticResult(11, 16);
 			DiagnosticResult diagnosticResult2 = GetDiagnosticResult(15, 3);
 			DiagnosticResult[] expected = new DiagnosticResult[] { diagnosticResult1, diagnosticResult2 };
-			VerifyCSharpDiagnostic(file, expected);
+			VerifyDiagnostic(file, expected);
 		}
 
 		/// <summary>
@@ -234,7 +234,7 @@ class ContainerControl
 		{
 			DiagnosticResult diagnosticResult = GetDiagnosticResult(9, 22);
 			DiagnosticResult[] expected = new DiagnosticResult[] { diagnosticResult };
-			VerifyCSharpDiagnostic(file, expected);
+			VerifyDiagnostic(file, expected);
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/WinFormsInitializeComponentMustBeCalledOnceAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/WinFormsInitializeComponentMustBeCalledOnceAnalyzerTest.cs
@@ -25,10 +25,10 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		#region Non-Public Properties/Methods
 
 		/// <summary>
-		/// GetCSharpDiagnosticAnalyzer
+		/// GetDiagnosticAnalyzer
 		/// </summary>
 		/// <returns></returns>
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new WinFormsInitializeComponentMustBeCalledOnceAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Naming/EnforceBoolNamingConventionAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Naming/EnforceBoolNamingConventionAnalyzerTest.cs
@@ -16,7 +16,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 	{
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new EnforceBoolNamingConventionAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Naming/EnforceBoolNamingConventionAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Naming/EnforceBoolNamingConventionAnalyzerTest.cs
@@ -81,7 +81,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 				};
 			}
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[DataRow("isfoo", false, 3)]
@@ -142,7 +142,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 				};
 			}
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[TestMethod]
@@ -157,7 +157,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 
 			DiagnosticResult[] expected = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[TestMethod]
@@ -174,7 +174,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 
 			DiagnosticResult[] expected = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[DataRow("i", false, 5)]
@@ -235,7 +235,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 				};
 			}
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[DataRow("foreach(bool i in new[] { true, false }){}", false, 5)]
@@ -297,7 +297,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 				};
 			}
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[DataRow("_foo", false, 4)]
@@ -333,7 +333,7 @@ class Foo
 				};
 			}
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[DataRow("foo", false, 6)]
@@ -372,7 +372,7 @@ class Foo
 				};
 			}
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[DataRow("foo", false, 5)]
@@ -410,7 +410,7 @@ class Foo
 				};
 			}
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[DataRow("Foo", false, 4)]
@@ -457,7 +457,7 @@ class Foo
 				};
 			}
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 
@@ -485,7 +485,7 @@ class Foo : BaseClass
 
 			DiagnosticResult[] expected = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[TestMethod]
@@ -512,7 +512,7 @@ abstract class Foo : BaseClass
 
 			DiagnosticResult[] expected = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[TestMethod]
@@ -533,7 +533,7 @@ abstract class Foo : ApplicationContext
 
 			DiagnosticResult[] expected = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/Maintainability/Naming/NamespaceMatchAssemblyAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Naming/NamespaceMatchAssemblyAnalyzerTest.cs
@@ -35,7 +35,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 			return new DiagnosticResultLocation(path + ".cs", 4 + rowOffset, 14 + columnOffset);
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			Mock<AdditionalFilesHelper> _mockAdditionalFilesHelper = new(new AnalyzerOptions(ImmutableArray.Create<AdditionalText>()), null);
 			_mockAdditionalFilesHelper.Setup(c => c.GetValueFromEditorConfig(It.IsAny<string>(), It.IsAny<string>())).Returns("true");
@@ -81,7 +81,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 	[TestClass]
 	public class NamespaceMatchAssemblyAnalyzerNoFolderTest : DiagnosticVerifier
 	{
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			Mock<AdditionalFilesHelper> _mockAdditionalFilesHelper = new(new AnalyzerOptions(ImmutableArray.Create<AdditionalText>()), null);
 			_mockAdditionalFilesHelper.Setup(c => c.GetValueFromEditorConfig(It.IsAny<string>(), It.IsAny<string>())).Returns("false");

--- a/Philips.CodeAnalysis.Test/Maintainability/Naming/NamespaceMatchAssemblyAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Naming/NamespaceMatchAssemblyAnalyzerTest.cs
@@ -63,7 +63,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 				}
 			};
 
-			VerifyCSharpDiagnostic(code, path, expected);
+			VerifyDiagnostic(code, path, expected);
 		}
 
 		[DataTestMethod]
@@ -74,7 +74,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 		{
 			path = path.Replace('\\', Path.DirectorySeparatorChar);
 			string code = string.Format(ClassString, ns);
-			VerifyCSharpDiagnostic(code, path, Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(code, path, Array.Empty<DiagnosticResult>());
 		}
 	}
 
@@ -110,7 +110,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 				}
 			};
 
-			VerifyCSharpDiagnostic(code, path, expected);
+			VerifyDiagnostic(code, path, expected);
 		}
 
 		[DataTestMethod]
@@ -120,7 +120,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 		{
 			path = path.Replace('\\', Path.DirectorySeparatorChar);
 			string code = string.Format(NamespaceMatchAssemblyAnalyzerUseFolderTest.ClassString, ns);
-			VerifyCSharpDiagnostic(code, path, Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(code, path, Array.Empty<DiagnosticResult>());
 		}
 	}
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Naming/NamespacePrefixAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Naming/NamespacePrefixAnalyzerTest.cs
@@ -77,14 +77,14 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 				}
 			};
 
-			VerifyCSharpDiagnostic(code, expected);
+			VerifyDiagnostic(code, expected);
 		}
 
 		[TestMethod]
 		public void DoNotReportANamespacePrefixError()
 		{
 			string code = string.Format(ClassString, configuredPrefix + ".");
-			VerifyCSharpDiagnostic(code);
+			VerifyDiagnostic(code);
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/Maintainability/Naming/NamespacePrefixAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Naming/NamespacePrefixAnalyzerTest.cs
@@ -49,7 +49,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 			};
 			return options;
 		}
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new NamespacePrefixAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Naming/NamespacePrefixAnalyzerTest1.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Naming/NamespacePrefixAnalyzerTest1.cs
@@ -63,7 +63,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 				}
 			};
 
-			VerifyCSharpDiagnostic(code, expected);
+			VerifyDiagnostic(code, expected);
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/Maintainability/Naming/NamespacePrefixAnalyzerTest1.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Naming/NamespacePrefixAnalyzerTest1.cs
@@ -37,7 +37,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 			return new DiagnosticResultLocation("Test.cs", 4 + rowOffset, 14 + columnOffset);
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new NamespacePrefixAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Naming/PositiveNamingAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Naming/PositiveNamingAnalyzerTest.cs
@@ -26,7 +26,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.PositiveNaming));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.PositiveNaming));
 		}
 
 		[TestMethod]
@@ -40,7 +40,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template);
+			VerifyDiagnostic(template);
 		}
 
 		[TestMethod]
@@ -57,7 +57,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.PositiveNaming));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.PositiveNaming));
 		}
 
 		[TestMethod]
@@ -71,7 +71,7 @@ class Foo
 }
 ";
 
-			VerifyCSharpDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.PositiveNaming));
+			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.PositiveNaming));
 		}
 	}
 }

--- a/Philips.CodeAnalysis.Test/Maintainability/Naming/PositiveNamingAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Naming/PositiveNamingAnalyzerTest.cs
@@ -10,7 +10,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 	[TestClass]
 	public class PositiveNamingAnalyzerTest : DiagnosticVerifier
 	{
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new PositiveNamingAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Naming/VariableNamingConventionAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Naming/VariableNamingConventionAnalyzerTest.cs
@@ -19,7 +19,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new VariableNamingConventionAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Naming/VariableNamingConventionAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Naming/VariableNamingConventionAnalyzerTest.cs
@@ -60,7 +60,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 				};
 			}
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[DataRow("foo", true, 3)]
@@ -101,7 +101,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 				};
 			}
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[TestMethod]
@@ -116,7 +116,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 
 			DiagnosticResult[] expected = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[TestMethod]
@@ -131,7 +131,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 
 			DiagnosticResult[] expected = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[TestMethod]
@@ -146,7 +146,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 
 			DiagnosticResult[] expected = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[TestMethod]
@@ -161,7 +161,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 
 			DiagnosticResult[] expected = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[TestMethod]
@@ -176,7 +176,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 
 			DiagnosticResult[] expected = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[TestMethod]
@@ -191,7 +191,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 
 			DiagnosticResult[] expected = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[TestMethod]
@@ -211,7 +211,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 
 			DiagnosticResult[] expected = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 
@@ -228,7 +228,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 
 			DiagnosticResult[] expected = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[TestMethod]
@@ -243,7 +243,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 
 			DiagnosticResult[] expected = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[TestMethod]
@@ -258,7 +258,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 
 			DiagnosticResult[] expected = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[DataRow("foo", false, 3)]
@@ -298,7 +298,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 				};
 			}
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[DataRow("i", true, 5)]
@@ -341,7 +341,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 				};
 			}
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[DataRow("Foo", "const", true, 5)]
@@ -383,7 +383,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 				};
 			}
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[DataRow("int i; for(i=0;i<5;i++){}", true, 5, 9)]
@@ -425,7 +425,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 				};
 			}
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[DataRow("using(var i = new MemoryStream()){}", true, 5)]
@@ -464,7 +464,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 				};
 			}
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[DataRow("foreach(var i in new[] { 1, 2 }){}", true, 5)]
@@ -503,7 +503,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 				};
 			}
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidInlineNewAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidInlineNewAnalyzerTest.cs
@@ -21,7 +21,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Readability
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidInlineNewAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidInlineNewAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidInlineNewAnalyzerTest.cs
@@ -127,12 +127,12 @@ class Foo
 
 		private void VerifyNoDiagnostic(string file)
 		{
-			VerifyCSharpDiagnostic(file);
+			base.VerifyDiagnostic(file);
 		}
 
 		private void VerifyDiagnostic(string file)
 		{
-			VerifyCSharpDiagnostic(file, new DiagnosticResult()
+			VerifyDiagnostic(file, new DiagnosticResult()
 			{
 				Id = AvoidInlineNewAnalyzer.Rule.Id,
 				Message = new Regex(".+"),

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidMultipleLambdasOnSingleLineAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidMultipleLambdasOnSingleLineAnalyzerTest.cs
@@ -152,7 +152,7 @@ public static class Foo
 		{
 
 			VerifyCSharpDiagnostic(input, DiagnosticResultHelper.Create(DiagnosticIds.AvoidMultipleLambdasOnSingleLine));
-			VerifyCSharpFix(input, fixedCode);
+			VerifyFix(input, fixedCode);
 		}
 
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidMultipleLambdasOnSingleLineAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidMultipleLambdasOnSingleLineAnalyzerTest.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Readability
 			return new AvoidMultipleLambdasOnSingleLineAnalyzer();
 		}
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new AvoidMultipleLambdasOnSingleLineCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidMultipleLambdasOnSingleLineAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidMultipleLambdasOnSingleLineAnalyzerTest.cs
@@ -12,7 +12,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Readability
 	[TestClass]
 	public class AvoidMultipleLambdasOnSingleLineAnalyzerTest : CodeFixVerifier
 	{
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidMultipleLambdasOnSingleLineAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidMultipleLambdasOnSingleLineAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidMultipleLambdasOnSingleLineAnalyzerTest.cs
@@ -171,7 +171,7 @@ public static class Foo
 		[TestMethod]
 		public void GeneratedFileWrongIsNotFlagged()
 		{
-			VerifyCSharpDiagnostic(WrongMultiple, @"Foo.designer");
+			VerifyDiagnostic(WrongMultiple, @"Foo.designer");
 		}
 	}
 }

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidMultipleLambdasOnSingleLineAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidMultipleLambdasOnSingleLineAnalyzerTest.cs
@@ -151,7 +151,7 @@ public static class Foo
 		public void FlagWhen2LambdasOnSameLine(string input, string fixedCode)
 		{
 
-			VerifyCSharpDiagnostic(input, DiagnosticResultHelper.Create(DiagnosticIds.AvoidMultipleLambdasOnSingleLine));
+			VerifyDiagnostic(input, DiagnosticResultHelper.Create(DiagnosticIds.AvoidMultipleLambdasOnSingleLine));
 			VerifyFix(input, fixedCode);
 		}
 
@@ -165,7 +165,7 @@ public static class Foo
 		 DataRow(CorrectParenthesized, DisplayName = nameof(CorrectParenthesized))]
 		public void CorrectDoesNotFlag(string input)
 		{
-			VerifyCSharpDiagnostic(input);
+			VerifyDiagnostic(input);
 		}
 
 		[TestMethod]

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidRedundantSwitchStatementAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidRedundantSwitchStatementAnalyzerTest.cs
@@ -14,7 +14,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Readability
 	[TestClass]
 	public class AvoidRedundantSwitchStatementAnalyzerGeneratedCodeTest : AvoidRedundantSwitchStatementAnalyzerTest
 	{
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidRedundantSwitchStatementAnalyzer(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
 		}
@@ -23,7 +23,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Readability
 	[TestClass]
 	public class AvoidRedundantSwitchStatementAnalyzerTest : DiagnosticVerifier
 	{
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidRedundantSwitchStatementAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidRedundantSwitchStatementAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidRedundantSwitchStatementAnalyzerTest.cs
@@ -49,7 +49,7 @@ public static class Foo
 }}
 ";
 
-			VerifyCSharpDiagnostic(input, DiagnosticResultHelper.Create(DiagnosticIds.AvoidSwitchStatementsWithNoCases));
+			VerifyDiagnostic(input, DiagnosticResultHelper.Create(DiagnosticIds.AvoidSwitchStatementsWithNoCases));
 		}
 
 
@@ -76,7 +76,7 @@ public class Foo
 		public void GeneratedSwitchWithOnlyDefaultCaseIsNotFlagged()
 		{
 			string input = @"[System.CodeDom.Compiler.GeneratedCodeAttribute(""protoc"", null)]" + SampleMethodWithSwitches;
-			VerifyCSharpDiagnostic(input);
+			VerifyDiagnostic(input);
 		}
 
 
@@ -108,7 +108,7 @@ public static class Foo
 }}
 ";
 
-			VerifyCSharpDiagnostic(input, DiagnosticResultHelper.Create(DiagnosticIds.AvoidSwitchStatementsWithNoCases));
+			VerifyDiagnostic(input, DiagnosticResultHelper.Create(DiagnosticIds.AvoidSwitchStatementsWithNoCases));
 		}
 
 		[DataRow("byte", "1")]
@@ -134,7 +134,7 @@ public static class Foo
 }}
 ";
 
-			VerifyCSharpDiagnostic(input);
+			VerifyDiagnostic(input);
 		}
 
 
@@ -157,7 +157,7 @@ public static class Foo
 }}
 ";
 
-			VerifyCSharpDiagnostic(input, DiagnosticResultHelper.Create(DiagnosticIds.AvoidSwitchStatementsWithNoCases));
+			VerifyDiagnostic(input, DiagnosticResultHelper.Create(DiagnosticIds.AvoidSwitchStatementsWithNoCases));
 		}
 
 		[DataRow("byte", "1")]
@@ -180,7 +180,7 @@ public static class Foo
 }}
 ";
 
-			VerifyCSharpDiagnostic(input);
+			VerifyDiagnostic(input);
 		}
 
 	}

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidRedundantSwitchStatementAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidRedundantSwitchStatementAnalyzerTest.cs
@@ -83,7 +83,7 @@ public class Foo
 		[TestMethod]
 		public void GeneratedFileSwitchWithOnlyDefaultCaseIsNotFlagged()
 		{
-			VerifyCSharpDiagnostic(SampleMethodWithSwitches, @"Foo.designer");
+			VerifyDiagnostic(SampleMethodWithSwitches, @"Foo.designer");
 		}
 
 		[DataRow("byte", "1")]

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/EnforceRegionsTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/EnforceRegionsTest.cs
@@ -265,7 +265,7 @@ class Foo
 			VerifyCSharpDiagnostic(givenText, results);
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new EnforceRegionsAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/EnforceRegionsTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/EnforceRegionsTest.cs
@@ -237,7 +237,7 @@ class Foo
 			{
 				results = Array.Empty<DiagnosticResult>();
 			}
-			VerifyCSharpDiagnostic(givenText, results);
+			VerifyDiagnostic(givenText, results);
 		}
 
 		private void VerifyError(string baseline, string given, bool isError, int line = 6, int column = 2)
@@ -262,7 +262,7 @@ class Foo
 			{
 				results = Array.Empty<DiagnosticResult>();
 			}
-			VerifyCSharpDiagnostic(givenText, results);
+			VerifyDiagnostic(givenText, results);
 		}
 
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/EveryLinqStatementOnSeparateLineAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/EveryLinqStatementOnSeparateLineAnalyzerTest.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Readability
 			return new EveryLinqStatementOnSeparateLineAnalyzer();
 		}
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new EveryLinqStatementOnSeparateLineCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/EveryLinqStatementOnSeparateLineAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/EveryLinqStatementOnSeparateLineAnalyzerTest.cs
@@ -71,7 +71,7 @@ public static class Foo
 		public void SingleStatementsPerLineDoesNotTriggersDiagnostics(string input)
 		{
 
-			VerifyCSharpDiagnostic(input);
+			VerifyDiagnostic(input);
 		}
 
 		private const string WhereOnSameLine = $@"
@@ -103,7 +103,7 @@ public static class Foo
 		 DataRow(SelectOnSameLine, DisplayName = nameof(SelectOnSameLine))]
 		public void MultipleStatementsOnSameLineTriggersDiagnostics(string input)
 		{
-			VerifyCSharpDiagnostic(input, DiagnosticResultHelper.Create(DiagnosticIds.EveryLinqStatementOnSeparateLine));
+			VerifyDiagnostic(input, DiagnosticResultHelper.Create(DiagnosticIds.EveryLinqStatementOnSeparateLine));
 			VerifyFix(input, Correct);
 		}
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/EveryLinqStatementOnSeparateLineAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/EveryLinqStatementOnSeparateLineAnalyzerTest.cs
@@ -104,7 +104,7 @@ public static class Foo
 		public void MultipleStatementsOnSameLineTriggersDiagnostics(string input)
 		{
 			VerifyCSharpDiagnostic(input, DiagnosticResultHelper.Create(DiagnosticIds.EveryLinqStatementOnSeparateLine));
-			VerifyCSharpFix(input, Correct);
+			VerifyFix(input, Correct);
 		}
 
 		/// <summary>

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/EveryLinqStatementOnSeparateLineAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/EveryLinqStatementOnSeparateLineAnalyzerTest.cs
@@ -12,7 +12,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Readability
 	[TestClass]
 	public class EveryLinqStatementOnSeparateLineAnalyzerTest : CodeFixVerifier
 	{
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new EveryLinqStatementOnSeparateLineAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/EveryLinqStatementOnSeparateLineAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/EveryLinqStatementOnSeparateLineAnalyzerTest.cs
@@ -114,7 +114,7 @@ public static class Foo
 		[DataRow(WhereOnSameLine, "Dummy.Designer", DisplayName = "OutOfScopeSourceFile")]
 		public void WhenSourceFileIsOutOfScopeNoDiagnosticIsTriggered(string testCode, string filePath)
 		{
-			VerifyCSharpDiagnostic(testCode, filePath);
+			VerifyDiagnostic(testCode, filePath);
 		}
 	}
 }

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/LimitConditionComplexityAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/LimitConditionComplexityAnalyzerTest.cs
@@ -65,7 +65,7 @@ namespace ComplexConditionUnitTests {
 			DataRow(CorrectSingle, DisplayName = nameof(CorrectSingle))]
 		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
 		{
-			VerifyCSharpDiagnostic(testCode);
+			VerifyDiagnostic(testCode);
 		}
 
 		/// <summary>
@@ -76,7 +76,7 @@ namespace ComplexConditionUnitTests {
 		public void WhenConditionIsTooComplexDiagnosticIsTriggered(string testCode)
 		{
 			var expected = DiagnosticResultHelper.Create(DiagnosticIds.LimitConditionComplexity);
-			VerifyCSharpDiagnostic(testCode, expected);
+			VerifyDiagnostic(testCode, expected);
 		}
 
 		/// <summary>

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/LimitConditionComplexityAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/LimitConditionComplexityAnalyzerTest.cs
@@ -86,7 +86,7 @@ namespace ComplexConditionUnitTests {
 		[DataRow(Wrong, "Dummy.Designer", DisplayName = "OutOfScopeSourceFile")]
 		public void WhenSourceFileIsOutOfScopeNoDiagnosticIsTriggered(string testCode, string filePath)
 		{
-			VerifyCSharpDiagnostic(testCode, filePath);
+			VerifyDiagnostic(testCode, filePath);
 		}
 
 		/// <summary>

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/LimitConditionComplexityAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/LimitConditionComplexityAnalyzerTest.cs
@@ -92,7 +92,7 @@ namespace ComplexConditionUnitTests {
 		/// <summary>
 		/// <inheritdoc cref="DiagnosticVerifier"/>
 		/// </summary>
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new LimitConditionComplexityAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/LimitConditionComplexityAnalyzerTest2.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/LimitConditionComplexityAnalyzerTest2.cs
@@ -66,7 +66,7 @@ namespace ComplexConditionUnitTests {
 		/// <summary>
 		/// <inheritdoc cref="DiagnosticVerifier"/>
 		/// </summary>
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new LimitConditionComplexityAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/LimitConditionComplexityAnalyzerTest2.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/LimitConditionComplexityAnalyzerTest2.cs
@@ -48,7 +48,7 @@ namespace ComplexConditionUnitTests {
 		[DataRow(CorrectCode, DisplayName = nameof(WhenConfigInvalidDefaultValueUsedAndCorrectCodePasses))]
 		public void WhenConfigInvalidDefaultValueUsedAndCorrectCodePasses(string testCode)
 		{
-			VerifyCSharpDiagnostic(testCode);
+			VerifyDiagnostic(testCode);
 		}
 
 		/// <summary>
@@ -59,7 +59,7 @@ namespace ComplexConditionUnitTests {
 		public void WhenConfigInvalidDefaultValueUsedAndIncorrectCodeFails(string testCode)
 		{
 			var expected = DiagnosticResultHelper.Create(DiagnosticIds.LimitConditionComplexity);
-			VerifyCSharpDiagnostic(testCode, expected);
+			VerifyDiagnostic(testCode, expected);
 		}
 
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/PreferNamedTuplesAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/PreferNamedTuplesAnalyzerTest.cs
@@ -48,7 +48,7 @@ class Foo
 		public void NamedTuplesDontCauseErrors(string argument)
 		{
 			var source = CreateFunction(argument);
-			VerifyCSharpDiagnostic(source);
+			VerifyDiagnostic(source);
 		}
 
 		[DataRow("(int, int)")]
@@ -56,7 +56,7 @@ class Foo
 		public void ErrorIfTupleElementsDoNotHaveNames(string argument)
 		{
 			var source = CreateFunction(argument);
-			VerifyCSharpDiagnostic(source, DiagnosticResultHelper.Create(DiagnosticIds.PreferTuplesWithNamedFields), DiagnosticResultHelper.Create(DiagnosticIds.PreferTuplesWithNamedFields));
+			VerifyDiagnostic(source, DiagnosticResultHelper.Create(DiagnosticIds.PreferTuplesWithNamedFields), DiagnosticResultHelper.Create(DiagnosticIds.PreferTuplesWithNamedFields));
 		}
 
 		[DataRow("(int Foo, int)")]
@@ -64,7 +64,7 @@ class Foo
 		public void ErrorIfTupleElementDoesNotHaveName(string argument)
 		{
 			var source = CreateFunction(argument);
-			VerifyCSharpDiagnostic(source, DiagnosticResultHelper.Create(DiagnosticIds.PreferTuplesWithNamedFields));
+			VerifyDiagnostic(source, DiagnosticResultHelper.Create(DiagnosticIds.PreferTuplesWithNamedFields));
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/PreferNamedTuplesAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/PreferNamedTuplesAnalyzerTest.cs
@@ -20,7 +20,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Readability
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new PreferNamedTuplesAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/PreferTupleFieldNamesAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/PreferTupleFieldNamesAnalyzerTest.cs
@@ -59,7 +59,7 @@ class Foo
 			}
 
 			var source = CreateFunction(argument);
-			VerifyCSharpDiagnostic(source, results);
+			VerifyDiagnostic(source, results);
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/PreferTupleFieldNamesAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/PreferTupleFieldNamesAnalyzerTest.cs
@@ -21,7 +21,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Readability
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new PreferTupleFieldNamesAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/PreventUnnecessaryRangeChecksAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/PreventUnnecessaryRangeChecksAnalyzerTest.cs
@@ -22,7 +22,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Readability
 			return new PreventUnnecessaryRangeChecksAnalyzer();
 		}
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new PreventUnnecessaryRangeChecksCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/PreventUnnecessaryRangeChecksAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/PreventUnnecessaryRangeChecksAnalyzerTest.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Readability
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new PreventUnnecessaryRangeChecksAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/PreventUnnecessaryRangeChecksAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/PreventUnnecessaryRangeChecksAnalyzerTest.cs
@@ -77,7 +77,7 @@ class Foo
 
 			VerifyCSharpDiagnostic(errorCode, DiagnosticResultHelper.Create(DiagnosticIds.PreventUncessaryRangeChecks));
 
-			VerifyCSharpFix(errorCode, string.Format(fixedTemplate, declaration));
+			VerifyFix(errorCode, string.Format(fixedTemplate, declaration));
 		}
 
 		[DataRow("int[] data = new int[0]", "Length")]
@@ -168,7 +168,7 @@ class Foo
 
 			VerifyCSharpDiagnostic(errorCode, DiagnosticResultHelper.Create(DiagnosticIds.PreventUncessaryRangeChecks));
 
-			VerifyCSharpFix(errorCode, string.Format(fixedTemplate, declaration));
+			VerifyFix(errorCode, string.Format(fixedTemplate, declaration));
 		}
 
 		[DataRow("int[] data = new int[0]", "Length")]
@@ -324,7 +324,7 @@ class Foo
 
 			VerifyCSharpDiagnostic(errorCode, DiagnosticResultHelper.Create(DiagnosticIds.PreventUncessaryRangeChecks));
 
-			VerifyCSharpFix(errorCode, string.Format(fixedTemplate, declaration));
+			VerifyFix(errorCode, string.Format(fixedTemplate, declaration));
 		}
 
 		[DataRow("int[] data = new int[0]", "Length")]
@@ -367,7 +367,7 @@ class Foo
 
 			VerifyCSharpDiagnostic(errorCode, DiagnosticResultHelper.Create(DiagnosticIds.PreventUncessaryRangeChecks));
 
-			VerifyCSharpFix(errorCode, string.Format(fixedTemplate, declaration));
+			VerifyFix(errorCode, string.Format(fixedTemplate, declaration));
 		}
 
 		[DataRow("int[] data = new int[0]", "Length")]

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/PreventUnnecessaryRangeChecksAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/PreventUnnecessaryRangeChecksAnalyzerTest.cs
@@ -75,7 +75,7 @@ class Foo
 
 			string errorCode = string.Format(template, declaration, countLengthMethod);
 
-			VerifyCSharpDiagnostic(errorCode, DiagnosticResultHelper.Create(DiagnosticIds.PreventUncessaryRangeChecks));
+			VerifyDiagnostic(errorCode, DiagnosticResultHelper.Create(DiagnosticIds.PreventUncessaryRangeChecks));
 
 			VerifyFix(errorCode, string.Format(fixedTemplate, declaration));
 		}
@@ -108,7 +108,7 @@ class Foo
 }}
 ";
 			string errorCode = string.Format(template, declaration, countLengthMethod);
-			VerifyCSharpDiagnostic(errorCode);
+			VerifyDiagnostic(errorCode);
 		}
 
 
@@ -166,7 +166,7 @@ class Foo
 
 			string errorCode = string.Format(template, declaration, countLengthMethod);
 
-			VerifyCSharpDiagnostic(errorCode, DiagnosticResultHelper.Create(DiagnosticIds.PreventUncessaryRangeChecks));
+			VerifyDiagnostic(errorCode, DiagnosticResultHelper.Create(DiagnosticIds.PreventUncessaryRangeChecks));
 
 			VerifyFix(errorCode, string.Format(fixedTemplate, declaration));
 		}
@@ -204,7 +204,7 @@ class Foo
 ";
 			string errorCode = string.Format(template, declaration, countLengthMethod);
 
-			VerifyCSharpDiagnostic(errorCode);
+			VerifyDiagnostic(errorCode);
 		}
 
 		[TestMethod]
@@ -238,7 +238,7 @@ class Foo
 ";
 			string errorCode = string.Format(template);
 
-			VerifyCSharpDiagnostic(errorCode);
+			VerifyDiagnostic(errorCode);
 		}
 
 		[DataRow("int[] data = new int[0]", "Length")]
@@ -279,7 +279,7 @@ class Foo
 ";
 			string errorCode = string.Format(template, declaration, countLengthMethod);
 
-			VerifyCSharpDiagnostic(errorCode);
+			VerifyDiagnostic(errorCode);
 		}
 
 		[DataRow("int[] data = new int[0]", "Length")]
@@ -322,7 +322,7 @@ class Foo
 
 			string errorCode = string.Format(template, declaration, countLengthMethod);
 
-			VerifyCSharpDiagnostic(errorCode, DiagnosticResultHelper.Create(DiagnosticIds.PreventUncessaryRangeChecks));
+			VerifyDiagnostic(errorCode, DiagnosticResultHelper.Create(DiagnosticIds.PreventUncessaryRangeChecks));
 
 			VerifyFix(errorCode, string.Format(fixedTemplate, declaration));
 		}
@@ -365,7 +365,7 @@ class Foo
 
 			string errorCode = string.Format(template, declaration, countLengthMethod);
 
-			VerifyCSharpDiagnostic(errorCode, DiagnosticResultHelper.Create(DiagnosticIds.PreventUncessaryRangeChecks));
+			VerifyDiagnostic(errorCode, DiagnosticResultHelper.Create(DiagnosticIds.PreventUncessaryRangeChecks));
 
 			VerifyFix(errorCode, string.Format(fixedTemplate, declaration));
 		}
@@ -398,7 +398,7 @@ public void test()
 }}
 ";
 
-			VerifyCSharpDiagnostic(string.Format(template, declaration, countLengthMethod));
+			VerifyDiagnostic(string.Format(template, declaration, countLengthMethod));
 		}
 
 		[DataRow("int[] data = new int[0]", "Length")]
@@ -427,7 +427,7 @@ public void test()
 }}
 ";
 
-			VerifyCSharpDiagnostic(string.Format(template, declaration, countLengthMethod), DiagnosticResultHelper.Create(DiagnosticIds.PreventUncessaryRangeChecks));
+			VerifyDiagnostic(string.Format(template, declaration, countLengthMethod), DiagnosticResultHelper.Create(DiagnosticIds.PreventUncessaryRangeChecks));
 		}
 
 		[DataRow("int[] data = new int[0]", "Length")]
@@ -458,7 +458,7 @@ public void test()
 }}
 ";
 
-			VerifyCSharpDiagnostic(string.Format(template, declaration, countLengthMethod));
+			VerifyDiagnostic(string.Format(template, declaration, countLengthMethod));
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/DereferenceNullAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/DereferenceNullAnalyzerTest.cs
@@ -11,7 +11,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.RuntimeFailure
 	[TestClass]
 	public class DereferenceNullAnalyzerTest : DiagnosticVerifier
 	{
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new DereferenceNullAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/DereferenceNullAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/DereferenceNullAnalyzerTest.cs
@@ -65,7 +65,7 @@ Instruction i = method.Body.Instructions[0];
 }}
 ";
 			var expected = DiagnosticResultHelper.CreateArray(DiagnosticIds.DereferenceNull);
-			VerifyCSharpDiagnostic(testCode, expected);
+			VerifyDiagnostic(testCode, expected);
 		}
 		
 		/// <summary>
@@ -84,7 +84,7 @@ Instruction i = method.Body.Instructions[0];
 			var format = GetTemplate();
 			string testCode = string.Format(format, content1, content2);
 			var expected = DiagnosticResultHelper.CreateArray(DiagnosticIds.DereferenceNull);
-			VerifyCSharpDiagnostic(testCode, expected);
+			VerifyDiagnostic(testCode, expected);
 		}
 
 		/// <summary>
@@ -103,7 +103,7 @@ Instruction i = method.Body.Instructions[0];
 		{
 			var format = GetTemplate();
 			string testCode = string.Format(format, content1, content2);
-			VerifyCSharpDiagnostic(testCode, Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(testCode, Array.Empty<DiagnosticResult>());
 		}
 
 
@@ -125,7 +125,7 @@ class Foo
   }}
 }}
 ";
-			VerifyCSharpDiagnostic(testCode, Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(testCode, Array.Empty<DiagnosticResult>());
 		}
 
 
@@ -148,7 +148,7 @@ class Foo
 }}
 ";
 			var expected = DiagnosticResultHelper.CreateArray(DiagnosticIds.DereferenceNull);
-			VerifyCSharpDiagnostic(testCode, expected);
+			VerifyDiagnostic(testCode, expected);
 		}
 
 		[TestMethod]
@@ -169,7 +169,7 @@ class Foo
   }}
 }}
 ";
-			VerifyCSharpDiagnostic(testCode, Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(testCode, Array.Empty<DiagnosticResult>());
 		}
 
 		[TestMethod]
@@ -190,7 +190,7 @@ class Foo
   }}
 }}
 ";
-			VerifyCSharpDiagnostic(testCode, Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(testCode, Array.Empty<DiagnosticResult>());
 		}
 
 
@@ -209,7 +209,7 @@ class Foo
   }}
 }}
 ";
-			VerifyCSharpDiagnostic(testCode, Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(testCode, Array.Empty<DiagnosticResult>());
 		}
 
 		[TestMethod]
@@ -230,7 +230,7 @@ class Foo
   }}
 }}
 ";
-			VerifyCSharpDiagnostic(testCode, Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(testCode, Array.Empty<DiagnosticResult>());
 		}
 		
 		[TestMethod]
@@ -251,7 +251,7 @@ class Foo
   }}
 }}
 ";
-			VerifyCSharpDiagnostic(testCode, Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(testCode, Array.Empty<DiagnosticResult>());
 		}
 
 		[TestMethod]
@@ -273,7 +273,7 @@ class Foo
 }}
 ";
 			var expected = DiagnosticResultHelper.CreateArray(DiagnosticIds.DereferenceNull);
-			VerifyCSharpDiagnostic(testCode, expected);
+			VerifyDiagnostic(testCode, expected);
 		}
 
 
@@ -295,7 +295,7 @@ class Foo
   }}
 }}
 ";
-			VerifyCSharpDiagnostic(testCode, Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(testCode, Array.Empty<DiagnosticResult>());
 		}
 
 	}

--- a/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/LimitPathLengthAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/LimitPathLengthAnalyzerTest.cs
@@ -76,7 +76,7 @@ namespace PathTooLongUnitTest {
 			VerifyCSharpDiagnostic(Correct, filePath, expected);
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() {
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer() {
 			return new LimitPathLengthAnalyzer();
 		}
 	}

--- a/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/LimitPathLengthAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/LimitPathLengthAnalyzerTest.cs
@@ -60,7 +60,7 @@ namespace PathTooLongUnitTest {
 		 DataRow(ShortRelativePath, DisplayName = "ShortRelativePath")]
 		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string filePath)
 		{
-			VerifyCSharpDiagnostic(Correct, filePath);
+			VerifyDiagnostic(Correct, filePath);
 		}
 
 		/// <summary>
@@ -73,7 +73,7 @@ namespace PathTooLongUnitTest {
 		 DataRow(GeneratedFilePath, DisplayName = "GeneratedFile")]
 		public void WhenPathIsTooLongDiagnosticIsRaised(string filePath) {
 			var expected = DiagnosticResultHelper.Create(DiagnosticIds.LimitPathLength);
-			VerifyCSharpDiagnostic(Correct, filePath, expected);
+			VerifyDiagnostic(Correct, filePath, expected);
 		}
 
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer() {

--- a/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/NoSpaceInFilenameAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/NoSpaceInFilenameAnalyzerTest.cs
@@ -55,7 +55,7 @@ namespace PathTooLongUnitTest {
 			VerifyCSharpDiagnostic(Correct, filePath, expected);
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() {
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer() {
 			return new NoSpaceInFilenameAnalyzer();
 		}
 	}

--- a/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/NoSpaceInFilenameAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/NoSpaceInFilenameAnalyzerTest.cs
@@ -40,7 +40,7 @@ namespace PathTooLongUnitTest {
 		 DataRow(OutOfScopePath, DisplayName = "OutOfScopePath")]
 		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string filePath)
 		{
-			VerifyCSharpDiagnostic(Correct, filePath);
+			VerifyDiagnostic(Correct, filePath);
 		}
 
 		/// <summary>
@@ -52,7 +52,7 @@ namespace PathTooLongUnitTest {
 		 DataRow(SpaceRelativePath, 1, 1, DisplayName = "SpaceRelativePath")]
 		public void WhenFileNameHasSpaceDiagnosticIsRaised(string filePath, int line, int column) {
 			var expected = DiagnosticResultHelper.Create(DiagnosticIds.NoSpaceInFilename);
-			VerifyCSharpDiagnostic(Correct, filePath, expected);
+			VerifyDiagnostic(Correct, filePath, expected);
 		}
 
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer() {

--- a/Philips.CodeAnalysis.Test/Moq/MockObjectsMustCallExistingConstructorsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Moq/MockObjectsMustCallExistingConstructorsAnalyzerTest.cs
@@ -19,7 +19,7 @@ namespace Philips.CodeAnalysis.Test.Moq
 		#endregion
 
 		#region Non-Public Properties/Methods
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new MockObjectsMustCallExistingConstructorsAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Moq/MockObjectsMustCallExistingConstructorsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Moq/MockObjectsMustCallExistingConstructorsAnalyzerTest.cs
@@ -72,7 +72,7 @@ public static class Bar
 				};
 			}
 
-			VerifyCSharpDiagnostic(string.Format(template, arguments), expectedErrors);
+			VerifyDiagnostic(string.Format(template, arguments), expectedErrors);
 		}
 
 		[TestMethod]
@@ -104,7 +104,7 @@ public static class Bar
 				}
 			};
 
-			VerifyCSharpDiagnostic(string.Format(template), expectedErrors);
+			VerifyDiagnostic(string.Format(template), expectedErrors);
 		}
 
 		[TestMethod]
@@ -126,7 +126,7 @@ public static class Bar
 
 			DiagnosticResult[] expectedErrors = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(string.Format(template), expectedErrors);
+			VerifyDiagnostic(string.Format(template), expectedErrors);
 		}
 
 		[TestMethod]
@@ -157,7 +157,7 @@ public static class Bar
 
 			DiagnosticResult[] expectedErrors = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(string.Format(template), expectedErrors);
+			VerifyDiagnostic(string.Format(template), expectedErrors);
 		}
 
 		[TestMethod]
@@ -187,7 +187,7 @@ public static class Bar
 
 			DiagnosticResult[] expectedErrors = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(string.Format(template), expectedErrors);
+			VerifyDiagnostic(string.Format(template), expectedErrors);
 		}
 
 		[TestMethod]
@@ -217,7 +217,7 @@ public static class Bar
 
 			DiagnosticResult[] expectedErrors = Array.Empty<DiagnosticResult>();
 
-			VerifyCSharpDiagnostic(string.Format(template), expectedErrors);
+			VerifyDiagnostic(string.Format(template), expectedErrors);
 		}
 
 		[DataRow("", false)]
@@ -254,7 +254,7 @@ public static class Bar
 				};
 			}
 
-			VerifyCSharpDiagnostic(string.Format(template, arguments), expectedErrors);
+			VerifyDiagnostic(string.Format(template, arguments), expectedErrors);
 		}
 
 		[DataRow("{ TestProperty = string.Empty }", false)]
@@ -294,7 +294,7 @@ public static class Bar
 				};
 			}
 
-			VerifyCSharpDiagnostic(string.Format(template, arguments), expectedErrors);
+			VerifyDiagnostic(string.Format(template, arguments), expectedErrors);
 		}
 
 		[DataRow("-1, false", false)]
@@ -334,7 +334,7 @@ public static class Bar
 				};
 			}
 
-			VerifyCSharpDiagnostic(string.Format(template, arguments), expectedErrors);
+			VerifyDiagnostic(string.Format(template, arguments), expectedErrors);
 		}
 
 		[DataRow("-1, false", false)]
@@ -376,7 +376,7 @@ public static class Bar
 				};
 			}
 
-			VerifyCSharpDiagnostic(string.Format(template, arguments), expectedErrors);
+			VerifyDiagnostic(string.Format(template, arguments), expectedErrors);
 		}
 
 		[DataRow("", false)]
@@ -416,7 +416,7 @@ public static class Bar
 				};
 			}
 
-			VerifyCSharpDiagnostic(string.Format(template, arguments), expectedErrors);
+			VerifyDiagnostic(string.Format(template, arguments), expectedErrors);
 		}
 
 		[DataRow("", false)]
@@ -453,7 +453,7 @@ public static class Bar
 				};
 			}
 
-			VerifyCSharpDiagnostic(string.Format(template, arguments), expectedErrors);
+			VerifyDiagnostic(string.Format(template, arguments), expectedErrors);
 		}
 
 		[DataRow("Mockable m = Mock.Of<")]
@@ -486,7 +486,7 @@ public static class Bar
 ";
 
 			DiagnosticResult[] expectedErrors = Array.Empty<DiagnosticResult>();
-			VerifyCSharpDiagnostic(string.Format(template, statement), expectedErrors);
+			VerifyDiagnostic(string.Format(template, statement), expectedErrors);
 		}
 
 		[DataRow("", false)]
@@ -524,7 +524,7 @@ public static class Bar
 				};
 			}
 
-			VerifyCSharpDiagnostic(string.Format(template, arguments), expectedErrors);
+			VerifyDiagnostic(string.Format(template, arguments), expectedErrors);
 		}
 
 		[DataRow("string.Empty", false)]
@@ -564,7 +564,7 @@ public static class Bar
 				};
 			}
 
-			VerifyCSharpDiagnostic(string.Format(template, arguments), expectedErrors);
+			VerifyDiagnostic(string.Format(template, arguments), expectedErrors);
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/Moq/MockRaiseArgumentsMustMatchEventAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Moq/MockRaiseArgumentsMustMatchEventAnalyzerTest.cs
@@ -80,7 +80,7 @@ public static class Bar
 				arguments = $", {args}";
 			}
 
-			VerifyCSharpDiagnostic(string.Format(template, arguments), expectedErrors);
+			VerifyDiagnostic(string.Format(template, arguments), expectedErrors);
 		}
 
 		[DataRow(true, "")]
@@ -129,7 +129,7 @@ public static class Bar
 				arguments = $", {args}";
 			}
 
-			VerifyCSharpDiagnostic(string.Format(template, arguments), expectedErrors);
+			VerifyDiagnostic(string.Format(template, arguments), expectedErrors);
 		}
 
 		//[DataRow(true, "", DiagnosticIds.MockRaiseArgumentCountMismatch)]
@@ -180,7 +180,7 @@ public static class Bar
 				arguments = $", {args}";
 			}
 
-			VerifyCSharpDiagnostic(string.Format(template, arguments), expectedErrors);
+			VerifyDiagnostic(string.Format(template, arguments), expectedErrors);
 		}
 
 		[DataRow(true, "", 1, @"PH2054")]
@@ -236,7 +236,7 @@ public static class Bar
 				arguments = $", {args}";
 			}
 
-			VerifyCSharpDiagnostic(string.Format(template, arguments), expectedErrors);
+			VerifyDiagnostic(string.Format(template, arguments), expectedErrors);
 		}
 
 		[DataRow(true, "", 1, @"PH2054")]
@@ -291,7 +291,7 @@ public static class Bar
 				arguments = $", {args}";
 			}
 
-			VerifyCSharpDiagnostic(string.Format(template, arguments), expectedErrors);
+			VerifyDiagnostic(string.Format(template, arguments), expectedErrors);
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/Moq/MockRaiseArgumentsMustMatchEventAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Moq/MockRaiseArgumentsMustMatchEventAnalyzerTest.cs
@@ -20,7 +20,7 @@ namespace Philips.CodeAnalysis.Test.Moq
 		#endregion
 
 		#region Non-Public Properties/Methods
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new MockRaiseArgumentsMustMatchEventAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/AssertAreEqualAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AssertAreEqualAnalyzerTest.cs
@@ -21,7 +21,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 			};
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AssertAreEqualAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/AssertAreEqualAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AssertAreEqualAnalyzerTest.cs
@@ -26,7 +26,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 			return new AssertAreEqualAnalyzer();
 		}
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new AssertAreEqualCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/AssertAreEqualLiteralAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AssertAreEqualLiteralAnalyzerTest.cs
@@ -27,7 +27,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 			};
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AssertAreEqualLiteralAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/AssertAreEqualLiteralAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AssertAreEqualLiteralAnalyzerTest.cs
@@ -32,7 +32,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 			return new AssertAreEqualLiteralAnalyzer();
 		}
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new AssertAreEqualLiteralCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/AssertAreEqualTypesMatchAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AssertAreEqualTypesMatchAnalyzerTest.cs
@@ -63,7 +63,7 @@ namespace AssertAreEqualTypesMatchAnalyzerTest
 			VerifyCSharpDiagnostic(givenText, "Test0", isError ? expected : Array.Empty<DiagnosticResult>());
 		}
 		
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AssertAreEqualTypesMatchAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/AssertAreEqualTypesMatchAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AssertAreEqualTypesMatchAnalyzerTest.cs
@@ -60,7 +60,7 @@ namespace AssertAreEqualTypesMatchAnalyzerTest
 				}
 			}};
 
-			VerifyCSharpDiagnostic(givenText, "Test0", isError ? expected : Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(givenText, "Test0", isError ? expected : Array.Empty<DiagnosticResult>());
 		}
 		
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()

--- a/Philips.CodeAnalysis.Test/MsTest/AssertFailAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AssertFailAnalyzerTest.cs
@@ -16,7 +16,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AssertFailAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/AssertIsTrueAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AssertIsTrueAnalyzerTest.cs
@@ -212,7 +212,7 @@ Assert.IsTrue(foo.Test());
 			return new AssertIsTrueCodeFixProvider();
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AssertIsTrueAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/AssertIsTrueAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AssertIsTrueAnalyzerTest.cs
@@ -98,7 +98,7 @@ class Foo
 
 			VerifyCSharpDiagnostic(givenText);
 
-			VerifyCSharpFix(givenText, givenText);
+			VerifyFix(givenText, givenText);
 		}
 
 		[TestMethod]

--- a/Philips.CodeAnalysis.Test/MsTest/AssertIsTrueAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AssertIsTrueAnalyzerTest.cs
@@ -96,7 +96,7 @@ class Foo
 
 ";
 
-			VerifyCSharpDiagnostic(givenText);
+			VerifyDiagnostic(givenText);
 
 			VerifyFix(givenText, givenText);
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/AssertIsTrueAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AssertIsTrueAnalyzerTest.cs
@@ -207,7 +207,7 @@ Assert.IsTrue(foo.Test());
 			};
 		}
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new AssertIsTrueCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/AssertIsTrueLiteralAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AssertIsTrueLiteralAnalyzerTest.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AssertIsTrueLiteralAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/AssertIsTrueParenthesisAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AssertIsTrueParenthesisAnalyzerTest.cs
@@ -32,7 +32,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 			};
 		}
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new AssertIsTrueParenthesisCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/AssertIsTrueParenthesisAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AssertIsTrueParenthesisAnalyzerTest.cs
@@ -37,7 +37,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 			return new AssertIsTrueParenthesisCodeFixProvider();
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AssertIsTrueParenthesisAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/AvoidAssertConditionalAccessAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AvoidAssertConditionalAccessAnalyzerTest.cs
@@ -18,7 +18,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidAssertConditionalAccessAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/AvoidAssertConditionalAccessAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AvoidAssertConditionalAccessAnalyzerTest.cs
@@ -51,7 +51,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 		[DataRow("string name1=\"xyz\"; string name2=\"abc\"; Assert.AreEqual(name1.ToString(), name2.ToString(), $\"error{name1?.ToString()}\")")]
 		public void AvoidAssertConditionalAccessAnalyzerSuccessTest(string test)
 		{
-			VerifyCSharpDiagnostic(test, Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(test, Array.Empty<DiagnosticResult>());
 		}
 		#endregion
 	}

--- a/Philips.CodeAnalysis.Test/MsTest/AvoidAttributeAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AvoidAttributeAnalyzerTest.cs
@@ -254,7 +254,7 @@ class Foo
 			VerifyCSharpDiagnostic(givenText);
 		}
 		
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidAttributeAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/AvoidAttributeAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AvoidAttributeAnalyzerTest.cs
@@ -50,7 +50,7 @@ class Foo
 				}
 			};
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 
@@ -83,7 +83,7 @@ class Foo
 				}
 			};
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[DataTestMethod]
@@ -113,7 +113,7 @@ class Foo
 				}
 			};
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 
@@ -144,7 +144,7 @@ class Foo
 				}
 			};
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 
@@ -175,7 +175,7 @@ class Foo
 				}
 			};
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 
@@ -206,7 +206,7 @@ class Foo
 				}
 			};
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[DataTestMethod]
@@ -228,7 +228,7 @@ class Foo
 ";
 			string givenText = string.Format(baseline, test);
 
-			VerifyCSharpDiagnostic(givenText);
+			VerifyDiagnostic(givenText);
 		}
 
 		[DataTestMethod]
@@ -251,7 +251,7 @@ class Foo
 ";
 			string givenText = string.Format(baseline, test);
 
-			VerifyCSharpDiagnostic(givenText);
+			VerifyDiagnostic(givenText);
 		}
 		
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()

--- a/Philips.CodeAnalysis.Test/MsTest/AvoidAttributeCodeFixProviderTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AvoidAttributeCodeFixProviderTest.cs
@@ -40,7 +40,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 			var expected = GetExpectedDiagnostic(DiagnosticIds.AvoidTestInitializeMethod);
 			VerifyCSharpDiagnostic(givenText, expected);
 
-			VerifyCSharpFix(givenText, expectedText);
+			VerifyFix(givenText, expectedText);
 		}
 
 
@@ -53,7 +53,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 			var expected = GetExpectedDiagnostic(DiagnosticIds.AvoidClassInitializeMethod);
 			VerifyCSharpDiagnostic(givenText, expected);
 
-			VerifyCSharpFix(givenText, expectedText);
+			VerifyFix(givenText, expectedText);
 		}
 
 		[DataTestMethod]
@@ -65,7 +65,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 			var expected = GetExpectedDiagnostic(DiagnosticIds.AvoidTestCleanupMethod);
 			VerifyCSharpDiagnostic(givenText, expected);
 
-			VerifyCSharpFix(givenText, expectedText);
+			VerifyFix(givenText, expectedText);
 		}
 
 		[DataTestMethod]
@@ -77,7 +77,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 			var expected = GetExpectedDiagnostic(DiagnosticIds.AvoidClassCleanupMethod);
 			VerifyCSharpDiagnostic(givenText, expected);
 
-			VerifyCSharpFix(givenText, expectedText);
+			VerifyFix(givenText, expectedText);
 		}
 
 		private DiagnosticResult GetExpectedDiagnostic(DiagnosticIds id)

--- a/Philips.CodeAnalysis.Test/MsTest/AvoidAttributeCodeFixProviderTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AvoidAttributeCodeFixProviderTest.cs
@@ -94,7 +94,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 			};
 		}
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new AvoidMethodsCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/AvoidAttributeCodeFixProviderTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AvoidAttributeCodeFixProviderTest.cs
@@ -99,7 +99,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 			return new AvoidMethodsCodeFixProvider();
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidAttributeAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/AvoidAttributeCodeFixProviderTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AvoidAttributeCodeFixProviderTest.cs
@@ -38,7 +38,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 			string givenText = string.Format(baseline, testMethod);
 
 			var expected = GetExpectedDiagnostic(DiagnosticIds.AvoidTestInitializeMethod);
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 
 			VerifyFix(givenText, expectedText);
 		}
@@ -51,7 +51,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 			string givenText = string.Format(baseline, testMethod);
 
 			var expected = GetExpectedDiagnostic(DiagnosticIds.AvoidClassInitializeMethod);
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 
 			VerifyFix(givenText, expectedText);
 		}
@@ -63,7 +63,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 			string givenText = string.Format(baseline, testMethod);
 
 			var expected = GetExpectedDiagnostic(DiagnosticIds.AvoidTestCleanupMethod);
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 
 			VerifyFix(givenText, expectedText);
 		}
@@ -75,7 +75,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 			string givenText = string.Format(baseline, testMethod);
 
 			var expected = GetExpectedDiagnostic(DiagnosticIds.AvoidClassCleanupMethod);
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 
 			VerifyFix(givenText, expectedText);
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/AvoidMsFakesAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AvoidMsFakesAnalyzerTest.cs
@@ -61,12 +61,12 @@ class Foo
 
 		private void VerifyNoDiagnostic(string file)
 		{
-			VerifyCSharpDiagnostic(file);
+			base.VerifyDiagnostic(file);
 		}
 
 		private void VerifyDiagnostic(string file)
 		{
-			VerifyCSharpDiagnostic(file, new DiagnosticResult()
+			VerifyDiagnostic(file, new DiagnosticResult()
 			{
 				Id = AvoidMsFakesAnalyzer.Rule.Id,
 				Message = new Regex(".+"),

--- a/Philips.CodeAnalysis.Test/MsTest/AvoidMsFakesAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AvoidMsFakesAnalyzerTest.cs
@@ -20,7 +20,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidMsFakesAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/AvoidOwnerAttributeCodeFixProviderTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AvoidOwnerAttributeCodeFixProviderTest.cs
@@ -53,7 +53,7 @@ class Foo
 				}
 			};
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 			VerifyFix(givenText, fixedText);
 		}
 

--- a/Philips.CodeAnalysis.Test/MsTest/AvoidOwnerAttributeCodeFixProviderTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AvoidOwnerAttributeCodeFixProviderTest.cs
@@ -57,7 +57,7 @@ class Foo
 			VerifyCSharpFix(givenText, fixedText);
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidAttributeAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/AvoidOwnerAttributeCodeFixProviderTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AvoidOwnerAttributeCodeFixProviderTest.cs
@@ -54,7 +54,7 @@ class Foo
 			};
 
 			VerifyCSharpDiagnostic(givenText, expected);
-			VerifyCSharpFix(givenText, fixedText);
+			VerifyFix(givenText, fixedText);
 		}
 
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()

--- a/Philips.CodeAnalysis.Test/MsTest/AvoidOwnerAttributeCodeFixProviderTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AvoidOwnerAttributeCodeFixProviderTest.cs
@@ -62,7 +62,7 @@ class Foo
 			return new AvoidAttributeAnalyzer();
 		}
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new AvoidOwnerAttributeCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/DataTestMethodsHaveDataRowsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/DataTestMethodsHaveDataRowsAnalyzerTest.cs
@@ -57,7 +57,7 @@ public class Tests
 	public void Foo() { }
 }";
 
-			VerifyCSharpDiagnostic(code, new DiagnosticResult()
+			VerifyDiagnostic(code, new DiagnosticResult()
 			{
 				Id = Helper.ToDiagnosticId(DiagnosticIds.DataTestMethodsHaveDataRows),
 				Message = new Regex(".*"),
@@ -91,7 +91,7 @@ public class Tests
 				expected = DiagnosticResultHelper.CreateArray(DiagnosticIds.DataTestMethodsHaveDataRows);
 			}
 
-			VerifyCSharpDiagnostic(string.Format(code, arg), expected);
+			VerifyDiagnostic(string.Format(code, arg), expected);
 		}
 
 		[DataRow("[DerivedDataSource]", false)]
@@ -117,7 +117,7 @@ public class Tests
 				expected = DiagnosticResultHelper.CreateArray(DiagnosticIds.DataTestMethodsHaveDataRows);
 			}
 
-			VerifyCSharpDiagnostic(string.Format(code, arg), expected);
+			VerifyDiagnostic(string.Format(code, arg), expected);
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/MsTest/DataTestMethodsHaveDataRowsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/DataTestMethodsHaveDataRowsAnalyzerTest.cs
@@ -19,7 +19,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new DataTestMethodsHaveDataRowsAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/ExpectedExceptionAttributeAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/ExpectedExceptionAttributeAnalyzerTest.cs
@@ -42,7 +42,7 @@ namespace ExpectedAnalyzerAttributeTest
 			VerifyCSharpDiagnostic(givenText, expected);
 		}
 		
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new ExpectedExceptionAttributeAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/ExpectedExceptionAttributeAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/ExpectedExceptionAttributeAnalyzerTest.cs
@@ -39,7 +39,7 @@ namespace ExpectedAnalyzerAttributeTest
 				}
 			};
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 		
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()

--- a/Philips.CodeAnalysis.Test/MsTest/NoEmptyTestMethodsDiagnosticAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/NoEmptyTestMethodsDiagnosticAnalyzerTest.cs
@@ -60,7 +60,7 @@ public class DerivedTestMethod : TestMethodAttribute
 			const string template = @"using Microsoft.VisualStudio.TestTools.UnitTesting;
 [TestClass] public class Foo {{ [{0}] public void Method() {{ }} }}";
 
-			VerifyCSharpDiagnostic(string.Format(template, attribute), DiagnosticResultHelper.Create(DiagnosticIds.TestMethodsMustNotBeEmpty));
+			VerifyDiagnostic(string.Format(template, attribute), DiagnosticResultHelper.Create(DiagnosticIds.TestMethodsMustNotBeEmpty));
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/MsTest/NoEmptyTestMethodsDiagnosticAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/NoEmptyTestMethodsDiagnosticAnalyzerTest.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new NoEmptyTestMethodsDiagnosticAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/TestClassMustBePublicAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestClassMustBePublicAnalyzerTest.cs
@@ -52,11 +52,11 @@ namespace Philips.CodeAnalysis.Test.MsTest
 
 				if (isCorrect)
 				{
-					VerifyCSharpDiagnostic(text);
+					VerifyDiagnostic(text);
 				}
 				else
 				{
-					VerifyCSharpDiagnostic(text, new DiagnosticResult()
+					VerifyDiagnostic(text, new DiagnosticResult()
 					{
 						Id = Helper.ToDiagnosticId(DiagnosticIds.TestClassesMustBePublic),
 						Locations = new[] { new DiagnosticResultLocation("Test0.cs", 4, modifier.Length + 8) },
@@ -93,11 +93,11 @@ namespace Philips.CodeAnalysis.Test.MsTest
 
 				if (isCorrect)
 				{
-					VerifyCSharpDiagnostic(text);
+					VerifyDiagnostic(text);
 				}
 				else
 				{
-					VerifyCSharpDiagnostic(text, new DiagnosticResult()
+					VerifyDiagnostic(text, new DiagnosticResult()
 					{
 						Id = Helper.ToDiagnosticId(DiagnosticIds.TestClassesMustBePublic),
 						Locations = new[] { new DiagnosticResultLocation("Test0.cs", 4, modifier.Length + 8) },

--- a/Philips.CodeAnalysis.Test/MsTest/TestClassMustBePublicAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestClassMustBePublicAnalyzerTest.cs
@@ -18,7 +18,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new TestClassMustBePublicAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/TestClassPublicMethodShouldBeTestMethodTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestClassPublicMethodShouldBeTestMethodTest.cs
@@ -123,7 +123,7 @@ class Foo
 			VerifyCSharpDiagnostic(givenText, results);
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new TestClassPublicMethodShouldBeTestMethodAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/TestClassPublicMethodShouldBeTestMethodTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestClassPublicMethodShouldBeTestMethodTest.cs
@@ -120,7 +120,7 @@ class Foo
 			{
 				results = Array.Empty<DiagnosticResult>();
 			}
-			VerifyCSharpDiagnostic(givenText, results);
+			VerifyDiagnostic(givenText, results);
 		}
 
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()

--- a/Philips.CodeAnalysis.Test/MsTest/TestContextAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestContextAnalyzerTest.cs
@@ -60,7 +60,7 @@ namespace TestContextAnalyzerTest
 ";
 
 			VerifyCSharpDiagnostic(givenText, DiagnosticResultHelper.Create(DiagnosticIds.TestContext));
-			VerifyCSharpFix(givenText, fixedText);
+			VerifyFix(givenText, fixedText);
 		}
 
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()

--- a/Philips.CodeAnalysis.Test/MsTest/TestContextAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestContextAnalyzerTest.cs
@@ -68,7 +68,7 @@ namespace TestContextAnalyzerTest
 			return new TestContextAnalyzer();
 		}
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new TestContextCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/TestContextAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestContextAnalyzerTest.cs
@@ -59,7 +59,7 @@ namespace TestContextAnalyzerTest
 }
 ";
 
-			VerifyCSharpDiagnostic(givenText, DiagnosticResultHelper.Create(DiagnosticIds.TestContext));
+			VerifyDiagnostic(givenText, DiagnosticResultHelper.Create(DiagnosticIds.TestContext));
 			VerifyFix(givenText, fixedText);
 		}
 

--- a/Philips.CodeAnalysis.Test/MsTest/TestContextAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestContextAnalyzerTest.cs
@@ -63,7 +63,7 @@ namespace TestContextAnalyzerTest
 			VerifyCSharpFix(givenText, fixedText);
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new TestContextAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/TestHasCategoryTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestHasCategoryTest.cs
@@ -173,7 +173,7 @@ class Foo
 			return new TestHasCategoryAttributeAnalyzer();
 		}
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new TestHasCategoryCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/TestHasCategoryTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestHasCategoryTest.cs
@@ -139,7 +139,7 @@ class Foo
     }
 }
 ";
-			VerifyCSharpFix(baseline, fixedText);
+			VerifyFix(baseline, fixedText);
 		}
 
 		private void VerifyError(string baseline, string given, bool isError)

--- a/Philips.CodeAnalysis.Test/MsTest/TestHasCategoryTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestHasCategoryTest.cs
@@ -168,7 +168,7 @@ class Foo
 		}
 
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new TestHasCategoryAttributeAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/TestHasCategoryTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestHasCategoryTest.cs
@@ -41,7 +41,7 @@ class Foo
 				}
 			};
 
-			VerifyCSharpDiagnostic(givenText, expected);
+			VerifyDiagnostic(givenText, expected);
 		}
 
 		[DataTestMethod]
@@ -164,7 +164,7 @@ class Foo
 			{
 				results = Array.Empty<DiagnosticResult>();
 			}
-			VerifyCSharpDiagnostic(givenText, results);
+			VerifyDiagnostic(givenText, results);
 		}
 
 

--- a/Philips.CodeAnalysis.Test/MsTest/TestHasDescriptionTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestHasDescriptionTest.cs
@@ -61,7 +61,7 @@ var foo = 4;
 			};
 		}
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new TestHasDescriptionCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/TestHasDescriptionTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestHasDescriptionTest.cs
@@ -66,7 +66,7 @@ var foo = 4;
 			return new TestHasDescriptionCodeFixProvider();
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new TestHasDescriptionAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/TestHasTimeoutAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestHasTimeoutAnalyzerTest.cs
@@ -140,7 +140,7 @@ var foo = 4;
 			return new TestHasTimeoutCodeFixProvider();
 		}
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new TestHasTimeoutAttributeAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/TestHasTimeoutAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestHasTimeoutAnalyzerTest.cs
@@ -135,7 +135,7 @@ var foo = 4;
 			};
 		}
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new TestHasTimeoutCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodNameAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodNameAnalyzerTest.cs
@@ -55,7 +55,7 @@ namespace TestMethodNameAnalyzerTest
 				}
 			}};
 
-			VerifyCSharpDiagnostic(givenText, "Test0", isError ? expected : Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(givenText, "Test0", isError ? expected : Array.Empty<DiagnosticResult>());
 			VerifyCSharpFix(givenText, fixedText);
 		}
 		

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodNameAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodNameAnalyzerTest.cs
@@ -64,7 +64,7 @@ namespace TestMethodNameAnalyzerTest
 			return new TestMethodNameAnalyzer();
 		}
 
-		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		protected override CodeFixProvider GetCodeFixProvider()
 		{
 			return new TestMethodNameCodeFixProvider();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodNameAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodNameAnalyzerTest.cs
@@ -56,7 +56,7 @@ namespace TestMethodNameAnalyzerTest
 			}};
 
 			VerifyDiagnostic(givenText, "Test0", isError ? expected : Array.Empty<DiagnosticResult>());
-			VerifyCSharpFix(givenText, fixedText);
+			VerifyFix(givenText, fixedText);
 		}
 		
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodNameAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodNameAnalyzerTest.cs
@@ -59,7 +59,7 @@ namespace TestMethodNameAnalyzerTest
 			VerifyCSharpFix(givenText, fixedText);
 		}
 		
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new TestMethodNameAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodsMustBeInTestClassAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodsMustBeInTestClassAnalyzerTest.cs
@@ -64,7 +64,7 @@ public {2} class Tests : {3}
 	public void Foo() {{ }}
 }}";
 
-			VerifyCSharpDiagnostic(string.Format(code, "[TestClass]", testType, classQualifier, baseClass));
+			VerifyDiagnostic(string.Format(code, "[TestClass]", testType, classQualifier, baseClass));
 
 			DiagnosticResult[] expectedResult = Array.Empty<DiagnosticResult>();
 
@@ -73,7 +73,7 @@ public {2} class Tests : {3}
 				expectedResult = new[] { DiagnosticResultHelper.Create(DiagnosticIds.TestMethodsMustBeInTestClass) };
 			}
 
-			VerifyCSharpDiagnostic(string.Format(code, "", testType, classQualifier, baseClass), expectedResult);
+			VerifyDiagnostic(string.Format(code, "", testType, classQualifier, baseClass), expectedResult);
 		}
 		#endregion
 	}

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodsMustBeInTestClassAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodsMustBeInTestClassAnalyzerTest.cs
@@ -16,7 +16,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 		#endregion
 
 		#region Non-Public Properties/Methods
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new TestMethodsMustBeInTestClassAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodsMustBePublicAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodsMustBePublicAnalyzerTest.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 		#endregion
 
 		#region Non-Public Properties/Methods
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new TestMethodsMustBePublicAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodsMustBePublicAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodsMustBePublicAnalyzerTest.cs
@@ -51,11 +51,11 @@ public class Tests
 
 				if (isCorrect)
 				{
-					VerifyCSharpDiagnostic(text);
+					VerifyDiagnostic(text);
 				}
 				else
 				{
-					VerifyCSharpDiagnostic(text, new DiagnosticResult()
+					VerifyDiagnostic(text, new DiagnosticResult()
 					{
 						Id = Helper.ToDiagnosticId(DiagnosticIds.TestMethodsMustBePublic),
 						Locations = new[] { new DiagnosticResultLocation("Test0.cs", 7, modifier.Length + 8) },

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodsMustHaveTheCorrectNumberOfArgumentsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodsMustHaveTheCorrectNumberOfArgumentsAnalyzerTest.cs
@@ -67,11 +67,11 @@ public class Tests
 
 			if (isCorrect)
 			{
-				VerifyCSharpDiagnostic(string.Format(code, testType, parameterListString));
+				VerifyDiagnostic(string.Format(code, testType, parameterListString));
 			}
 			else
 			{
-				VerifyCSharpDiagnostic(string.Format(code, testType, parameterListString), new DiagnosticResult()
+				VerifyDiagnostic(string.Format(code, testType, parameterListString), new DiagnosticResult()
 				{
 					Id = Helper.ToDiagnosticId(DiagnosticIds.TestMethodsMustHaveTheCorrectNumberOfArguments),
 					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 7, null) },
@@ -103,7 +103,7 @@ public class Tests
 			}
 
 
-			VerifyCSharpDiagnostic(string.Format(code, parameterListString));
+			VerifyDiagnostic(string.Format(code, parameterListString));
 		}
 
 		private static IEnumerable<object[]> DataRowVariants()
@@ -173,11 +173,11 @@ public class Tests
 
 			if (isCorrect)
 			{
-				VerifyCSharpDiagnostic(code);
+				VerifyDiagnostic(code);
 			}
 			else
 			{
-				VerifyCSharpDiagnostic(code, DiagnosticResultHelper.Create(DiagnosticIds.TestMethodsMustHaveTheCorrectNumberOfArguments));
+				VerifyDiagnostic(code, DiagnosticResultHelper.Create(DiagnosticIds.TestMethodsMustHaveTheCorrectNumberOfArguments));
 			}
 		}
 

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodsMustHaveTheCorrectNumberOfArgumentsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodsMustHaveTheCorrectNumberOfArgumentsAnalyzerTest.cs
@@ -18,7 +18,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 		#endregion
 
 		#region Non-Public Properties/Methods
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new TestMethodsMustHaveTheCorrectNumberOfArgumentsAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodsShouldHaveUniqueNamesAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodsShouldHaveUniqueNamesAnalyzerTest.cs
@@ -46,7 +46,7 @@ public class Tests
 	public void Foo(object o, object y) { }
 }";
 
-			VerifyCSharpDiagnostic(code, new DiagnosticResult()
+			VerifyDiagnostic(code, new DiagnosticResult()
 			{
 				Id = Helper.ToDiagnosticId(DiagnosticIds.TestMethodsMustHaveUniqueNames),
 				Locations = new[] { new DiagnosticResultLocation("Test0.cs", 11, null) },

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodsShouldHaveUniqueNamesAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodsShouldHaveUniqueNamesAnalyzerTest.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 		#endregion
 
 		#region Non-Public Properties/Methods
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new TestMethodsShouldHaveUniqueNamesAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodsShouldHaveValidReturnTypesAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodsShouldHaveValidReturnTypesAnalyzerTest.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 
 		#region Non-Public Properties/Methods
 
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new TestMethodsShouldHaveValidReturnTypesAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodsShouldHaveValidReturnTypesAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodsShouldHaveValidReturnTypesAnalyzerTest.cs
@@ -48,7 +48,7 @@ public class Tests
 	public {(isAsync ? "async" : string.Empty)} {returnType} Foo() {{ throw new Exception(); }}
 }}";
 
-			VerifyCSharpDiagnostic(code, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.TestMethodsMustHaveValidReturnType) : Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(code, isError ? DiagnosticResultHelper.CreateArray(DiagnosticIds.TestMethodsMustHaveValidReturnType) : Array.Empty<DiagnosticResult>());
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/Security/AvoidPasswordAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Security/AvoidPasswordAnalyzerTest.cs
@@ -9,7 +9,7 @@ namespace Philips.CodeAnalysis.Test.Security
 	[TestClass]
 	public class AvoidPasswordAnalyzerTest : DiagnosticVerifier
 	{
-		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidPasswordAnalyzer();
 		}

--- a/Philips.CodeAnalysis.Test/Security/AvoidPasswordAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Security/AvoidPasswordAnalyzerTest.cs
@@ -39,7 +39,7 @@ class Foo
 			var format = GetTemplate();
 			string testCode = string.Format(format, content0, content1);
 			var expected = DiagnosticResultHelper.CreateArray(DiagnosticIds.AvoidPasswordField);
-			VerifyCSharpDiagnostic(testCode, expected);
+			VerifyDiagnostic(testCode, expected);
 		}
 
 		[DataTestMethod]
@@ -52,7 +52,7 @@ class Foo
 		{
 			var format = GetTemplate();
 			string testCode = string.Format(format, content0, content1);
-			VerifyCSharpDiagnostic(testCode, Array.Empty<DiagnosticResult>());
+			VerifyDiagnostic(testCode, Array.Empty<DiagnosticResult>());
 		}
 	}
 }

--- a/Philips.CodeAnalysis.Test/Verifiers/AssertCodeFixVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/AssertCodeFixVerifier.cs
@@ -24,7 +24,7 @@ namespace Philips.CodeAnalysis.Test
 		{
 			var test = _helper.GetText(methodBody, OtherClassSyntax, methodAttributes);
 
-			VerifyCSharpDiagnostic(test);
+			VerifyDiagnostic(test);
 
 			var fixtest = _helper.GetText(methodBody, OtherClassSyntax, methodAttributes);
 
@@ -41,7 +41,7 @@ namespace Philips.CodeAnalysis.Test
 			var test = _helper.GetText(methodBody, OtherClassSyntax, methodAttributes);
 			var expected = GetExpectedDiagnostic(expectedLineNumberErrorOffset: expectedErrorLineOffset, expectedColumnErrorOffset: expectedErrorColumnOffset);
 
-			VerifyCSharpDiagnostic(test, expected);
+			VerifyDiagnostic(test, expected);
 
 			var fixtest = _helper.GetText(expectedBody, OtherClassSyntax, expectedAttributes);
 
@@ -58,7 +58,7 @@ namespace Philips.CodeAnalysis.Test
 				expected.Message = new Regex(error);
 			}
 
-			VerifyCSharpDiagnostic(test, expected);
+			VerifyDiagnostic(test, expected);
 		}
 
 		protected void VerifyError(string methodBody, int expectedErrorLineOffset = 0, int expectedErrorColumnOffset = 0, string error = null)
@@ -70,7 +70,7 @@ namespace Philips.CodeAnalysis.Test
 		{
 			var test = _helper.GetText(methodBody, OtherClassSyntax, string.Empty);
 
-			VerifyCSharpDiagnostic(test);
+			VerifyDiagnostic(test);
 		}
 
 		protected override MetadataReference[] GetMetadataReferences()

--- a/Philips.CodeAnalysis.Test/Verifiers/AssertCodeFixVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/AssertCodeFixVerifier.cs
@@ -28,7 +28,7 @@ namespace Philips.CodeAnalysis.Test
 
 			var fixtest = _helper.GetText(methodBody, OtherClassSyntax, methodAttributes);
 
-			VerifyCSharpFix(test, fixtest);
+			VerifyFix(test, fixtest);
 		}
 
 		protected void VerifyChange(string methodBody, string expectedBody, int expectedErrorLineOffset = 0, int expectedErrorColumnOffset = 0)
@@ -45,7 +45,7 @@ namespace Philips.CodeAnalysis.Test
 
 			var fixtest = _helper.GetText(expectedBody, OtherClassSyntax, expectedAttributes);
 
-			VerifyCSharpFix(test, fixtest);
+			VerifyFix(test, fixtest);
 		}
 
 		protected void VerifyError(string methodBody, string methodAttributes, int expectedErrorLineOffset = 0, int expectedErrorColumnOffset = 0, string error = null)

--- a/Philips.CodeAnalysis.Test/Verifiers/AssertDiagnosticVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/AssertDiagnosticVerifier.cs
@@ -27,14 +27,14 @@ namespace Philips.CodeAnalysis.Test
 					Severity = DiagnosticSeverity.Error,
 					Location = new DiagnosticResultLocation("Test0.cs", null, null),
 				}).ToArray();
-			VerifyCSharpDiagnostic(test, expected);
+			VerifyDiagnostic(test, expected);
 		}
 
 		protected void VerifyNoError(string methodBody)
 		{
 			var test = _helper.GetText(methodBody, string.Empty, string.Empty);
 
-			VerifyCSharpDiagnostic(test);
+			VerifyDiagnostic(test);
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/Verifiers/CodeFixVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/CodeFixVerifier.cs
@@ -22,7 +22,7 @@ namespace Philips.CodeAnalysis.Test
 		/// Returns the codefix being tested (C#) - to be implemented in non-abstract class
 		/// </summary>
 		/// <returns>The CodeFixProvider to be used for CSharp code</returns>
-		protected abstract CodeFixProvider GetCSharpCodeFixProvider();
+		protected abstract CodeFixProvider GetCodeFixProvider();
 
 		/// <summary>
 		/// Called to test a C# codefix when applied on the inputted string as a source
@@ -34,7 +34,7 @@ namespace Philips.CodeAnalysis.Test
 		protected void VerifyCSharpFix(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false)
 		{
 			var analyzer = GetCSharpDiagnosticAnalyzer();
-			var codeFixProvider = GetCSharpCodeFixProvider();
+			var codeFixProvider = GetCodeFixProvider();
 			VerifyFix(analyzer, codeFixProvider, oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics);
 		}
 

--- a/Philips.CodeAnalysis.Test/Verifiers/CodeFixVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/CodeFixVerifier.cs
@@ -45,7 +45,7 @@ namespace Philips.CodeAnalysis.Test
 		{
 			var analyzer = GetCSharpDiagnosticAnalyzer();
 			var codeFixProvider = GetCSharpCodeFixProvider();
-			VerifyFix(LanguageNames.CSharp, analyzer, codeFixProvider, oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics);
+			VerifyFix(analyzer, codeFixProvider, oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics);
 		}
 
 		/// <summary>
@@ -61,9 +61,9 @@ namespace Philips.CodeAnalysis.Test
 		/// <param name="expectedSource">A class in the form of a string after the CodeFix was applied to it</param>
 		/// <param name="codeFixIndex">Index determining which codefix to apply if there are multiple</param>
 		/// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will fail if the CodeFix introduces other warnings after being applied</param>
-		private void VerifyFix(string language, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string oldSource, string expectedSource, int? codeFixIndex, bool allowNewCompilerDiagnostics)
+		private void VerifyFix(DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string oldSource, string expectedSource, int? codeFixIndex, bool allowNewCompilerDiagnostics)
 		{
-			var document = CreateDocument(oldSource, language);
+			var document = CreateDocument(oldSource);
 			var analyzerDiagnostics = GetSortedDiagnosticsFromDocuments(analyzer, new[] { document });
 			var compilerDiagnostics = GetCompilerDiagnostics(document);
 

--- a/Philips.CodeAnalysis.Test/Verifiers/CodeFixVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/CodeFixVerifier.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -24,15 +23,6 @@ namespace Philips.CodeAnalysis.Test
 		/// </summary>
 		/// <returns>The CodeFixProvider to be used for CSharp code</returns>
 		protected abstract CodeFixProvider GetCSharpCodeFixProvider();
-
-		/// <summary>
-		/// Returns the codefix being tested (VB) - to be implemented in non-abstract class
-		/// </summary>
-		/// <returns>The CodeFixProvider to be used for VisualBasic code</returns>
-		protected virtual CodeFixProvider GetBasicCodeFixProvider()
-		{
-			return null;
-		}
 
 		/// <summary>
 		/// Called to test a C# codefix when applied on the inputted string as a source

--- a/Philips.CodeAnalysis.Test/Verifiers/CodeFixVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/CodeFixVerifier.cs
@@ -49,20 +49,6 @@ namespace Philips.CodeAnalysis.Test
 		}
 
 		/// <summary>
-		/// Called to test a VB codefix when applied on the inputted string as a source
-		/// </summary>
-		/// <param name="oldSource">A class in the form of a string before the CodeFix was applied to it</param>
-		/// <param name="newSource">A class in the form of a string after the CodeFix was applied to it</param>
-		/// <param name="codeFixIndex">Index determining which codefix to apply if there are multiple</param>
-		/// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will fail if the CodeFix introduces other warnings after being applied</param>
-		protected void VerifyBasicFix(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false)
-		{
-			var analyzer = GetBasicDiagnosticAnalyzer();
-			var codeFixProvider = GetBasicCodeFixProvider();
-			VerifyFix(LanguageNames.VisualBasic, analyzer, codeFixProvider, oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics);
-		}
-
-		/// <summary>
 		/// General verifier for codefixes.
 		/// Creates a Document from the source string, then gets diagnostics on it and applies the relevant codefixes.
 		/// Then gets the string after the codefix is applied and compares it with the expected result.

--- a/Philips.CodeAnalysis.Test/Verifiers/CodeFixVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/CodeFixVerifier.cs
@@ -31,7 +31,7 @@ namespace Philips.CodeAnalysis.Test
 		/// <param name="newSource">A class in the form of a string after the CodeFix was applied to it</param>
 		/// <param name="codeFixIndex">Index determining which codefix to apply if there are multiple</param>
 		/// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will fail if the CodeFix introduces other warnings after being applied</param>
-		protected void VerifyCSharpFix(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false)
+		protected void VerifyFix(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false)
 		{
 			var analyzer = GetDiagnosticAnalyzer();
 			var codeFixProvider = GetCodeFixProvider();
@@ -44,7 +44,6 @@ namespace Philips.CodeAnalysis.Test
 		/// Then gets the string after the codefix is applied and compares it with the expected result.
 		/// Note: If any codefix causes new diagnostics to show up, the test fails unless allowNewCompilerDiagnostics is set to true.
 		/// </summary>
-		/// <param name="language">The language the source code is in</param>
 		/// <param name="analyzer">The analyzer to be applied to the source code</param>
 		/// <param name="codeFixProvider">The codefix to be applied to the code wherever the relevant Diagnostic is found</param>
 		/// <param name="oldSource">A class in the form of a string before the CodeFix was applied to it</param>

--- a/Philips.CodeAnalysis.Test/Verifiers/CodeFixVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/CodeFixVerifier.cs
@@ -33,7 +33,7 @@ namespace Philips.CodeAnalysis.Test
 		/// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will fail if the CodeFix introduces other warnings after being applied</param>
 		protected void VerifyCSharpFix(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false)
 		{
-			var analyzer = GetCSharpDiagnosticAnalyzer();
+			var analyzer = GetDiagnosticAnalyzer();
 			var codeFixProvider = GetCodeFixProvider();
 			VerifyFix(analyzer, codeFixProvider, oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics);
 		}

--- a/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
@@ -33,7 +33,7 @@ namespace Philips.CodeAnalysis.Test
 		protected void VerifyCSharpDiagnostic(string source, string filenamePrefix, params DiagnosticResult[] expected)
 		{
 			var analyzer = GetDiagnosticAnalyzer();
-			VerifyDiagnostics(new[] { source }, filenamePrefix, analyzer, expected);
+			VerifyDiagnosticsInternal(new[] { source }, filenamePrefix, analyzer, expected);
 		}
 
 		/// <summary>
@@ -56,18 +56,18 @@ namespace Philips.CodeAnalysis.Test
 		protected void VerifyCSharpDiagnostic(string[] sources, params DiagnosticResult[] expected)
 		{
 			var analyzer = GetDiagnosticAnalyzer();
-			VerifyDiagnostics(sources, null, analyzer, expected);
+			VerifyDiagnosticsInternal(sources, null, analyzer, expected);
 		}
 
-		/// <summary>
-		/// General method that gets a collection of actual diagnostics found in the source after the analyzer is run, 
-		/// then verifies each of them.
-		/// </summary>
-		/// <param name="sources">An array of strings to create source documents from to run the analyzers on</param>
-		/// <param name="language">The language of the classes represented by the source strings</param>
+        /// <summary>
+        /// General method that gets a collection of actual diagnostics found in the source after the analyzer is run, 
+        /// then verifies each of them.
+        /// </summary>
+        /// <param name="sources">An array of strings to create source documents from to run the analyzers on</param>
+        /// <param name="filenamePrefix">The name of the source file, without the extension</param>
 		/// <param name="analyzer">The analyzer to be run on the source code</param>
-		/// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
-		private void VerifyDiagnostics(string[] sources, string filenamePrefix, DiagnosticAnalyzer analyzer, params DiagnosticResult[] expected)
+        /// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
+        private void VerifyDiagnosticsInternal(string[] sources, string filenamePrefix, DiagnosticAnalyzer analyzer, params DiagnosticResult[] expected)
 		{
 			var diagnostics = GetSortedDiagnostics(sources, filenamePrefix, analyzer);
 			VerifyDiagnosticResults(diagnostics, analyzer, expected);

--- a/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
@@ -100,7 +100,7 @@ namespace Philips.CodeAnalysis.Test
 		/// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
 		private void VerifyDiagnostics(string[] sources, string filenamePrefix, string language, DiagnosticAnalyzer analyzer, params DiagnosticResult[] expected)
 		{
-			var diagnostics = GetSortedDiagnostics(sources, filenamePrefix, language, analyzer);
+			var diagnostics = GetSortedDiagnostics(sources, filenamePrefix, analyzer);
 			VerifyDiagnosticResults(diagnostics, analyzer, expected);
 		}
 

--- a/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
@@ -18,7 +18,7 @@ namespace Philips.CodeAnalysis.Test
 		/// <summary>
 		/// Get the CSharp analyzer being tested - to be implemented in non-abstract class
 		/// </summary>
-		protected abstract DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer();
+		protected abstract DiagnosticAnalyzer GetDiagnosticAnalyzer();
 
 		#endregion
 
@@ -32,7 +32,7 @@ namespace Philips.CodeAnalysis.Test
 		/// <param name="expected"> DiagnosticResults that should appear after the analyzer is run on the source</param>
 		protected void VerifyCSharpDiagnostic(string source, string filenamePrefix, params DiagnosticResult[] expected)
 		{
-			var analyzer = GetCSharpDiagnosticAnalyzer();
+			var analyzer = GetDiagnosticAnalyzer();
 			VerifyDiagnostics(new[] { source }, filenamePrefix, analyzer, expected);
 		}
 
@@ -55,7 +55,7 @@ namespace Philips.CodeAnalysis.Test
 		/// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
 		protected void VerifyCSharpDiagnostic(string[] sources, params DiagnosticResult[] expected)
 		{
-			var analyzer = GetCSharpDiagnosticAnalyzer();
+			var analyzer = GetDiagnosticAnalyzer();
 			VerifyDiagnostics(sources, null, analyzer, expected);
 		}
 

--- a/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
@@ -47,18 +47,6 @@ namespace Philips.CodeAnalysis.Test
 			VerifyDiagnostic(source, null, expected);
 		}
 
-		/// <summary>
-		/// Called to test a C# DiagnosticAnalyzer when applied on the inputted strings as a source
-		/// Note: input a DiagnosticResult for each Diagnostic expected
-		/// </summary>
-		/// <param name="sources">An array of strings to create source documents from to run the analyzers on</param>
-		/// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
-		protected void VerifyCSharpDiagnostic(string[] sources, params DiagnosticResult[] expected)
-		{
-			var analyzer = GetDiagnosticAnalyzer();
-			VerifyDiagnosticsInternal(sources, null, analyzer, expected);
-		}
-
         /// <summary>
         /// General method that gets a collection of actual diagnostics found in the source after the analyzer is run, 
         /// then verifies each of them.

--- a/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
@@ -16,7 +16,7 @@ namespace Philips.CodeAnalysis.Test
 	{
 		#region To be implemented by Test classes
 		/// <summary>
-		/// Get the CSharp analyzer being tested - to be implemented in non-abstract class
+		/// Get the Analyzer being tested - to be implemented in non-abstract class
 		/// </summary>
 		protected abstract DiagnosticAnalyzer GetDiagnosticAnalyzer();
 
@@ -218,7 +218,7 @@ namespace Philips.CodeAnalysis.Test
 							Assert.IsTrue(location.IsInSource,
 								$"Test base does not currently handle diagnostics in metadata locations. Diagnostic in metadata: {diagnostics[i]}\r\n");
 
-							string resultMethodName = diagnostics[i].Location.SourceTree.FilePath.EndsWith(".cs") ? "GetCSharpResultAt" : "GetBasicResultAt";
+							string resultMethodName = "GetCSharpResultAt";
 							var linePosition = diagnostics[i].Location.GetLineSpan().StartLinePosition;
 
 							builder.AppendFormat("{0}({1}, {2}, {3}.{4})",

--- a/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
@@ -20,13 +20,6 @@ namespace Philips.CodeAnalysis.Test
 		/// </summary>
 		protected abstract DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer();
 
-		/// <summary>
-		/// Get the Visual Basic analyzer being tested (C#) - to be implemented in non-abstract class
-		/// </summary>
-		protected virtual DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-		{
-			return null;
-		}
 		#endregion
 
 		#region Verifier wrappers

--- a/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
@@ -40,7 +40,7 @@ namespace Philips.CodeAnalysis.Test
 		protected void VerifyCSharpDiagnostic(string source, string filenamePrefix, params DiagnosticResult[] expected)
 		{
 			var analyzer = GetCSharpDiagnosticAnalyzer();
-			VerifyDiagnostics(new[] { source }, filenamePrefix, LanguageNames.CSharp, analyzer, expected);
+			VerifyDiagnostics(new[] { source }, filenamePrefix, analyzer, expected);
 		}
 
 		/// <summary>
@@ -55,18 +55,6 @@ namespace Philips.CodeAnalysis.Test
 		}
 
 		/// <summary>
-		/// Called to test a VB DiagnosticAnalyzer when applied on the single inputted string as a source
-		/// Note: input a DiagnosticResult for each Diagnostic expected
-		/// </summary>
-		/// <param name="source">A class in the form of a string to run the analyzer on</param>
-		/// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the source</param>
-		protected void VerifyBasicDiagnostic(string source, params DiagnosticResult[] expected)
-		{
-			var analyzer = GetBasicDiagnosticAnalyzer();
-			VerifyDiagnostics(new[] { source }, null, LanguageNames.VisualBasic, analyzer, expected);
-		}
-
-		/// <summary>
 		/// Called to test a C# DiagnosticAnalyzer when applied on the inputted strings as a source
 		/// Note: input a DiagnosticResult for each Diagnostic expected
 		/// </summary>
@@ -75,19 +63,7 @@ namespace Philips.CodeAnalysis.Test
 		protected void VerifyCSharpDiagnostic(string[] sources, params DiagnosticResult[] expected)
 		{
 			var analyzer = GetCSharpDiagnosticAnalyzer();
-			VerifyDiagnostics(sources, null, LanguageNames.CSharp, analyzer, expected);
-		}
-
-		/// <summary>
-		/// Called to test a VB DiagnosticAnalyzer when applied on the inputted strings as a source
-		/// Note: input a DiagnosticResult for each Diagnostic expected
-		/// </summary>
-		/// <param name="sources">An array of strings to create source documents from to run the analyzers on</param>
-		/// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
-		protected void VerifyBasicDiagnostic(string[] sources, params DiagnosticResult[] expected)
-		{
-			var analyzer = GetBasicDiagnosticAnalyzer();
-			VerifyDiagnostics(sources, null, LanguageNames.VisualBasic, analyzer, expected);
+			VerifyDiagnostics(sources, null, analyzer, expected);
 		}
 
 		/// <summary>
@@ -98,7 +74,7 @@ namespace Philips.CodeAnalysis.Test
 		/// <param name="language">The language of the classes represented by the source strings</param>
 		/// <param name="analyzer">The analyzer to be run on the source code</param>
 		/// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
-		private void VerifyDiagnostics(string[] sources, string filenamePrefix, string language, DiagnosticAnalyzer analyzer, params DiagnosticResult[] expected)
+		private void VerifyDiagnostics(string[] sources, string filenamePrefix, DiagnosticAnalyzer analyzer, params DiagnosticResult[] expected)
 		{
 			var diagnostics = GetSortedDiagnostics(sources, filenamePrefix, analyzer);
 			VerifyDiagnosticResults(diagnostics, analyzer, expected);

--- a/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
@@ -42,7 +42,7 @@ namespace Philips.CodeAnalysis.Test
 		/// </summary>
 		/// <param name="source">A class in the form of a string to run the analyzer on</param>
 		/// <param name="expected"> DiagnosticResults that should appear after the analyzer is run on the source</param>
-		protected void VerifyCSharpDiagnostic(string source, params DiagnosticResult[] expected)
+		protected void VerifyDiagnostic(string source, params DiagnosticResult[] expected)
 		{
 			VerifyDiagnostic(source, null, expected);
 		}

--- a/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
@@ -30,7 +30,7 @@ namespace Philips.CodeAnalysis.Test
 		/// </summary>
 		/// <param name="source">A class in the form of a string to run the analyzer on</param>
 		/// <param name="expected"> DiagnosticResults that should appear after the analyzer is run on the source</param>
-		protected void VerifyCSharpDiagnostic(string source, string filenamePrefix, params DiagnosticResult[] expected)
+		protected void VerifyDiagnostic(string source, string filenamePrefix, params DiagnosticResult[] expected)
 		{
 			var analyzer = GetDiagnosticAnalyzer();
 			VerifyDiagnosticsInternal(new[] { source }, filenamePrefix, analyzer, expected);
@@ -44,7 +44,7 @@ namespace Philips.CodeAnalysis.Test
 		/// <param name="expected"> DiagnosticResults that should appear after the analyzer is run on the source</param>
 		protected void VerifyCSharpDiagnostic(string source, params DiagnosticResult[] expected)
 		{
-			VerifyCSharpDiagnostic(source, null, expected);
+			VerifyDiagnostic(source, null, expected);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Removed all references to Visual Basic and hardcoded all test code to C#. Renamed all methods that referenced CSharp and removed that suffix. This will make the test code a little bit easier to read.