### PR TITLE
fix: crash in ReduceCognitiveLoadAnalyzer

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/ReduceCognitiveLoadAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/ReduceCognitiveLoadAnalyzer.cs
@@ -68,7 +68,6 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			if (blockSyntax == null)
 			{
 				return;
-
 			}
 			int cognitiveLoad = CalcCognitiveLoad(blockSyntax);
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/ReduceCognitiveLoadAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/ReduceCognitiveLoadAnalyzer.cs
@@ -64,7 +64,12 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			}
 
 			MethodDeclarationSyntax methodDeclarationSyntax = (MethodDeclarationSyntax)context.Node;
-			BlockSyntax blockSyntax = methodDeclarationSyntax.DescendantNodes().OfType<BlockSyntax>().First();
+			BlockSyntax blockSyntax = methodDeclarationSyntax.DescendantNodes().OfType<BlockSyntax>().FirstOrDefault();
+			if (blockSyntax == null)
+			{
+				return;
+
+			}
 			int cognitiveLoad = CalcCognitiveLoad(blockSyntax);
 
 			cognitiveLoad += blockSyntax.DescendantTokens().Count((token) =>

--- a/Philips.CodeAnalysis.Test/DuplicateCode/AvoidDuplicateCodeTest.cs
+++ b/Philips.CodeAnalysis.Test/DuplicateCode/AvoidDuplicateCodeTest.cs
@@ -277,7 +277,7 @@ Foo.WhitelistedFunction
 		public void AvoidDuplicateCodeNoError(string method1, string method2)
 		{
 			var file = CreateFunctions(method1, method2);
-			VerifyNoDiagnostic(file);
+			VerifySuccessfulCompilation(file);
 		}
 
 		[DataTestMethod]
@@ -325,7 +325,7 @@ class Foo
 }}
 ";
 
-			VerifyNoDiagnostic(baseline);
+			VerifySuccessfulCompilation(baseline);
 		}
 
 
@@ -349,11 +349,6 @@ class Foo
 			return string.Format(baseline, content1, content2);
 		}
 
-
-		private void VerifyNoDiagnostic(string file)
-		{
-			base.VerifyDiagnostic(file);
-		}
 
 		private void VerifyDiagnostic(string file)
 		{

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidStaticClassAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidStaticClassAnalyzerTest.cs
@@ -29,7 +29,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 			};
 			_mock.Setup(c => c.CreateCompilationAnalyzer(It.IsAny<HashSet<string>>(), It.IsAny<bool>())).Returns(new AvoidStaticClassesCompilationAnalyzer(exceptions, false));
 			var file = CreateFunction("static", KnownWhitelistClassNamespace, KnownWhitelistClassClassName);
-			VerifyNoDiagnostic(file);
+			VerifySuccessfulCompilation(file);
 		}
 	}
 
@@ -105,16 +105,16 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		public void AvoidStaticClassesShouldWhitelistWildCardClassTest()
 		{
 			var file = CreateFunction("static", "IAmSooooooNotWhitelisted", KnownWildcardClassName);
-			VerifyNoDiagnostic(file);
+			VerifySuccessfulCompilation(file);
 			var file2 = CreateFunction("static", "IAmSooooooNotWhitelisted", AnotherKnownWildcardClassName);
-			VerifyNoDiagnostic(file2);
+			VerifySuccessfulCompilation(file2);
 		}
 
 		[TestMethod]
 		public void AvoidStaticClassesShouldWhitelistExtensionClasses()
 		{
 			var noDiagnostic = CreateFunction("static", isExtension: true, hasNonExtensionMethods: false);
-			VerifyNoDiagnostic(noDiagnostic);
+			VerifySuccessfulCompilation(noDiagnostic);
 			var methodHavingDiagnostic = CreateFunction("static", isExtension: true);
 			VerifyDiagnostic(methodHavingDiagnostic);
 		}
@@ -123,14 +123,9 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		public void AvoidNoStaticClassesTest()
 		{
 			var file = CreateFunction("");
-			VerifyNoDiagnostic(file);
+			VerifySuccessfulCompilation(file);
 		}
 
