### PR TITLE
test: Coverage improvement for some Analyzers

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -107,6 +107,7 @@
       * Introduce PH2125: Align number of + and == operators.
       * Introduce PH2126: Avoid using Parameters as temporary variables.
       * Introduce PH2127: Avoid changing loop variables.
+      * Increased the test coverage.
     </PackageReleaseNotes>
 	  <Copyright>© 2019-2023 Koninklijke Philips N.V.</Copyright>
 	  <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -51,7 +51,7 @@
 | PH2097  | Avoid Empty Statement Blocks                 | Avoid empty statement blocks |
 | PH2098  | Avoid Empty Catch Block                      | Avoid try-catch-swallow pattern |
 | PH2099  | Enforce FileVersion to be same as PackageVersion | For NuGet packages, this analyzer enforces that the .NET AssemblyFileVersion is equal to the AssemblyInformationalVersion. AssemblyFileVersion is not used at runtime, so it is helpful for it to match the Package Version. Set it with the &lt;FileVersion&gt; tag in the project file. If not set, it will inherit from &lt;AssemblyVersion&gt;, which if not set will inherit from &lt;Version&gt;|
-| PH2101  | Detect Null Dereference after "as"           | After "as" include null checks; or, use static cast to set expectations |
+| PH2101  | Detect Null Dereference after "as"           | After "as" include null checks; or, use static cast to set expectations. |
 | PH2102  | Xml documentation should add value           | The content of the summary block of the inline XML code documentation, should add more information then merely repeating its name. |
 | PH2103  | Avoid method calls as arguments              | Avoid method calls as arguments to method calls. For example, avoid `Foo(Meow())` |
 | PH2104  | Every Linq statement on separate line        | Put every linq statement on a separate line, this makes it easier for a reader to follow the steps. |

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/AvoidAssemblyVersionChange.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/AvoidAssemblyVersionChange.cs
@@ -35,7 +35,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
 			context.RegisterCompilationAction(Analyze);
 		}
 
-		private static void Analyze(CompilationAnalysisContext context)
+		private void Analyze(CompilationAnalysisContext context)
 		{
 			Version expectedVersion = new(@"1.0.0.0");
 			var additionalFilesHelper = new AdditionalFilesHelper(context.Options, context.Compilation);
@@ -53,12 +53,20 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
 				expectedVersion = parsedVersion;
 			}
 
-			Version actualVersion = context.Compilation.Assembly.Identity.Version;
+			Version actualVersion = GetCompilationAssemblyVersion(context.Compilation);
 			if (actualVersion.CompareTo(expectedVersion) != 0)
 			{
 				Diagnostic diagnostic = Diagnostic.Create(Rule, null, actualVersion.ToString(), expectedVersion.ToString());
 				context.ReportDiagnostic(diagnostic);
 			}
+		}
+
+		/// <summary>
+		/// To be overridden in test code only.
+		/// </summary>
+		protected virtual Version GetCompilationAssemblyVersion(Compilation compilation)
+		{
+			return compilation.Assembly.Identity.Version;
 		}
 	}
 }

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/EnforceEditorConfigAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/EnforceEditorConfigAnalyzerTest.cs
@@ -1,0 +1,34 @@
+﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability;
+
+namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
+{
+	[TestClass]
+	public class EnforceEditorConfigAnalyzerTest : DiagnosticVerifier
+	{
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
+		{
+			return new EnforceEditorConfigAnalyzer();
+		}
+
+		private const string TestCode = @"
+class Foo 
+{
+}
+";
+
+		protected override (string name, string content)[] GetAdditionalTexts()
+		{
+			return new []{(name: ".editorconfig", content: string.Empty)};
+		}
+
+		[TestMethod]
+		public void HasEditorConfigShouldNotTriggerDiagnostics()
+		{
+			VerifySuccessfulCompilation(TestCode);
+		}
+	}
+}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/EnforceEditorConfigAnalyzerTest1.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/EnforceEditorConfigAnalyzerTest1.cs
@@ -1,0 +1,31 @@
+﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Philips.CodeAnalysis.Common;
+using Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability;
+
+namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
+{
+	[TestClass]
+	public class EnforceEditorConfigAnalyzerTest1 : DiagnosticVerifier
+	{
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
+		{
+			return new EnforceEditorConfigAnalyzer();
+		}
+
+		private const string TestCode = @"
+class Foo 
+{
+}
+";
+
+		[TestMethod]
+		public void AbsenceOfEditorConfigShouldTriggerDiagnostics()
+		{
+			var diagnostic = DiagnosticResultHelper.Create(DiagnosticIds.EnforceEditorConfig);
+			VerifyDiagnostic(TestCode, diagnostic);
+		}
+	}
+}

