### PR TITLE
feat: Intoduce Avoid throwing exceptions from unexpected locations check

### DIFF
--- a/Philips.CodeAnalysis.Common/DiagnosticIds.cs
+++ b/Philips.CodeAnalysis.Common/DiagnosticIds.cs
@@ -114,5 +114,6 @@ namespace Philips.CodeAnalysis.Common
 		CastCompleteObject = 2119,
 		DocumentThrownExceptions = 2120,
 		ThrowInformationalExceptions = 2121,
+		AvoidExceptionsFromUnexpectedLocations = 2122,
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/DocumentThrownExceptionsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/DocumentThrownExceptionsAnalyzer.cs
@@ -1,6 +1,8 @@
 ﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -22,12 +24,27 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 		private const string InformationalTitle = @"Throw only informational exceptions";
 		private const string InformationalMessageFormat = @"Specify context to the {0} exception, by using a constructor overload that sets the Message property.";
 		private const string InformationalDescription = @"Specify context to a thrown exception, by using a constructor overload that sets the Message property.";
+		private const string LocationsTitle = @"Avoid throwing exceptions from unexpected locations";
+		private const string LocationsMessageFormat = @"Avoid throwing exceptions from {0}, as this location is unexpected.";
+		private const string LocationsDescription = @"Avoid throwing exceptions from unexpected locations, like Finalizers, Dispose, Static Constructors, etc...";
 		private const string Category = Categories.Documentation;
 
 		private static readonly DiagnosticDescriptor DocumentRule = new(Helper.ToDiagnosticId(DiagnosticIds.DocumentThrownExceptions), DocumentTitle, DocumentMessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: false, description: DocumentDescription);
 		private static readonly DiagnosticDescriptor InformationalRule = new(Helper.ToDiagnosticId(DiagnosticIds.ThrowInformationalExceptions), InformationalTitle, InformationalMessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: false, description: InformationalDescription);
+		private static readonly DiagnosticDescriptor LocationsRule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidExceptionsFromUnexpectedLocations), LocationsTitle, LocationsMessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: false, description: LocationsDescription);
 
-		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DocumentRule, InformationalRule);
+		[SuppressMessage("", "IDE0090", Justification = "When type is removed the literal type cannot be deduced")]
+		private static readonly Dictionary<string, string> specialMethods = new Dictionary<string, string>
+		{
+			{ ".ctor", "constructor" },
+			{ ".cctor", "static constructor" },
+			{ "Equals", "Equals method" },
+			{ "GetHashCode", "GetHashCode method" },
+			{ "Dispose", "Dispose method" },
+			{ "ToString", "ToString method" }
+		};
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DocumentRule, InformationalRule, LocationsRule);
 
 		public override void Initialize(AnalysisContext context)
 		{
@@ -66,6 +83,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 				return;
 			}
 
