### PR TITLE
feat: Add check for + and == operators alignment

### DIFF
--- a/Philips.CodeAnalysis.Common/DiagnosticIds.cs
+++ b/Philips.CodeAnalysis.Common/DiagnosticIds.cs
@@ -116,5 +116,6 @@ namespace Philips.CodeAnalysis.Common
 		ThrowInformationalExceptions = 2121,
 		AvoidExceptionsFromUnexpectedLocations = 2122,
 		PassSenderToEventHandler = 2123,
+		AlignNumberOfPlusAndEqualOperators = 2125,
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AlignOperatorsCountAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AlignOperatorsCountAnalyzer.cs
@@ -41,6 +41,9 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		private static readonly DiagnosticDescriptor ShiftRightAndLeftRule =
 			GenerateRule(">>", "<<", DiagnosticIds.AlignNumberOfShiftRightAndLeftOperators);
 
+		private static readonly DiagnosticDescriptor PlusAndEqualRule =
+			GenerateRule("+", "==", DiagnosticIds.AlignNumberOfPlusAndEqualOperators);
+
 		private static DiagnosticDescriptor GenerateRule(string first, string second, DiagnosticIds diagnosticId)
 		{
 			return new(
@@ -58,7 +61,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		/// <inheritdoc cref="DiagnosticAnalyzer"/>
 		/// </summary>
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-			ImmutableArray.Create(IncrementAndDecrementRule, PlusMinusRule, MultiplyDivideRule, GreaterLessThanRule, GreaterLessThanOrEqualRule, ShiftRightAndLeftRule);
+			ImmutableArray.Create(IncrementAndDecrementRule, PlusMinusRule, MultiplyDivideRule, GreaterLessThanRule, GreaterLessThanOrEqualRule, ShiftRightAndLeftRule, PlusAndEqualRule);
 
 		/// <summary>
 		/// <inheritdoc cref="DiagnosticAnalyzer"/>
@@ -139,6 +142,12 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			{
 				var location = identifier.GetLocation();
 				context.ReportDiagnostic(Diagnostic.Create(ShiftRightAndLeftRule, location));
+			}
+
+			if (visitor.PlusCount != visitor.EqualCount)
+			{
+				var location = identifier.GetLocation();
+				context.ReportDiagnostic(Diagnostic.Create(PlusAndEqualRule, location));
 			}
 		}
 	}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AlignOperatorsCountAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AlignOperatorsCountAnalyzer.cs
@@ -19,8 +19,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 	{
 		private const string TitleFormat = "Align number of {0} and {1} operators.";
 		private const string MessageFormat = "Align number of {0} and {1} operators.";
-		private const string DescriptionFormat = 
-			"A class should have the same number of {0} as {1} operators.";
+		private const string DescriptionFormat =
+			"Overload the {1} operator, when you overload the {0} operator, as they are often used in combination with each other.";
 		private const string Category = Categories.Maintainability;
 
 		private static readonly DiagnosticDescriptor IncrementAndDecrementRule =

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/OperatorsVisitor.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/OperatorsVisitor.cs
@@ -56,6 +56,9 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 				case SyntaxKind.LessThanLessThanToken:
 					ShiftLeftCount += 1;
 					break;
+				case SyntaxKind.EqualsEqualsToken:
+					EqualCount += 1;
+					break;
 			}
 		}
 
@@ -82,5 +85,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 		public int ShiftRightCount { get; private set; }
 
 		public int ShiftLeftCount { get; private set; }
+
+		public int EqualCount { get; private set; }
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -103,6 +103,7 @@
       * Introduce PH2121: Throw informational exceptions.
       * Introduce PH2122: Avoid throwing exceptions from unexpected locations.
       * Introduce PH2123: Pass sender to EventHandler.
+      * Introduce PH2125: Align number of + and == operators.
     </PackageReleaseNotes>
 	  <Copyright>© 2019-2023 Koninklijke Philips N.V.</Copyright>
 	  <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -55,12 +55,12 @@
 | PH2102  | Xml documentation should add value           | The content of the summary block of the inline XML code documentation, should add more information then merely repeating its name. |
 | PH2103  | Avoid method calls as arguments              | Avoid method calls as arguments to method calls. For example, avoid `Foo(Meow())` |
 | PH2104  | Every Linq statement on separate line        | Put every linq statement on a separate line, this makes it easier for a reader to follow the steps. |