-
-		protected void VerifyNoDiagnostic(string file)
-		{
-			base.VerifyDiagnostic(file);
-		}
 
 		private void VerifyDiagnostic(string file)
 		{

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoRegionsInMethodAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoRegionsInMethodAnalyzerTest.cs
@@ -20,25 +20,25 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 
 		public void NoRegionNoMethodTest()
 		{
-			VerifyNoDiagnostic(@"Class C{C(){}}");
+			VerifySuccessfulCompilation(@"Class C{C(){}}");
 		}
 
 		[TestMethod]
 		public void NoRegionTest()
 		{
-			VerifyNoDiagnostic(@"Class C{C(){}public void foo(){}}");
+			VerifySuccessfulCompilation(@"Class C{C(){}public void foo(){}}");
 		}
 
 		[TestMethod]
 		public void EmptyClassWithRegionTest()
 		{
-			VerifyNoDiagnostic(@"Class C{	#region testRegion	#endregion	}");
+			VerifySuccessfulCompilation(@"Class C{	#region testRegion	#endregion	}");
 		}
 
 		[TestMethod]
 		public void RegionOutsideMethodTest()
 		{
-			VerifyNoDiagnostic(@"Class C{#region testRegion	public void foo() {int x = 2; }	#endregion}");
+			VerifySuccessfulCompilation(@"Class C{#region testRegion	public void foo() {int x = 2; }	#endregion}");
 		}
 
 		[TestMethod]
@@ -70,19 +70,19 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		[TestMethod]
 		public void RegionCoversMultipleMethodsTest()
 		{
-			VerifyNoDiagnostic(@"Class C{	#region testRegion	public void foo(){	return;	} public void bar(){	}	#endregion	}");
+			VerifySuccessfulCompilation(@"Class C{	#region testRegion	public void foo(){	return;	} public void bar(){	}	#endregion	}");
 		}
 
 		[TestMethod]
 		public void RegionBeforeClassTest()
 		{
-			VerifyNoDiagnostic(@"	#region testRegion	#endregion Class C{	public void foo(){	return; }	public void bar(){	}	}");
+			VerifySuccessfulCompilation(@"	#region testRegion	#endregion Class C{	public void foo(){	return; }	public void bar(){	}	}");
 		}
 
 		[TestMethod]
 		public void UnnamedRegionTest()
 		{
-			VerifyNoDiagnostic(@"Class C{	#region #endregion	public void foo(){	return; }public void bar(){}	}");
+			VerifySuccessfulCompilation(@"Class C{	#region #endregion	public void foo(){	return; }public void bar(){}	}");
 		}
 
 		[TestMethod]
@@ -106,24 +106,17 @@ Class C{
 		[TestMethod]
 		public void MalformedCodeTest()
 		{
-			VerifyNoDiagnostic(@"Class C{	#region 	public void foo(){		return;	}	#endregion	public void bar(){	}	");
+			VerifySuccessfulCompilation(@"Class C{	#region 	public void foo(){		return;	}	#endregion	public void bar(){	}	");
 		}
 
 		[TestMethod]
 		public void EmptyStringTest()
 		{
-			VerifyNoDiagnostic("");
+			VerifySuccessfulCompilation("");
 		}
 
 
 
-
-		//***********Methods under this line were taken from AvoidInLineNewAnalyzerTest.cs and modified
-
-		private void VerifyNoDiagnostic(string file)
-		{
-			VerifyDiagnostic(file);
-		}
 
 		private void VerifyDiagnostic(string file, int line)
 		{

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ReduceCognitiveLoadAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ReduceCognitiveLoadAnalyzerTest.cs
@@ -66,6 +66,7 @@ class Foo
 			VerifyDiagnostic(template);
 		}
 
+
 		[TestMethod]
 		public void CognitiveLoadIf()
 		{
@@ -79,6 +80,18 @@ class Foo
 }
 ";
 			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.ReduceCognitiveLoad, MakeRegex(2)));
+		}
+
+		[TestMethod]
+		public void CognitiveLoadExpressionBody()
+		{
+			const string template = @"
+class Foo
+{
+	private string MakeString() => new string(""MyString"");
+}
+";
+			VerifySuccessfulCompilation(template);
 		}
 
 		[TestMethod]

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/WinFormsInitializeComponentMustBeCalledOnceAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/WinFormsInitializeComponentMustBeCalledOnceAnalyzerTest.cs
@@ -184,15 +184,6 @@ class ContainerControl
 		}
 
 		/// <summary>
-		/// VerifyNoDiagnostic
-		/// </summary>
-		/// <param name="file"></param>
-		private void VerifyNoDiagnostic(string file)
-		{
-			VerifyDiagnostic(file);
-		}
-
-		/// <summary>
 		/// VerifyDiagnosticOnFirst
 		/// </summary>
 		/// <param name="file"></param>
@@ -268,7 +259,7 @@ class ContainerControl
 			}
 			else
 			{
-				VerifyNoDiagnostic(code);
+				VerifySuccessfulCompilation(code);
 			}
 		}
 
