### PR TITLE
feat: Return immutable collections

### DIFF
--- a/Philips.CodeAnalysis.Common/DiagnosticIds.cs
+++ b/Philips.CodeAnalysis.Common/DiagnosticIds.cs
@@ -120,5 +120,6 @@ namespace Philips.CodeAnalysis.Common
 		AlignNumberOfPlusAndEqualOperators = 2125,
 		AvoidUsingParametersAsTempVariables = 2126,
 		AvoidChangingLoopVariables = 2127,
+		ReturnImmutableCollections = 2129,
 	}
 }

--- a/Philips.CodeAnalysis.Common/Helper.cs
+++ b/Philips.CodeAnalysis.Common/Helper.cs
@@ -357,5 +357,9 @@ namespace Philips.CodeAnalysis.Common
 			return list;
 		}
 
+		public static bool IsCallableFromOutsideClass(MemberDeclarationSyntax method)
+		{
+			return method.Modifiers.Any(SyntaxKind.PublicKeyword) || method.Modifiers.Any(SyntaxKind.InternalKeyword) || method.Modifiers.Any(SyntaxKind.ProtectedKeyword);
+		}
 	}
 }

--- a/Philips.CodeAnalysis.Common/Helper.cs
+++ b/Philips.CodeAnalysis.Common/Helper.cs
@@ -322,7 +322,7 @@ namespace Philips.CodeAnalysis.Common
 			return false;
 		}
 
-		public static string GetFullName(TypeSyntax typeSyntax, Dictionary<string, string> aliases)
+		public static string GetFullName(this TypeSyntax typeSyntax, Dictionary<string, string> aliases)
 		{
 			string name = string.Empty;
 			if(typeSyntax is SimpleNameSyntax simpleNameSyntax)

--- a/Philips.CodeAnalysis.Common/NamespaceIgnoringComparer.cs
+++ b/Philips.CodeAnalysis.Common/NamespaceIgnoringComparer.cs
@@ -3,16 +3,18 @@
 using System;
 using System.Collections.Generic;
 
-namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
+namespace Philips.CodeAnalysis.Common
 {
 	public sealed class NamespaceIgnoringComparer : IEqualityComparer<string>
 	{
 		public int Compare(string x, string y)
 		{
-			int dotX = Math.Max(x.LastIndexOf(".", StringComparison.Ordinal) + 1, 0);
-			string comparableX = x.Substring(dotX);
-			int dotY = Math.Max(y.LastIndexOf(".", StringComparison.Ordinal) + 1, 0);
-			string comparableY = y.Substring( dotY);
+			var dotX = Math.Max(x.LastIndexOf(".", StringComparison.Ordinal) + 1, 0);
+			var comparableX = x.Substring(dotX);
+			
+			var dotY = Math.Max(y.LastIndexOf(".", StringComparison.Ordinal) + 1, 0);
+			var comparableY = y.Substring( dotY);
+			
 			return StringComparer.Ordinal.Compare(comparableX, comparableY);
 		}
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/ReturnImmutableCollectionsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/ReturnImmutableCollectionsAnalyzer.cs
@@ -1,0 +1,71 @@
+﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class ReturnImmutableCollectionsAnalyzer : DiagnosticAnalyzer
+	{
+		private const string Title = @"Return only immutable collections";
+		private const string MessageFormat = @"Don't return the mutable collection {0}, use a ReadOnly interface or immutable collection instead";
+		private const string Description = @"Return only immutable or readonly collections from a public method, otherwise these collections can be changed by the caller without the callee noticing.";
+		private const string Category = Categories.Maintainability;
+
+		private static readonly DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.ReturnImmutableCollections),
+			Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true,
+			description: Description);
+
+		private static readonly IReadOnlyList<string> MutableCollections = new List<string>() { "List", "Collection", "Dictionary", "IList", "ICollection", "IDictionary" };
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		public override void Initialize(AnalysisContext context)
+		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.ReportDiagnostics);
+			context.EnableConcurrentExecution();
+			context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.MethodDeclaration);
+		}
+		
+		private static void Analyze(SyntaxNodeAnalysisContext context)
+		{
+			var method = (MethodDeclarationSyntax)context.Node;
+
+			if (!IsCallableFromOutsideClass(method))
+			{
+				// Private methods are allowed to return mutable collections.
+				return;
+			}
+
+			var aliases = Helper.GetUsingAliases(method);
+			var returnTypeName = Helper.GetFullName(method.ReturnType, aliases);
+			if (method.ReturnType is GenericNameSyntax genericName)
+			{
+				var baseName = genericName.Identifier.Text;
+				if (!aliases.TryGetValue(baseName, out returnTypeName))
+				{
+					returnTypeName = baseName;
+				}
+			}
+
+			NamespaceIgnoringComparer comparer = new();
+			if (MutableCollections.Any(m => comparer.Compare(m, returnTypeName) == 0))
+			{
+				var loc = method.ReturnType.GetLocation();
+				context.ReportDiagnostic(Diagnostic.Create(Rule, loc, returnTypeName));
+			}
+		}
+
+		private static bool IsCallableFromOutsideClass(MethodDeclarationSyntax method)
+		{
+			return method.Modifiers.Any(SyntaxKind.PublicKeyword) || method.Modifiers.Any(SyntaxKind.InternalKeyword) || method.Modifiers.Any(SyntaxKind.ProtectedKeyword);
+		}
+	}
+}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/ReturnImmutableCollectionsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/ReturnImmutableCollectionsAnalyzer.cs
@@ -54,9 +54,9 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 					returnTypeName = baseName;
 				}
 			}