+			// Determine our parent.
 			SyntaxNode methodDeclaration = throwStatement.Ancestors().OfType<BaseMethodDeclarationSyntax>().FirstOrDefault();
 			if (methodDeclaration == null)
 			{
@@ -74,6 +92,56 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 				{
 					return;
 				}
+			}
+
+			// Check if the Parent is an unexpected location.
+			if (methodDeclaration is MethodDeclarationSyntax method)
+			{
+				if (specialMethods.TryGetValue(method.Identifier.Text, out string specialMethodKind))
+				{
+					var loc = method.Identifier.GetLocation();
+					bool? withinExceptionClass =
+						(method.Parent as TypeDeclarationSyntax)?.Identifier.Text.EndsWith("Exception");
+					if(specialMethodKind == "constructor" && withinExceptionClass.HasValue && (bool)withinExceptionClass)
+					{
+						Diagnostic diagnostic = Diagnostic.Create(LocationsRule, loc, "constructor of an Exception");
+						context.ReportDiagnostic(diagnostic);
+					}
+					else
+					{
+						Diagnostic diagnostic = Diagnostic.Create(LocationsRule, loc, specialMethodKind);
+						context.ReportDiagnostic(diagnostic);
+					}
+				}
+			}
+			else if (methodDeclaration is OperatorDeclarationSyntax { OperatorToken.Text: "==" or "!=" } operatorDeclaration)
+			{
+				var loc = operatorDeclaration.OperatorKeyword.GetLocation();
+				Diagnostic diagnostic = Diagnostic.Create(LocationsRule, loc, "equality comparison operator");
+				context.ReportDiagnostic(diagnostic);
+			}
+			else if (methodDeclaration is ConversionOperatorDeclarationSyntax { ImplicitOrExplicitKeyword.Text: "implicit" } conversionDeclaration)
+			{
+				var loc = conversionDeclaration.OperatorKeyword.GetLocation();
+				Diagnostic diagnostic = Diagnostic.Create(LocationsRule, loc, "implicit cast operator");
+				context.ReportDiagnostic(diagnostic);
+			}
+			else if(methodDeclaration is ConstructorDeclarationSyntax constructorDeclaration)
+			{
+				bool? withinExceptionClass =
+					(methodDeclaration.Parent as TypeDeclarationSyntax)?.Identifier.Text.EndsWith("Exception");
+				if ((withinExceptionClass.HasValue && (bool)withinExceptionClass) || constructorDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword))
+				{
+					var loc = constructorDeclaration.Identifier.GetLocation();
+					Diagnostic diagnostic = Diagnostic.Create(LocationsRule, loc, "implicit cast operator");
+					context.ReportDiagnostic(diagnostic);
+				}
+			}
+			else if(methodDeclaration is DestructorDeclarationSyntax destructorDeclaration)
+			{
+				var loc = destructorDeclaration.Identifier.GetLocation();
+				Diagnostic diagnostic = Diagnostic.Create(LocationsRule, loc, "finalizer");
+				context.ReportDiagnostic(diagnostic);
 			}
 
 			var mentionedExceptions = methodDeclaration.GetLeadingTrivia()

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/DocumentThrownExceptionsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/DocumentThrownExceptionsAnalyzer.cs
@@ -24,27 +24,12 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 		private const string InformationalTitle = @"Throw only informational exceptions";
 		private const string InformationalMessageFormat = @"Specify context to the {0} exception, by using a constructor overload that sets the Message property.";
 		private const string InformationalDescription = @"Specify context to a thrown exception, by using a constructor overload that sets the Message property.";
-		private const string LocationsTitle = @"Avoid throwing exceptions from unexpected locations";
-		private const string LocationsMessageFormat = @"Avoid throwing exceptions from {0}, as this location is unexpected.";
-		private const string LocationsDescription = @"Avoid throwing exceptions from unexpected locations, like Finalizers, Dispose, Static Constructors, etc...";
 		private const string Category = Categories.Documentation;
 
 		private static readonly DiagnosticDescriptor DocumentRule = new(Helper.ToDiagnosticId(DiagnosticIds.DocumentThrownExceptions), DocumentTitle, DocumentMessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: false, description: DocumentDescription);
 		private static readonly DiagnosticDescriptor InformationalRule = new(Helper.ToDiagnosticId(DiagnosticIds.ThrowInformationalExceptions), InformationalTitle, InformationalMessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: false, description: InformationalDescription);
-		private static readonly DiagnosticDescriptor LocationsRule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidExceptionsFromUnexpectedLocations), LocationsTitle, LocationsMessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: false, description: LocationsDescription);
 
