### PR TITLE
test: Allow Unit Testing CodeFixers that modify AdditionalDocuments

### DIFF
--- a/Philips.CodeAnalysis.Test/DuplicateCode/AvoidDuplicateCodeTest.cs
+++ b/Philips.CodeAnalysis.Test/DuplicateCode/AvoidDuplicateCodeTest.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -12,7 +13,7 @@ using Philips.CodeAnalysis.DuplicateCodeAnalyzer;
 namespace Philips.CodeAnalysis.Test.DuplicateCode
 {
 	[TestClass]
-	public class AvoidDuplicateCodeAnalyzerTest : DiagnosticVerifier
+	public class AvoidDuplicateCodeAnalyzerTest : CodeFixVerifier
 	{
 		private const string allowedMethodName = @"Foo.AllowedInitializer()
 Foo.AllowedInitializer(Bar)
@@ -22,6 +23,11 @@ Foo.WhitelistedFunction
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidDuplicateCodeAnalyzer() { DefaultDuplicateTokenThreshold = 100 };
+		}
+
+		protected override CodeFixProvider GetCodeFixProvider()
+		{
+			return new AvoidDuplicateCodeFixProvider();
 		}
 
 		protected override Dictionary<string, string> GetAdditionalAnalyzerConfigOptions()
@@ -287,7 +293,7 @@ Foo.WhitelistedFunction
 		public void AvoidDuplicateCodeError(string method1, string method2)
 		{
 			var file = CreateFunctions(method1, method2);
-			VerifyDiagnostic(file);
+			VerifyFix(file, file);
 		}
 
 
@@ -333,15 +339,18 @@ class Foo
 		private string CreateFunctions(string content1, string content2)
 		{
 			string baseline = @"
-class Foo 
+namespace MyNamespace
 {{
-  public void Foo()
+  class FooClass
   {{
-	{0};
-  }}
-  public void Bar()
-  {{
-	{1};
+    public void Foo()
+    {{
+	  {0};
+    }}
+    public void Bar()
+    {{
+	  {1};
+    }}
   }}
 }}
 ";

--- a/Philips.CodeAnalysis.Test/Helpers/TestTextLoader.cs
+++ b/Philips.CodeAnalysis.Test/Helpers/TestTextLoader.cs
@@ -1,0 +1,30 @@
+﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Philips.CodeAnalysis.Test.Helpers
+{
+	public class TestTextLoader : TextLoader
+	{
+		private readonly Dictionary<DocumentId, string> _textDocuments = new();
+
+		public void Register(DocumentId documentId, string content)
+		{
+			_textDocuments.Add(documentId, content);
+		}
+
+		public override Task<TextAndVersion> LoadTextAndVersionAsync(Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
+		{
+			SourceText text = SourceText.From(_textDocuments[documentId]);
+			var textAndVersion = TextAndVersion.Create(text, VersionStamp.Default);
+			return Task.FromResult(textAndVersion);
+		}
+	}
+}


### PR DESCRIPTION
* Register "AdditionalDocuments" with the project when the project is created, so that the CodeFixers can find these configuration files.
* When the Analyzer creates its compilation context in GetSortedDiagnosticsFromDocuments, get the AdditionalDocuments from the project level, rather than from the Test class. That way, if a CodeFixer modifies the contents of the AdditionalDocuments, when the Analyzer is re-run, it will use the updated configuration files.