--- a/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/AvoidAssemblyVersionChangeAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/AvoidAssemblyVersionChangeAnalyzerTest.cs
@@ -1,0 +1,42 @@
+﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.Test.Maintainability.RuntimeFailure
+{
+	[TestClass]
+	public class AvoidAssemblyVersionChangeAnalyzerTest : DiagnosticVerifier
+	{
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
+		{
+			return new TestableAvoidAssemblyVersionChangeAnalyzer(CorrectReturnedVersion);
+		}
+
+		private const string TestCode = @"
+class Foo 
+{
+}
+";
+
+		private const string ConfiguredVersion = "1.2.3.4";
+		private const string CorrectReturnedVersion = ConfiguredVersion;
+
+		protected override Dictionary<string, string> GetAdditionalAnalyzerConfigOptions()
+		{
+			Dictionary<string, string> options = new()
+			{
+				{ $@"dotnet_code_quality.{ Helper.ToDiagnosticId(DiagnosticIds.AvoidAssemblyVersionChange) }.assembly_version", ConfiguredVersion }
+			};
+			return options;
+		}
+
+		[TestMethod]
+		public void HasExpectedVersionShouldNotTriggerDiagnostics()
+		{
+			VerifySuccessfulCompilation(TestCode);
+		}
+	}
+}

--- a/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/AvoidAssemblyVersionChangeAnalyzerTest1.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/AvoidAssemblyVersionChangeAnalyzerTest1.cs
@@ -1,0 +1,43 @@
+﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.Test.Maintainability.RuntimeFailure
+{
+	[TestClass]
+	public class AvoidAssemblyVersionChangeAnalyzerTest1 : DiagnosticVerifier
+	{
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
+		{
+			return new TestableAvoidAssemblyVersionChangeAnalyzer(WrongReturnedVersion);
+		}
+
+		private const string TestCode = @"
+class Foo 
+{
+}
+";
+
+		private const string ConfiguredVersion = "1.2.3.4";
+		private const string WrongReturnedVersion = "2.0.0.0";
+
+		protected override Dictionary<string, string> GetAdditionalAnalyzerConfigOptions()
+		{
+			Dictionary<string, string> options = new()
+			{
+				{ $@"dotnet_code_quality.{ Helper.ToDiagnosticId(DiagnosticIds.AvoidAssemblyVersionChange) }.assembly_version", ConfiguredVersion }
+			};
+			return options;
+		}
+
+		[TestMethod]
+		public void HasWrongVersionTriggersDiagnostics()
+		{
+			var diagnostics = DiagnosticResultHelper.Create(DiagnosticIds.AvoidAssemblyVersionChange);
+			VerifyDiagnostic(TestCode, diagnostics);
+		}
+	}
+}

--- a/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/AvoidAssemblyVersionChangeAnalyzerTest2.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/AvoidAssemblyVersionChangeAnalyzerTest2.cs
@@ -1,0 +1,30 @@
+﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Philips.CodeAnalysis.Test.Maintainability.RuntimeFailure
+{
+	[TestClass]
+	public class AvoidAssemblyVersionChangeAnalyzerTest2 : DiagnosticVerifier
+	{
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
+		{
+			return new TestableAvoidAssemblyVersionChangeAnalyzer(CorrectReturnedVersion);
+		}
+
+		private const string TestCode = @"
+class Foo 
+{
+}
+";
+
+		private const string CorrectReturnedVersion = "1.0.0.0";
+
+		[TestMethod]
+		public void DefaultVersionIs1000()
+		{
+			VerifySuccessfulCompilation(TestCode);
+		}
+	}
+}

--- a/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/AvoidAssemblyVersionChangeAnalyzerTest3.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/AvoidAssemblyVersionChangeAnalyzerTest3.cs
@@ -1,0 +1,43 @@
+﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.Test.Maintainability.RuntimeFailure
+{
+	[TestClass]
+	public class AvoidAssemblyVersionChangeAnalyzerTest3 : DiagnosticVerifier
+	{
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
+		{
+			return new TestableAvoidAssemblyVersionChangeAnalyzer(AnyVersion);
+		}
+
+		private const string TestCode = @"
+class Foo 
+{
+}
+";
+
+		private const string AnyVersion = "5.6.3.4";
+		private const string InvalidVersion = "1";
+
+		protected override Dictionary<string, string> GetAdditionalAnalyzerConfigOptions()
+		{
+			Dictionary<string, string> options = new()
+			{
+				{ $@"dotnet_code_quality.{ Helper.ToDiagnosticId(DiagnosticIds.AvoidAssemblyVersionChange) }.assembly_version", InvalidVersion }
+			};
+			return options;
+		}
+		
+		[TestMethod]
+		public void InvalidVersionShouldTriggerTriggerDiagnostics()
+		{
+			var diagnostic = DiagnosticResultHelper.Create(DiagnosticIds.AvoidAssemblyVersionChange);
+			VerifyDiagnostic(TestCode, diagnostic);
+		}
+	}
+}

--- a/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/TestableAssemblyVersionChangeAnalyzer.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/TestableAssemblyVersionChangeAnalyzer.cs
@@ -1,0 +1,23 @@
+﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis;
+using Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure;
+
+namespace Philips.CodeAnalysis.Test.Maintainability.RuntimeFailure
+{
+	internal sealed class TestableAvoidAssemblyVersionChangeAnalyzer : AvoidAssemblyVersionChangeAnalyzer
+	{
+		private readonly Version _version;
+
+		public TestableAvoidAssemblyVersionChangeAnalyzer(string version)
+		{
+			_version = Version.Parse(version);
+		}
+
+		protected override Version GetCompilationAssemblyVersion(Compilation compilation)
+		{
+			return _version;
+		}
+	}
+}


### PR DESCRIPTION
I have added test classes for `AvoidAssemblyVersionChangeAnalyzer` and `EnforceEditorConfigAnalyzer`. This will increase our code coverage a bit more.