-		[SuppressMessage("", "IDE0090", Justification = "When type is removed the literal type cannot be deduced")]
-		private static readonly Dictionary<string, string> specialMethods = new Dictionary<string, string>
-		{
-			{ ".ctor", "constructor" },
-			{ ".cctor", "static constructor" },
-			{ "Equals", "Equals method" },
-			{ "GetHashCode", "GetHashCode method" },
-			{ "Dispose", "Dispose method" },
-			{ "ToString", "ToString method" }
-		};
-
-		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DocumentRule, InformationalRule, LocationsRule);
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DocumentRule, InformationalRule);
 
 		public override void Initialize(AnalysisContext context)
 		{
@@ -92,46 +77,6 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 				{
 					return;
 				}
-			}
-
-			// Check if the Parent is an unexpected location.
-			if (methodDeclaration is MethodDeclarationSyntax method)
-			{
-				if (specialMethods.TryGetValue(method.Identifier.Text, out string specialMethodKind))
-				{
-					var loc = method.Identifier.GetLocation();
-					Diagnostic diagnostic = Diagnostic.Create(LocationsRule, loc, specialMethodKind);
-					context.ReportDiagnostic(diagnostic);
-				}
-			}
-			else if (methodDeclaration is OperatorDeclarationSyntax { OperatorToken.Text: "==" or "!=" } operatorDeclaration)
-			{
-				var loc = operatorDeclaration.OperatorKeyword.GetLocation();
-				Diagnostic diagnostic = Diagnostic.Create(LocationsRule, loc, "equality comparison operator");
-				context.ReportDiagnostic(diagnostic);
-			}
-			else if (methodDeclaration is ConversionOperatorDeclarationSyntax { ImplicitOrExplicitKeyword.Text: "implicit" } conversionDeclaration)
-			{
-				var loc = conversionDeclaration.OperatorKeyword.GetLocation();
-				Diagnostic diagnostic = Diagnostic.Create(LocationsRule, loc, "implicit cast operator");
-				context.ReportDiagnostic(diagnostic);
-			}
-			else if(methodDeclaration is ConstructorDeclarationSyntax constructorDeclaration)
-			{
-				bool? withinExceptionClass =
-					(methodDeclaration.Parent as TypeDeclarationSyntax)?.Identifier.Text.EndsWith("Exception");
-				if ((withinExceptionClass.HasValue && (bool)withinExceptionClass) || constructorDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword))
-				{
-					var loc = constructorDeclaration.Identifier.GetLocation();
-					Diagnostic diagnostic = Diagnostic.Create(LocationsRule, loc, "implicit cast operator");
-					context.ReportDiagnostic(diagnostic);
-				}
-			}
-			else if(methodDeclaration is DestructorDeclarationSyntax destructorDeclaration)
-			{
-				var loc = destructorDeclaration.Identifier.GetLocation();
-				Diagnostic diagnostic = Diagnostic.Create(LocationsRule, loc, "finalizer");
-				context.ReportDiagnostic(diagnostic);
 			}
 
 			var mentionedExceptions = methodDeclaration.GetLeadingTrivia()

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/DocumentThrownExceptionsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/DocumentThrownExceptionsAnalyzer.cs
@@ -1,8 +1,6 @@
 ﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/DocumentThrownExceptionsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/DocumentThrownExceptionsAnalyzer.cs
@@ -77,6 +77,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 				}
 			}
 