-| PH2105  | Align number of + and - operators            | Align the number of operators + and -, as these are often used in combination with each other. |
-| PH2106  | Align number of * and / operators            | Align the number of operators * and /, as these are often used in combination with each other. |
-| PH2107  | Align number of > and < operators            | Align the number of operators > and <, as these are often used in combination with each other. |
-| PH2108  | Align number of >= and <= operators          | Align the number of operators >= and <=, as these are often used in combination with each other. |
-| PH2109  | Align number of >> and << operators          | Align the number of operators >> and <<, as these are often used in combination with each other. |
-| PH2110  | Align number of ++ and -- operators          | Align the number of operators ++ and --, as these are often used in combination with each other. |
+| PH2105  | Align number of + and - operators            | Overload the minus (-) operator, when you overload the plus (+) operator, as these are often used in combination with each other. |
+| PH2106  | Align number of * and / operators            | Overload the divide (/) operator, when you overload the multiple (*) operator, as these are often used in combination with each other. |
+| PH2107  | Align number of > and < operators            | Overload the smaller than (<) operator, when you overload the greater than (>) operator, as these are often used in combination with each other. |
+| PH2108  | Align number of >= and <= operators          | Overload the smaller or equal (<=) operator, when you overload the greater or equal (>=) operator, as these are often used in combination with each other. |
+| PH2109  | Align number of >> and << operators          | Overload the left shift (<<) operator, when you overload the right shift (>>) operator, as these are often used in combination with each other. |
+| PH2110  | Align number of ++ and -- operators          | Overload the increment (--) operator, when you overload the increment (++) operator, as these are often used in combination with each other. |
 | PH2111  | Reduce Cognitive Load                        | Reduce the number of nested blocks, logical cases, and negations in this method. |
 | PH2112  | Avoid overridde with new keyword             | Overriding with the new keyword gives unexpected behavior for the callers of the overridden method or property. |
 | PH2113  | Merge If Statements                          | Nested If statements lacking else clauses and containing the same body can be safely merged to reduce cognitive load |
@@ -74,4 +74,4 @@
 | PH2121  | Throw informational exceptions               | Specify context to a thrown exception, by using a constructor overload that sets the Message property. |
 | PH2122  | Avoid Exceptions from unexpected locations   | Avoid throwing exceptions from unexpected locations, like Finalizers, Dispose, Static Constructors, some operators, and overidden methods of Object. |
 | PH2123  | Pass sender to EventHandler                  | Prevent passing null values for sender/object to event handler (for instance-based events).|
-| PH2125  | Align number of + and == operators           | Align the number of operators + and ==, as these are often used in combination with each other. |
+| PH2125  | Align number of + and == operators           | Overload the equality operator (==), when you overload the addition (+) operator. |

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -74,3 +74,4 @@
 | PH2121  | Throw informational exceptions               | Specify context to a thrown exception, by using a constructor overload that sets the Message property. |
 | PH2122  | Avoid Exceptions from unexpected locations   | Avoid throwing exceptions from unexpected locations, like Finalizers, Dispose, Static Constructors, some operators, and overidden methods of Object. |
 | PH2123  | Pass sender to EventHandler                  | Prevent passing null values for sender/object to event handler (for instance-based events).|
+| PH2125  | Align number of + and == operators           | Align the number of operators + and ==, as these are often used in combination with each other. |

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AlignOperatorsCountAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AlignOperatorsCountAnalyzerTest.cs
@@ -41,6 +41,10 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
             {
                 return num1.n - num2.n;
             }
+            public static Number operator ==(Number num1, Number num2)
+            {
+                return num1.n == num2.n;
+            }
         }
     }";
 
@@ -55,6 +59,10 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
             public static Number operator -(Number num1, Number num2)
             {
                 return num1.n - num2.n;
+            }
+            public static Number operator ==(Number num1, Number num2)
+            {
+                return num1.n == num2.n;
             }
         }
     }";
@@ -116,6 +124,25 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
         }
     }";
 