-
+			
 			NamespaceIgnoringComparer comparer = new();
-			if (MutableCollections.Any(m => comparer.Compare(m, returnTypeName) == 0))
+			if (method.ReturnType is ArrayTypeSyntax || MutableCollections.Any(m => comparer.Compare(m, returnTypeName) == 0))
 			{
 				var loc = method.ReturnType.GetLocation();
 				context.ReportDiagnostic(Diagnostic.Create(Rule, loc, returnTypeName));

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/ReturnImmutableCollectionsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/ReturnImmutableCollectionsAnalyzer.cs
@@ -50,7 +50,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 		private static void AssertType(SyntaxNodeAnalysisContext context, TypeSyntax type, MemberDeclarationSyntax parent)
 		{
-			if(!IsCallableFromOutsideClass(parent))
+			if(!Helper.IsCallableFromOutsideClass(parent))
 			{
 				// Private members are allowed to return mutable collections.
 				return;
@@ -73,16 +73,11 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			}
 		}
 
-		private static bool IsCallableFromOutsideClass(MemberDeclarationSyntax method)
-		{
-			return method.Modifiers.Any(SyntaxKind.PublicKeyword) || method.Modifiers.Any(SyntaxKind.InternalKeyword) || method.Modifiers.Any(SyntaxKind.ProtectedKeyword);
-		}
-
 		private static string GetTypeName(TypeSyntax type)
 		{
 			var aliases = Helper.GetUsingAliases(type);
 			var typeName = Helper.GetFullName(type, aliases);
-			if(type is GenericNameSyntax genericName)
+			if (type is GenericNameSyntax genericName)
 			{
 				var baseName = genericName.Identifier.Text;
 				if(!aliases.TryGetValue(baseName, out typeName))

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -107,6 +107,7 @@
       * Introduce PH2125: Align number of + and == operators.
       * Introduce PH2126: Avoid using Parameters as temporary variables.
       * Introduce PH2127: Avoid changing loop variables.
+      * Introduce PH2128: Return immutable collections.
     </PackageReleaseNotes>
 	  <Copyright>© 2019-2023 Koninklijke Philips N.V.</Copyright>
 	  <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -78,3 +78,4 @@
 | PH2125  | Align number of + and == operators           | Overload the equality operator (==), when you overload the addition (+) operator. |
 | PH2126  | Avoid using Parameters as temporary variables| Don't use parameters as temporary variables, define a local variable instead. |
 | PH2127  | Avoid changing loop variables                | Don't change loop variables, this gives unexpected loop iterations. Use continue and break instead.|
+| PH2129  | Return immutable collections                 | Return only immutable or readonly collections from a public method, otherwise these collections can be changed by the caller without the callee noticing.|

--- a/Philips.CodeAnalysis.Test/Common/HelperTest.cs
+++ b/Philips.CodeAnalysis.Test/Common/HelperTest.cs
@@ -2,6 +2,7 @@
 
 using System;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Philips.CodeAnalysis.Common;
@@ -28,6 +29,44 @@ namespace Philips.CodeAnalysis.Test.Common
 			Assert.AreEqual("PH1000", Helper.ToPrettyList(new Diagnostic[] { diagnostic1 }));
 			Assert.AreEqual("PH1000, PH2000", Helper.ToPrettyList(new Diagnostic[] { diagnostic1, diagnostic2 }));
 			Assert.AreEqual("PH1000, PH2000, PH3000", Helper.ToPrettyList(new Diagnostic[] { diagnostic1, diagnostic2, diagnostic3 }));
+		}
+
+		[DataTestMethod]
+		[DataRow("private static readonly", false),
+		 DataRow("private static", false),
+		 DataRow("private const", false),
+		 DataRow("private", false),
+		 DataRow("public static readonly", true),
+		 DataRow("public const", true),
+		 DataRow("public static", true),
+		 DataRow("public readonly", true),
+		 DataRow("public", true),
+		 DataRow("internal static readonly", true),
+		 DataRow("internal static", true),
+		 DataRow("internal const", true),
+		 DataRow("internal readonly", true),
+		 DataRow("internal", true),
+		 DataRow("protected static readonly", true),
+		 DataRow("protected static", true),
+		 DataRow("protected const", true),
+		 DataRow("protected readonly", true),
+		 DataRow("protected", true),
+		 DataRow("protected internal static readonly", true),
+		 DataRow("protected internal static", true),
+		 DataRow("protected internal const", true),
+		 DataRow("protected internal readonly", true),
+		 DataRow("protected internal", true)]
+		public void IsCallableFromOutsideClassTest(string modifiers, bool expected)
+		{
+			// Arrange
+			var testCode = $"{modifiers} int I;";
+			var memberDeclaration = SyntaxFactory.ParseMemberDeclaration(testCode);
+
+			// Act
+			var actual = Helper.IsCallableFromOutsideClass(memberDeclaration);
+
+			// Assert
+			Assert.AreEqual(expected, actual);
 		}
 	}
 }