+			// Check if our parent has proper documentation.
 			var mentionedExceptions = methodDeclaration.GetLeadingTrivia()
 				.Select(i => i.GetStructure())
 				.OfType<DocumentationCommentTriviaSyntax>()

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/DocumentThrownExceptionsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/DocumentThrownExceptionsAnalyzer.cs
@@ -100,18 +100,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 				if (specialMethods.TryGetValue(method.Identifier.Text, out string specialMethodKind))
 				{
 					var loc = method.Identifier.GetLocation();
-					bool? withinExceptionClass =
-						(method.Parent as TypeDeclarationSyntax)?.Identifier.Text.EndsWith("Exception");
-					if(specialMethodKind == "constructor" && withinExceptionClass.HasValue && (bool)withinExceptionClass)
-					{
-						Diagnostic diagnostic = Diagnostic.Create(LocationsRule, loc, "constructor of an Exception");
-						context.ReportDiagnostic(diagnostic);
-					}
-					else
-					{
-						Diagnostic diagnostic = Diagnostic.Create(LocationsRule, loc, specialMethodKind);
-						context.ReportDiagnostic(diagnostic);
-					}
+					Diagnostic diagnostic = Diagnostic.Create(LocationsRule, loc, specialMethodKind);
+					context.ReportDiagnostic(diagnostic);
 				}
 			}
 			else if (methodDeclaration is OperatorDeclarationSyntax { OperatorToken.Text: "==" or "!=" } operatorDeclaration)

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidThrowingUnexpectedExceptionsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidThrowingUnexpectedExceptionsAnalyzer.cs
@@ -28,8 +28,6 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		[SuppressMessage("", "IDE0090", Justification = "When type is removed the literal type cannot be deduced")]
 		private static readonly Dictionary<string, string> specialMethods = new Dictionary<string, string>
 		{
-			{ ".ctor", "constructor" },
-			{ ".cctor", "static constructor" },
 			{ "Equals", "Equals method" },
 			{ "GetHashCode", "GetHashCode method" },
 			{ "Dispose", "Dispose method" },
@@ -63,6 +61,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			// Check if the Parent is an unexpected location.
 			if (methodDeclaration is MethodDeclarationSyntax method)
 			{
+				// Check overriden methods of Object.
 				if (specialMethods.TryGetValue(method.Identifier.Text, out string specialMethodKind))
 				{
 					var loc = method.Identifier.GetLocation();
@@ -72,18 +71,21 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			}
 			else if (methodDeclaration is OperatorDeclarationSyntax { OperatorToken.Text: "==" or "!=" } operatorDeclaration)
 			{
+				// Check == and != operators.
 				var loc = operatorDeclaration.OperatorKeyword.GetLocation();
 				Diagnostic diagnostic = Diagnostic.Create(LocationsRule, loc, "equality comparison operator");
 				context.ReportDiagnostic(diagnostic);
 			}
 			else if (methodDeclaration is ConversionOperatorDeclarationSyntax { ImplicitOrExplicitKeyword.Text: "implicit" } conversionDeclaration)
 			{
+				// Check implicit cast operators.
 				var loc = conversionDeclaration.OperatorKeyword.GetLocation();
 				Diagnostic diagnostic = Diagnostic.Create(LocationsRule, loc, "implicit cast operator");
 				context.ReportDiagnostic(diagnostic);
 			}
 			else if (methodDeclaration is ConstructorDeclarationSyntax constructorDeclaration)
 			{
+				// Check constructors of an Exception.
 				bool? withinExceptionClass =
 					(methodDeclaration.Parent as TypeDeclarationSyntax)?.Identifier.Text.EndsWith("Exception");
 				if ((withinExceptionClass.HasValue && (bool)withinExceptionClass) || constructorDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword))
@@ -95,6 +97,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			}
 			else if (methodDeclaration is DestructorDeclarationSyntax destructorDeclaration)
 			{
+				// Check finalizers.
 				var loc = destructorDeclaration.Identifier.GetLocation();
 				Diagnostic diagnostic = Diagnostic.Create(LocationsRule, loc, "finalizer");
 				context.ReportDiagnostic(diagnostic);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidThrowingUnexpectedExceptionsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidThrowingUnexpectedExceptionsAnalyzer.cs
@@ -1,0 +1,104 @@
+﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
+{
+	/// <summary>
+	/// Analyzer that checks exception are not thrown in locations in the code where they are not expected or cause issues.
+	/// </summary>
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class AvoidThrowingUnexpectedExceptionsAnalyzer : DiagnosticAnalyzer
+	{
+		private const string LocationsTitle = @"Avoid throwing exceptions from unexpected locations";
+		private const string LocationsMessageFormat = @"Avoid throwing exceptions from {0}, as this location is unexpected.";
+		private const string LocationsDescription = @"Avoid throwing exceptions from unexpected locations, like Finalizers, Dispose, Static Constructors, etc...";
+		private const string Category = Categories.Documentation;
+
+		private static readonly DiagnosticDescriptor LocationsRule = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidExceptionsFromUnexpectedLocations), LocationsTitle, LocationsMessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: false, description: LocationsDescription);
+
+		[SuppressMessage("", "IDE0090", Justification = "When type is removed the literal type cannot be deduced")]
+		private static readonly Dictionary<string, string> specialMethods = new Dictionary<string, string>
+		{
+			{ ".ctor", "constructor" },
+			{ ".cctor", "static constructor" },
+			{ "Equals", "Equals method" },
+			{ "GetHashCode", "GetHashCode method" },
+			{ "Dispose", "Dispose method" },
+			{ "ToString", "ToString method" }
+		};
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(LocationsRule);
+
+		public override void Initialize(AnalysisContext context)
+		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.EnableConcurrentExecution();
+			context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.ThrowStatement);
+		}
+
+		private static void Analyze(SyntaxNodeAnalysisContext context)
+		{
+			var throwStatement = (ThrowStatementSyntax)context.Node;
+
+			// Determine our parent.
+			SyntaxNode methodDeclaration = throwStatement.Ancestors().OfType<BaseMethodDeclarationSyntax>().FirstOrDefault();
+			if (methodDeclaration == null)
+			{
+				methodDeclaration = throwStatement.Ancestors().OfType<BasePropertyDeclarationSyntax>().FirstOrDefault();
+				if (methodDeclaration == null)
+				{
+					return;
+				}
+			}
+
+			// Check if the Parent is an unexpected location.
+			if (methodDeclaration is MethodDeclarationSyntax method)
+			{
+				if (specialMethods.TryGetValue(method.Identifier.Text, out string specialMethodKind))
+				{
+					var loc = method.Identifier.GetLocation();
+					Diagnostic diagnostic = Diagnostic.Create(LocationsRule, loc, specialMethodKind);
+					context.ReportDiagnostic(diagnostic);
+				}
+			}
+			else if (methodDeclaration is OperatorDeclarationSyntax { OperatorToken.Text: "==" or "!=" } operatorDeclaration)
+			{
+				var loc = operatorDeclaration.OperatorKeyword.GetLocation();
+				Diagnostic diagnostic = Diagnostic.Create(LocationsRule, loc, "equality comparison operator");
+				context.ReportDiagnostic(diagnostic);
+			}
+			else if (methodDeclaration is ConversionOperatorDeclarationSyntax { ImplicitOrExplicitKeyword.Text: "implicit" } conversionDeclaration)
+			{
+				var loc = conversionDeclaration.OperatorKeyword.GetLocation();
+				Diagnostic diagnostic = Diagnostic.Create(LocationsRule, loc, "implicit cast operator");
+				context.ReportDiagnostic(diagnostic);
+			}
+			else if (methodDeclaration is ConstructorDeclarationSyntax constructorDeclaration)
+			{
+				bool? withinExceptionClass =
+					(methodDeclaration.Parent as TypeDeclarationSyntax)?.Identifier.Text.EndsWith("Exception");
+				if ((withinExceptionClass.HasValue && (bool)withinExceptionClass) || constructorDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword))
+				{
+					var loc = constructorDeclaration.Identifier.GetLocation();
+					Diagnostic diagnostic = Diagnostic.Create(LocationsRule, loc, "implicit cast operator");
+					context.ReportDiagnostic(diagnostic);
+				}
+			}
+			else if (methodDeclaration is DestructorDeclarationSyntax destructorDeclaration)
+			{
+				var loc = destructorDeclaration.Identifier.GetLocation();
+				Diagnostic diagnostic = Diagnostic.Create(LocationsRule, loc, "finalizer");
+				context.ReportDiagnostic(diagnostic);
+			}
+		}
+	}
+}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -101,6 +101,7 @@
       * Introduce PH2119: Cast complete object.
       * Introduce PH2120: Document thrown exceptions.
       * Introduce PH2121: Throw informational exceptions.