+		private const string CorrectNumberOfPlusEqual = @"
+    namespace AssignmentInConditionUnitTests {
+        public class Number {
+			private int n;
+            public static Number operator +(Number num1, Number num2)
+            {
+                return num1.n + num2.n;
+            }
+            public static Number operator -(Number num1, Number num2)
+            {
+                return num1.n - num2.n;
+            }
+            public static Number operator ==(Number num1, Number num2)
+            {
+                return num1.n == num2.n;
+            }
+        }
+    }";
+
 		private const string WrongNumberOfIncrementDecrement = @"
     namespace AssignmentInConditionUnitTests {
         public class Number {
@@ -135,6 +162,10 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
             {
                 return num1.n + num2.n;
             }
+            public static Number operator ==(Number num1, Number num2)
+            {
+                return num1.n == num2.n;
+            }
         }
     }";
 		
@@ -146,7 +177,11 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
             {
                 return num1.n + num2.n;
             }
-        }
+             public static Number operator ==(Number num1, Number num2)
+            {
+                return num1.n == num2.n;
+            }
+       }
     }";
 
 		private const string WrongNumberOfMultiplyDivide = @"
@@ -193,6 +228,20 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
             }
         }
     }";
+		private const string WrongNumberOfPlusEqual = @"
+    namespace AssignmentInConditionUnitTests {
+        public class Number {
+			private int n;
+            public static Number operator +(Number num1, Number num2)
+            {
+                return num1.n + num2.n;
+            }
+            public static Number operator -(Number num1, Number num2)
+            {
+                return num1.n - num2.n;
+            }
+        }
+    }";
 
 		/// <summary>
 		/// No diagnostics expected to show up
@@ -205,7 +254,8 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		 DataRow(CorrectNumberOfMultiplyDivide, DisplayName = nameof(CorrectNumberOfMultiplyDivide)),
 		 DataRow(CorrectNumberOfGreaterLessThan, DisplayName = nameof(CorrectNumberOfGreaterLessThan)),
 		 DataRow(CorrectNumberOfGreaterLessThanOrEqual, DisplayName = nameof(CorrectNumberOfGreaterLessThanOrEqual)),
-		 DataRow(CorrectNumberOfRightLeftShift, DisplayName = nameof(CorrectNumberOfRightLeftShift))]
+		 DataRow(CorrectNumberOfRightLeftShift, DisplayName = nameof(CorrectNumberOfRightLeftShift)),
+		 DataRow(CorrectNumberOfPlusEqual, DisplayName = nameof(CorrectNumberOfPlusEqual))]
 		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
 		{
 			VerifyDiagnostic(testCode);
@@ -221,7 +271,8 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		 DataRow(WrongNumberOfMultiplyDivide, DiagnosticIds.AlignNumberOfMultiplyAndDivideOperators, DisplayName = nameof(WrongNumberOfMultiplyDivide)),
 		 DataRow(WrongNumberOfGreaterLessThan, DiagnosticIds.AlignNumberOfGreaterAndLessThanOperators, DisplayName = nameof(WrongNumberOfGreaterLessThan)),
 		 DataRow(WrongNumberOfGreaterLessThanOrEqual, DiagnosticIds.AlignNumberOfGreaterAndLessThanOrEqualOperators, DisplayName = nameof(WrongNumberOfGreaterLessThanOrEqual)),
-		 DataRow(WrongNumberOfRightLeftShift, DiagnosticIds.AlignNumberOfShiftRightAndLeftOperators, DisplayName = nameof(WrongNumberOfRightLeftShift))]
+		 DataRow(WrongNumberOfRightLeftShift, DiagnosticIds.AlignNumberOfShiftRightAndLeftOperators, DisplayName = nameof(WrongNumberOfRightLeftShift)),
+		 DataRow(WrongNumberOfPlusEqual, DiagnosticIds.AlignNumberOfPlusAndEqualOperators, DisplayName = nameof(WrongNumberOfPlusEqual))]
 		public void WhenMismatchOfPlusMinusDiagnosticIsRaised(string testCode, DiagnosticIds diagnosticId) {
 			var expected = DiagnosticResultHelper.Create(diagnosticId);
 			VerifyDiagnostic(testCode, expected);


### PR DESCRIPTION
This checks rule [7@531](https://csviewer.tiobe.com/#/ruleset/rule?setid=4T_Jr6-VSX6fp6egDIhGow&status=CHECKED,UNCHECKED&tagid=6u27MkXORKaev0VNuWR_SA&ruleid=TCjgzMnETo2yCNKdNzCS0Q) of the Philips C# Coding Standard.

We only check if `+` and `==` align here, as PH2105 checks if `+` and `-` align and the compiler checks if `==` and `!=` align.