### PR TITLE
test: Test coverage for fixers

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidArrayListAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidArrayListAnalyzer.cs
@@ -31,7 +31,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			context.EnableConcurrentExecution();
 			context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.VariableDeclaration);
 		}
-
+		
 		private static void Analyze(SyntaxNodeAnalysisContext context)
 		{
 			var variable = (VariableDeclarationSyntax)context.Node;

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidArrayListCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidArrayListCodeFixProvider.cs
@@ -15,7 +15,7 @@ using Philips.CodeAnalysis.Common;
 
 namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 {
-	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AvoidArrayListAnalyzer)), Shared]
+	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AvoidArrayListCodeFixProvider)), Shared]
 	public class AvoidArrayListCodeFixProvider : CodeFixProvider
 	{
 		private const string Title = "Replace ArrayList with List<T>";
@@ -83,7 +83,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 		public override FixAllProvider GetFixAllProvider()
 		{
-			return null;
+			return WellKnownFixAllProviders.BatchFixer;
 		}
 
 		/// <summary>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/CastCompleteObjectAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/CastCompleteObjectAnalyzer.cs
@@ -35,12 +35,9 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		{
 			var conversion = (ConversionOperatorDeclarationSyntax)context.Node;
 			var container = conversion.ParameterList.Parameters.FirstOrDefault()?.Type;
-			if (container == null)
-			{
-				return;
-			}
 			// TODO: Consider banning explicitly casting to string, in favor of overriding ToString().
 			if (
+				container == null ||
 				context.SemanticModel.GetSymbolInfo(conversion.Type).Symbol is not INamedTypeSymbol convertTo ||
 				context.SemanticModel.GetSymbolInfo(container).Symbol is not INamedTypeSymbol containingType)
 			{

--- a/Philips.CodeAnalysis.Test/DuplicateCode/AvoidDuplicateCodeTest.cs
+++ b/Philips.CodeAnalysis.Test/DuplicateCode/AvoidDuplicateCodeTest.cs
@@ -44,6 +44,11 @@ Foo.WhitelistedFunction
 			return new[] { ("NotFile.txt", "data"), (AvoidDuplicateCodeAnalyzer.AllowedFileName, allowedMethodName) };
 		}
 
+		protected override void AssertFixAllProvider(FixAllProvider fixAllProvider)
+		{
+			// TODO: Implement an meaningful assert.
+			Assert.IsTrue(true);
+		}
 
 		public class SumHashCalculator : RollingHashCalculator<TokenInfo>
 		{

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidAsyncVoidAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidAsyncVoidAnalyzerTest.cs
@@ -8,7 +8,7 @@ using Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability;
 namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 {
 	[TestClass]
-	public class AvoidAsyncVoidAnalyzerTest : AssertCodeFixVerifier
+	public class AvoidAsyncVoidAnalyzerTest : AssertDiagnosticVerifier
 	{
 
 		[TestMethod]
@@ -130,19 +130,9 @@ class FooClass
 		}
 
 
-		protected override CodeFixProvider GetCodeFixProvider()
-		{
-			throw new NotImplementedException();
-		}
-
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{
 			return new AvoidAsyncVoidAnalyzer();
-		}
-
-		protected override DiagnosticResult GetExpectedDiagnostic(int expectedLineNumberErrorOffset = 0, int expectedColumnErrorOffset = 0)
-		{
-			throw new NotImplementedException();
 		}
 	}
 }

--- a/Philips.CodeAnalysis.Test/Verifiers/CodeFixVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/CodeFixVerifier.cs
@@ -2,14 +2,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Philips.CodeAnalysis.Test
@@ -25,6 +24,15 @@ namespace Philips.CodeAnalysis.Test
 		/// </summary>
 		/// <returns>The CodeFixProvider to be used for CSharp code</returns>
 		protected abstract CodeFixProvider GetCodeFixProvider();
+
+		/// <summary>
+		/// Checks if the specified <see cref="FixAllProvider"/> is as expected.
+		/// </summary>
+		/// <param name="fixAllProvider">The <see cref="FixAllProvider"/> instance returned by the code fixer.</param>
+		protected virtual void AssertFixAllProvider(FixAllProvider fixAllProvider)
+		{
+			Assert.AreSame(WellKnownFixAllProviders.BatchFixer, fixAllProvider);
+		}
 
 		/// <summary>
 		/// Called to test a C# codefix when applied on the inputted string as a source
@@ -128,6 +136,15 @@ namespace Philips.CodeAnalysis.Test
 				// Trimming the lines, to ignore indentation differences.
 				Assert.AreEqual(expectedSourceLines[i].Trim(), actualSourceLines[i].Trim(), $"Source line {i}");
 			}
+		}
+
+		[TestMethod]
+		public void CheckFixAllProvider()
+		{
+			// Arrange
+			var fixAllProvider = GetCodeFixProvider().GetFixAllProvider();
+			// Assert
+			AssertFixAllProvider(fixAllProvider);
 		}
 	}
 }


### PR DESCRIPTION
Updated the `CodeFixVerifier` to have a test method already. By default it checks if the `FixAllProvider` is the `BatchFixAllProvider`. Fixed a few test cases that violated this guidelines.

However, the test class can override this check and do custom checks. Please create a follow up PR to implement this for the `AvoidDuplicateCodeTest` class.