+      * Introduce PH2122: Avoid throwing exceptions from unexpected locations.
     </PackageReleaseNotes>
 	  <Copyright>© 2019-2023 Koninklijke Philips N.V.</Copyright>
 	  <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -72,3 +72,4 @@
 | PH2119  | Cast complete object                         | A cast should include all information from the previous type. By casting to a type of one of the fields, the cast is losing information. Use an AsType() or ToType() method instead. |
 | PH2120  | Document thrown exceptions                   | Be clear to your callers what exception can be thrown from your method by mentioning each of them in an <exception> element in the documentation of the method. |
 | PH2121  | Throw informational exceptions               | Specify context to a thrown exception, by using a constructor overload that sets the Message property. |
+| PH2122  | Avoid Exceptions from unexpected locations   | Avoid throwing exceptions from unexpected locations, like Finalizers, Dispose, Static Constructors, etc... |

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -72,4 +72,4 @@
 | PH2119  | Cast complete object                         | A cast should include all information from the previous type. By casting to a type of one of the fields, the cast is losing information. Use an AsType() or ToType() method instead. |
 | PH2120  | Document thrown exceptions                   | Be clear to your callers what exception can be thrown from your method by mentioning each of them in an <exception> element in the documentation of the method. |
 | PH2121  | Throw informational exceptions               | Specify context to a thrown exception, by using a constructor overload that sets the Message property. |