@@ -291,7 +282,7 @@ class ContainerControl
 		public void WinFormsInitialComponentMustBeCalledOnceAnalyzerWithDisjointConstructors()
 		{
 			string code = CreateCodeWithDisjointConstructors();
-			VerifyNoDiagnostic(code);
+			VerifySuccessfulCompilation(code);
 		}
 
 		/// <summary>

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidInlineNewAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidInlineNewAnalyzerTest.cs
@@ -56,14 +56,14 @@ class Foo
 		public void NoErrorIfPlacedInLocal()
 		{
 			var file = CreateFunction("object obj = new object(); string str = obj.ToString();");
-			VerifyNoDiagnostic(file);
+			VerifySuccessfulCompilation(file);
 		}
 
 		[TestMethod]
 		public void NoErrorIfPlacedInField()
 		{
 			var file = CreateFunction("_obj = new object(); string str = _obj.ToString();");
-			VerifyNoDiagnostic(file);
+			VerifySuccessfulCompilation(file);
 		}
 
 		[DataRow("new Foo()")]
@@ -79,14 +79,14 @@ class Foo
 		public void NoErrorIfPlacedInLocalCustomType()
 		{
 			var file = CreateFunction("object obj = new Foo(); string str = obj.ToString();");
-			VerifyNoDiagnostic(file);
+			VerifySuccessfulCompilation(file);
 		}
 
 		[TestMethod]
 		public void NoErrorIfPlacedInFieldCustomType()
 		{
 			var file = CreateFunction("_obj = new Foo(); string str = _obj.ToString();");
-			VerifyNoDiagnostic(file);
+			VerifySuccessfulCompilation(file);
 		}
 
 
@@ -94,14 +94,14 @@ class Foo
 		public void NoErrorIfPlacedInContainer()
 		{
 			var file = CreateFunction("var v = new List<object>(); v.Add(new object());");
-			VerifyNoDiagnostic(file);
+			VerifySuccessfulCompilation(file);
 		}
 
 		[TestMethod]
 		public void NoErrorIfReturned()
 		{
 			var file = CreateFunction("return new object();");
-			VerifyNoDiagnostic(file);
+			VerifySuccessfulCompilation(file);
 		}
 
 		[TestMethod]
@@ -115,7 +115,7 @@ class Foo
 		public void NoErrorIfThrown()
 		{
 			var file = CreateFunction("throw new Exception();");
-			VerifyNoDiagnostic(file);
+			VerifySuccessfulCompilation(file);
 		}
 
 		[TestMethod]
@@ -123,11 +123,6 @@ class Foo
 		{
 			var file = CreateFunction("throw new object().Foo;");
 			VerifyDiagnostic(file);
-		}
-
-		private void VerifyNoDiagnostic(string file)
-		{
-			base.VerifyDiagnostic(file);
 		}
 
 		private void VerifyDiagnostic(string file)

--- a/Philips.CodeAnalysis.Test/MsTest/AvoidMsFakesAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AvoidMsFakesAnalyzerTest.cs
@@ -55,14 +55,9 @@ class Foo
 		public void AvoidMsFakesNotRelevantTest()
 		{
 			var file = CreateFunction("using (new MemoryStream()) {}");
-			VerifyNoDiagnostic(file);
+			VerifySuccessfulCompilation(file);
 		}
 
-
-		private void VerifyNoDiagnostic(string file)
-		{
-			base.VerifyDiagnostic(file);
-		}
 
 		private void VerifyDiagnostic(string file)
 		{

--- a/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
@@ -47,15 +47,20 @@ namespace Philips.CodeAnalysis.Test
 			VerifyDiagnostic(source, null, expected);
 		}
 
-        /// <summary>
-        /// General method that gets a collection of actual diagnostics found in the source after the analyzer is run, 
-        /// then verifies each of them.
-        /// </summary>
-        /// <param name="sources">An array of strings to create source documents from to run the analyzers on</param>
-        /// <param name="filenamePrefix">The name of the source file, without the extension</param>
+		protected void VerifySuccessfulCompilation(string source)
+		{
+			VerifyDiagnostic(source);
+		}
+
+		/// <summary>
+		/// General method that gets a collection of actual diagnostics found in the source after the analyzer is run, 
+		/// then verifies each of them.
+		/// </summary>
+		/// <param name="sources">An array of strings to create source documents from to run the analyzers on</param>
+		/// <param name="filenamePrefix">The name of the source file, without the extension</param>
 		/// <param name="analyzer">The analyzer to be run on the source code</param>
-        /// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
-        private void VerifyDiagnosticsInternal(string[] sources, string filenamePrefix, DiagnosticAnalyzer analyzer, params DiagnosticResult[] expected)
+		/// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
+		private void VerifyDiagnosticsInternal(string[] sources, string filenamePrefix, DiagnosticAnalyzer analyzer, params DiagnosticResult[] expected)
 		{
 			var diagnostics = GetSortedDiagnostics(sources, filenamePrefix, analyzer);
 			VerifyDiagnosticResults(diagnostics, analyzer, expected);


### PR DESCRIPTION
The analyzer fails on expression bodies because there is not a block.