--- a/Philips.CodeAnalysis.Test/Common/NamespaceIgnoringComparerTest.cs
+++ b/Philips.CodeAnalysis.Test/Common/NamespaceIgnoringComparerTest.cs
@@ -2,9 +2,9 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation;
+using Philips.CodeAnalysis.Common;
 
-namespace Philips.CodeAnalysis.Test.Maintainability.Documentation
+namespace Philips.CodeAnalysis.Test.Common
 {
 	[TestClass]
 	public class NamespaceIgnoringComparerTest

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ReturnImmutableCollectionsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ReturnImmutableCollectionsAnalyzerTest.cs
@@ -102,11 +102,31 @@ namespace ReturnImmutableTests {
     }
 }";
 
-		private const string WrongCollection = @"
+		private const string WrongQueue = @"
 using System.Collections.Generic;
 namespace ReturnImmutableTests {
     public class Number {
-        public Collection<int> MethodA() {
+        public Queue<int> MethodA() {
+            return null;
+        }
+    }
+}";
+
+		private const string WrongSortedList = @"
+using System.Collections.Generic;
+namespace ReturnImmutableTests {
+    public class Number {
+        public SortedList<string, int> MethodA() {
+            return null;
+        }
+    }
+}";
+
+		private const string WrongStack = @"
+using System.Collections.Generic;
+namespace ReturnImmutableTests {
+    public class Number {
+        public Stack<string> MethodA() {
             return null;
         }
     }
@@ -126,7 +146,7 @@ namespace ReturnImmutableTests {
 using System.Collections.Generic;
 namespace ReturnImmutableTests {
     public class Number {
-        public Dictionary<string,int> MethodA() {
+        public Dictionary<string, int> MethodA() {
             return null;
         }
     }
@@ -136,7 +156,7 @@ namespace ReturnImmutableTests {
 using System.Collections.Generic;
 namespace ReturnImmutableTests {
     public class Number {
-        public IDictionary<string,int> MethodA() {
+        public IDictionary<string, int> MethodA() {
             return null;
         }
     }
@@ -183,7 +203,9 @@ namespace ReturnImmutableTests {
 		[TestMethod]
 		[DataRow(WrongList, DisplayName = nameof(WrongList)),
 		 DataRow(WrongIList, DisplayName = nameof(WrongIList)),
-		 DataRow(WrongCollection, DisplayName = nameof(WrongCollection)),
+		 DataRow(WrongQueue, DisplayName = nameof(WrongQueue)),
+		 DataRow(WrongSortedList, DisplayName = nameof(WrongSortedList)),
+		 DataRow(WrongStack, DisplayName = nameof(WrongStack)),
 		 DataRow(WrongICollection, DisplayName = nameof(WrongICollection)),
 		 DataRow(WrongDictionary, DisplayName = nameof(WrongDictionary)),
 		 DataRow(WrongIDictionary, DisplayName = nameof(WrongIDictionary)),

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ReturnImmutableCollectionsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ReturnImmutableCollectionsAnalyzerTest.cs
@@ -74,6 +74,14 @@ namespace ReturnImmutableTests {
     }
 }";
 
+		private const string CorrectProperty = @"
+using System.Collections.Generic;
+namespace ReturnImmutableTests {
+    public class Number {
+        private ImmutableArray<int> PropertyA() { get; }
+    }
+}";
+
 		private const string WrongList = @"
 using System.Collections.Generic;
 namespace ReturnImmutableTests {
@@ -144,6 +152,14 @@ namespace ReturnImmutableTests {
     }
 }";
 
+		private const string WrongProperty = @"
+using System.Collections.Generic;
+namespace ReturnImmutableTests {
+    public class Number {
+        public int[] PropertyA() { get; }
+    }
+}";
+
 		/// <summary>
 		/// No diagnostics expected to show up
 		/// </summary>
@@ -154,7 +170,8 @@ namespace ReturnImmutableTests {
 		 DataRow(CorrectReadOnlyDictionary, DisplayName = nameof(CorrectReadOnlyDictionary)),
 		 DataRow(CorrectEnumerable, DisplayName = nameof(CorrectEnumerable)),
 		 DataRow(CorrectImmutableArray, DisplayName = nameof(CorrectImmutableArray)),
-		 DataRow(CorrectPrivate, DisplayName = nameof(CorrectPrivate))]
+		 DataRow(CorrectPrivate, DisplayName = nameof(CorrectPrivate)),
+		 DataRow(CorrectProperty, DisplayName = nameof(CorrectProperty))]
 		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
 		{
 			VerifySuccessfulCompilation(testCode);
@@ -170,7 +187,8 @@ namespace ReturnImmutableTests {
 		 DataRow(WrongICollection, DisplayName = nameof(WrongICollection)),
 		 DataRow(WrongDictionary, DisplayName = nameof(WrongDictionary)),
 		 DataRow(WrongIDictionary, DisplayName = nameof(WrongIDictionary)),
-		 DataRow(WrongArray, DisplayName = nameof(WrongArray))]
+		 DataRow(WrongArray, DisplayName = nameof(WrongArray)),
+		 DataRow(WrongProperty, DisplayName = nameof(WrongProperty))]
 		public void WhenMismatchOfPlusMinusDiagnosticIsRaised(string testCode) {
 			var expected = DiagnosticResultHelper.Create(DiagnosticIds.ReturnImmutableCollections);
 			VerifyDiagnostic(testCode, expected);

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ReturnImmutableCollectionsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ReturnImmutableCollectionsAnalyzerTest.cs
@@ -78,7 +78,7 @@ namespace ReturnImmutableTests {
 using System.Collections.Generic;
 namespace ReturnImmutableTests {
     public class Number {
-        private ImmutableArray<int> PropertyA() { get; }
+        private ImmutableArray<int> PropertyA { get; }
     }
 }";
 
@@ -156,7 +156,7 @@ namespace ReturnImmutableTests {
 using System.Collections.Generic;
 namespace ReturnImmutableTests {
     public class Number {
-        public int[] PropertyA() { get; }
+        public int[] PropertyA { get; }
     }
 }";
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ReturnImmutableCollectionsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ReturnImmutableCollectionsAnalyzerTest.cs
@@ -1,0 +1,183 @@
+﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Philips.CodeAnalysis.Common;
+using Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability;
+
+namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
+{
+	/// <summary>
+	/// Test class for <see cref="ReturnImmutableCollectionsAnalyzer"/>.
+	/// </summary>
+	[TestClass]
+	public class ReturnImmutableCollectionsAnalyzerTest : DiagnosticVerifier
+	{
+		private const string CorrectReadOnlyList = @"
+using System.Collections.Generic;
+namespace ReturnImmutableTests {
+    public class Number {
+        public IReadOnlyList<int> MethodA() {
+            return null;
+        }
+    }
+}";
+
+		private const string CorrectReadOnlyCollection = @"
+using System.Collections.Generic;
+namespace ReturnImmutableTests {
+    public class Number {
+        public IReadOnlyCollection<int> MethodA() {
+            return null;
+        }
+    }
+}";
+
+		private const string CorrectReadOnlyDictionary = @"
+using System.Collections.Generic;
+namespace ReturnImmutableTests {
+    public class Number {
+        public IReadOnlyDictionary<string,int> MethodA() {
+            return null;
+        }
+    }
+}";
+
+		private const string CorrectEnumerable = @"
+using System.Collections.Generic;
+namespace ReturnImmutableTests {
+    public class Number {
+        public IEnumerable<int> MethodA() {
+            return null;
+        }
+    }
+}";
+
+		private const string CorrectImmutableArray = @"
+using System.Collections.Generic;
+namespace ReturnImmutableTests {
+    public class Number {
+        public ImmutableArray<int> MethodA() {
+            return ImmutableArray<int>.Empty;
+        }
+    }
+}";
+
+		private const string CorrectPrivate = @"
+using System.Collections.Generic;
+namespace ReturnImmutableTests {
+    public class Number {
+        private ImmutableArray<int> MethodA() {
+            return ImmutableArray<int>.Empty;
+        }
+    }
+}";
+
+		private const string WrongList = @"
+using System.Collections.Generic;
+namespace ReturnImmutableTests {
+    public class Number {
+        public List<int> MethodA() {
+            return null;
+        }
+    }
+}";
+
+		private const string WrongIList = @"
+using System.Collections.Generic;
+namespace ReturnImmutableTests {
+    public class Number {
+        public IList<int> MethodA() {
+            return null;
+        }
+    }
+}";
+
+		private const string WrongCollection = @"
+using System.Collections.Generic;
+namespace ReturnImmutableTests {
+    public class Number {
+        public Collection<int> MethodA() {
+            return null;
+        }
+    }
+}";
+
+		private const string WrongICollection = @"
+using System.Collections.Generic;
+namespace ReturnImmutableTests {
+    public class Number {
+        public ICollection<int> MethodA() {
+            return null;
+        }
+    }
+}";
+
+		private const string WrongDictionary = @"
+using System.Collections.Generic;
+namespace ReturnImmutableTests {
+    public class Number {
+        public Dictionary<string,int> MethodA() {
+            return null;
+        }
+    }
+}";
+
+		private const string WrongIDictionary = @"
+using System.Collections.Generic;
+namespace ReturnImmutableTests {
+    public class Number {
+        public IDictionary<string,int> MethodA() {
+            return null;
+        }
+    }
+}";
+
+		/// <summary>
+		/// No diagnostics expected to show up
+		/// </summary>
+		[TestMethod]
+		[DataRow("", DisplayName = "Empty"),
+		 DataRow(CorrectReadOnlyList, DisplayName = nameof(CorrectReadOnlyList)),
+		 DataRow(CorrectReadOnlyCollection, DisplayName = nameof(CorrectReadOnlyCollection)),
+		 DataRow(CorrectReadOnlyDictionary, DisplayName = nameof(CorrectReadOnlyDictionary)),
+		 DataRow(CorrectEnumerable, DisplayName = nameof(CorrectEnumerable)),
+		 DataRow(CorrectImmutableArray, DisplayName = nameof(CorrectImmutableArray)),
+		 DataRow(CorrectPrivate, DisplayName = nameof(CorrectPrivate))]
+		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
+		{
+			VerifySuccessfulCompilation(testCode);
+		}
+
+		/// <summary>
+		/// Diagnostics expected to show up
+		/// </summary>
+		[TestMethod]
+		[DataRow(WrongList, DisplayName = nameof(WrongList)),
+		 DataRow(WrongIList, DisplayName = nameof(WrongIList)),
+		 DataRow(WrongCollection, DisplayName = nameof(WrongCollection)),
+		 DataRow(WrongICollection, DisplayName = nameof(WrongICollection)),
+		 DataRow(WrongDictionary, DisplayName = nameof(WrongDictionary)),
+		 DataRow(WrongIDictionary, DisplayName = nameof(WrongIDictionary)),
+		]
+		public void WhenMismatchOfPlusMinusDiagnosticIsRaised(string testCode) {
+			var expected = DiagnosticResultHelper.Create(DiagnosticIds.ReturnImmutableCollections);
+			VerifyDiagnostic(testCode, expected);
+		}
+
+		/// <summary>
+		/// No diagnostics expected to show up 
+		/// </summary>
+		[TestMethod]
+		[DataRow("File.g", DisplayName = "OutOfScopeSourceFile")]
+		public void WhenSourceFileIsOutOfScopeNoDiagnosticIsTriggered(string filePath)
+		{
+			VerifyDiagnostic(WrongList, filePath);
+		}
+
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer() {
+			return new ReturnImmutableCollectionsAnalyzer();
+		}
+	}
+}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ReturnImmutableCollectionsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ReturnImmutableCollectionsAnalyzerTest.cs
@@ -134,6 +134,16 @@ namespace ReturnImmutableTests {
     }
 }";
 
+		private const string WrongArray = @"
+using System.Collections.Generic;
+namespace ReturnImmutableTests {
+    public class Number {
+        public int[] MethodA() {
+            return null;
+        }
+    }
+}";
+
 		/// <summary>
 		/// No diagnostics expected to show up
 		/// </summary>
@@ -160,7 +170,7 @@ namespace ReturnImmutableTests {
 		 DataRow(WrongICollection, DisplayName = nameof(WrongICollection)),
 		 DataRow(WrongDictionary, DisplayName = nameof(WrongDictionary)),
 		 DataRow(WrongIDictionary, DisplayName = nameof(WrongIDictionary)),
-		]
+		 DataRow(WrongArray, DisplayName = nameof(WrongArray))]
 		public void WhenMismatchOfPlusMinusDiagnosticIsRaised(string testCode) {
 			var expected = DiagnosticResultHelper.Create(DiagnosticIds.ReturnImmutableCollections);
 			VerifyDiagnostic(testCode, expected);


### PR DESCRIPTION
The checks rule [5@119](https://csviewer.tiobe.com/#/ruleset/rule?setid=4T_Jr6-VSX6fp6egDIhGow&status=CHECKED,UNCHECKED&tagid=6u27MkXORKaev0VNuWR_SA&ruleid=R8DUGJzYSfWdIWt3nDk7JQ) of the Philips C# Coding Standard.