-| PH2122  | Avoid Exceptions from unexpected locations   | Avoid throwing exceptions from unexpected locations, like Finalizers, Dispose, Static Constructors, etc... |
+| PH2122  | Avoid Exceptions from unexpected locations   | Avoid throwing exceptions from unexpected locations, like Finalizers, Dispose, Static Constructors, some operators, and overidden methods of Object. |

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/AvoidThrowFromUnexpectedLocationsTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/AvoidThrowFromUnexpectedLocationsTest.cs
@@ -1,0 +1,187 @@
+﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Philips.CodeAnalysis.Common;
+using Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation;
+
+namespace Philips.CodeAnalysis.Test.Maintainability.Documentation
+{
+	[TestClass]
+	public class AvoidThrowFromUnexpectedLocationsTest : DiagnosticVerifier
+	{
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
+		{
+			return new DocumentThrownExceptionsAnalyzer();
+		}
+
+		private const string CorrectExplicitCast = @"
+public class Foo
+{
+    /// <summary> Helpful text. </summary>
+    /// <exception cref=""ArgumentException"">
+    public static explicit operator int(Foo f1)
+    {
+        throw new ArgumentException(""Error"");
+    }
+}
+";
+
+		private const string CorrectOperatorPlus = @"
+public class Foo
+{
+    /// <summary> Helpful text. </summary>
+    /// <exception cref=""ArgumentException"">
+    public static Foo operator +(Foo f1, int i)
+    {
+        throw new ArgumentException(""Error"");
+    }
+}
+";
+
+		private const string WrongStaticConstructor = @"
+public class Foo
+{
+    /// <summary> Helpful text. </summary>
+    /// <exception cref=""ArgumentException"">
+    static Foo()
+    {
+        throw new ArgumentException(""Error"");
+    }
+}
+";
+
+		private const string WrongFinalizer = @"
+public class Foo
+{
+    /// <summary> Helpful text. </summary>
+    /// <exception cref=""ArgumentException"">
+    ~Foo()
+    {
+        throw new ArgumentException(""Error"");
+    }
+}
+";
+
+		private const string WrongDispose = @"
+public class Foo
+{
+    /// <summary> Helpful text. </summary>
+    /// <exception cref=""ArgumentException"">
+    public void Dispose()
+    {
+        throw new ArgumentException(""Error"");
+    }
+}
+";
+
+		private const string WrongToString = @"
+public class Foo
+{
+    /// <summary> Helpful text. </summary>
+    /// <exception cref=""ArgumentException"">
+    public override string ToString()
+    {
+        throw new ArgumentException(""Error"");
+    }
+}
+";
+
+		private const string WrongEquals = @"
+public class Foo
+{
+    /// <summary> Helpful text. </summary>
+    /// <exception cref=""ArgumentException"">
+    public override bool Equals(object other)
+    {
+        throw new ArgumentException(""Error"");
+    }
+}
+";
+
+		private const string WrongGetHashCode = @"
+public class Foo
+{
+    /// <summary> Helpful text. </summary>
+    /// <exception cref=""ArgumentException"">
+    public override int GetHashCode()
+    {
+        throw new ArgumentException(""Error"");
+    }
+}
+";
+
+		private const string WrongOperatorEquals = @"
+public class Foo
+{
+    /// <summary> Helpful text. </summary>
+    /// <exception cref=""ArgumentException"">
+    public static bool operator ==(Foo f1, Foo f2)
+    {
+        throw new ArgumentException(""Error"");
+    }
+}
+";
+
+		private const string WrongOperatorNotEquals = @"
+public class Foo
+{
+    /// <summary> Helpful text. </summary>
+    /// <exception cref=""ArgumentException"">
+    public static bool operator !=(Foo f1, Foo f2)
+    {
+        throw new ArgumentException(""Error"");
+    }
+}
+";
+
+		private const string WrongImplicitCast = @"
+public class Foo
+{
+    /// <summary> Helpful text. </summary>
+    /// <exception cref=""ArgumentException"">
+    public static implicit operator int(Foo f1)
+    {
+        throw new ArgumentException(""Error"");
+    }
+}
+";
+
+		private const string WrongExceptionConstructor = @"
+public class FooException
+{
+    /// <summary> Helpful text. </summary>
+    /// <exception cref=""ArgumentException"">
+    public Foo()
+    {
+        throw new ArgumentException(""Error"");
+    }
+}
+";
+
+		[DataTestMethod]
+		[DataRow(CorrectExplicitCast, DisplayName = nameof(CorrectExplicitCast)),
+		 DataRow(CorrectOperatorPlus, DisplayName = nameof(CorrectOperatorPlus))]
+		public void CorrectCodeShouldNotTriggerAnyDiagnostics(string testCode)
+		{
+			VerifyDiagnostic(testCode);
+		}
+
+		[DataTestMethod]
+		[DataRow(WrongStaticConstructor, DisplayName = nameof(WrongStaticConstructor)),
+		 DataRow(WrongFinalizer, DisplayName = nameof(WrongFinalizer)),
+		 DataRow(WrongDispose, DisplayName = nameof(WrongDispose)),
+		 DataRow(WrongToString, DisplayName = nameof(WrongToString)),
+		 DataRow(WrongEquals, DisplayName = nameof(WrongEquals)),
+		 DataRow(WrongGetHashCode, DisplayName = nameof(WrongGetHashCode)),
+		 DataRow(WrongOperatorEquals, DisplayName = nameof(WrongOperatorEquals)),
+		 DataRow(WrongOperatorNotEquals, DisplayName = nameof(WrongOperatorNotEquals)),
+		 DataRow(WrongImplicitCast, DisplayName = nameof(WrongImplicitCast)),
+		 DataRow(WrongExceptionConstructor, DisplayName = nameof(WrongExceptionConstructor))]
+		public void MissingOrWrongDocumentationShouldTriggerDiagnostic(string testCode)
+		{
+			VerifyDiagnostic(testCode, DiagnosticResultHelper.Create(DiagnosticIds.AvoidExceptionsFromUnexpectedLocations));
+		}
+	}
+}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidThrowingUnexpectedExceptionsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidThrowingUnexpectedExceptionsAnalyzerTest.cs
@@ -4,16 +4,16 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Philips.CodeAnalysis.Common;
-using Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation;
+using Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability;
 
-namespace Philips.CodeAnalysis.Test.Maintainability.Documentation
+namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 {
 	[TestClass]
 	public class AvoidThrowFromUnexpectedLocationsTest : DiagnosticVerifier
 	{
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
-			return new DocumentThrownExceptionsAnalyzer();
+			return new AvoidThrowingUnexpectedExceptionsAnalyzer();
 		}
 
 		private const string CorrectExplicitCast = @"


### PR DESCRIPTION
Added a new check to the existing `DocumentThrownExceptionsAnalyzer` which checks rule [8@102](https://tics.tiobe.com/viewerCS/?ID=105&CSTD=Rule) of the Philips C# Coding Standard