### PR TITLE
chore: Remove VerifyDiagnostic overload with empty array

### DIFF
--- a/Philips.CodeAnalysis.Test/Helpers/DiagnosticResult.cs
+++ b/Philips.CodeAnalysis.Test/Helpers/DiagnosticResult.cs
@@ -116,10 +116,18 @@ namespace Philips.CodeAnalysis.Test
 
 		public static DiagnosticResult[] CreateArray(DiagnosticIds diagnosticId, Regex message = null)
 		{
-			return new DiagnosticResult[]
+			return new []
 			{
 				Create(diagnosticId, message),
 			};
+		}
+
+		public static DiagnosticResult[] Append(this DiagnosticResult[] array, DiagnosticIds diagnosticId, Regex message = null)
+		{
+			DiagnosticResult[] larger = new DiagnosticResult[array.Length + 1];
+			array.AsSpan().CopyTo(larger);
+			larger[array.Length] = Create(diagnosticId, message);
+			return larger;
 		}
 	}
 }

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/DocumentUnhandledExceptionsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/DocumentUnhandledExceptionsAnalyzerTest.cs
@@ -146,7 +146,7 @@ public class Foo
 		 DataRow(CorrectEnumerateDirectories, DisplayName = nameof(CorrectEnumerateDirectories))]
 		public void CorrectCodeShouldNotTriggerAnyDiagnostics(string testCode)
 		{
-			VerifyDiagnostic(testCode);
+			VerifySuccessfulCompilation(testCode);
 		}
 
 		[DataTestMethod]

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidOverrideWithNewKeywordAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidOverrideWithNewKeywordAnalyzerTest.cs
@@ -82,7 +82,7 @@ namespace MultiLineConditionUnitTests
 		public void OverrideVirtualDoesNotTriggersDiagnostics(string input)
 		{
 
-			VerifyDiagnostic(input);
+			VerifySuccessfulCompilation(input);
 		}
 
 		[DataTestMethod]

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoNestedStringFormatsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoNestedStringFormatsAnalyzerTest.cs
@@ -490,7 +490,7 @@ class Foo
 	}}
 }}
 ";
-			VerifyDiagnostic(string.Format(template, format));
+			VerifySuccessfulCompilation(string.Format(template, format));
 		}
 
 		[TestMethod]

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/PreventUseOfGotoAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/PreventUseOfGotoAnalyzerTest.cs
@@ -49,7 +49,7 @@ class Foo
 }
 ";
 
-			VerifyDiagnostic(template, DiagnosticResultHelper.Create(DiagnosticIds.GotoNotAllowed), DiagnosticResultHelper.Create(DiagnosticIds.GotoNotAllowed));
+			VerifyDiagnostic(template, DiagnosticResultHelper.CreateArray(DiagnosticIds.GotoNotAllowed).Append(DiagnosticIds.GotoNotAllowed));
 		}
 
 		[TestMethod]

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidMultipleLambdasOnSingleLineAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidMultipleLambdasOnSingleLineAnalyzerTest.cs
@@ -165,7 +165,7 @@ public static class Foo
 		 DataRow(CorrectParenthesized, DisplayName = nameof(CorrectParenthesized))]
 		public void CorrectDoesNotFlag(string input)
 		{
-			VerifyDiagnostic(input);
+			VerifySuccessfulCompilation(input);
 		}
 
 		[TestMethod]

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/PreferNamedTuplesAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/PreferNamedTuplesAnalyzerTest.cs
@@ -56,7 +56,7 @@ class Foo
 		public void ErrorIfTupleElementsDoNotHaveNames(string argument)
 		{
 			var source = CreateFunction(argument);
-			VerifyDiagnostic(source, DiagnosticResultHelper.Create(DiagnosticIds.PreferTuplesWithNamedFields), DiagnosticResultHelper.Create(DiagnosticIds.PreferTuplesWithNamedFields));
+			VerifyDiagnostic(source, DiagnosticResultHelper.CreateArray(DiagnosticIds.PreferTuplesWithNamedFields).Append(DiagnosticIds.PreferTuplesWithNamedFields));
 		}
 
 		[DataRow("(int Foo, int)")]

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/PreventUnnecessaryRangeChecksAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/PreventUnnecessaryRangeChecksAnalyzerTest.cs
@@ -397,7 +397,7 @@ public void test()
 }}
 ";
 
-			VerifyDiagnostic(string.Format(template, declaration, countLengthMethod));
+			VerifySuccessfulCompilation(string.Format(template, declaration, countLengthMethod));
 		}
 
 		[DataRow("int[] data = new int[0]", "Length")]
@@ -457,7 +457,7 @@ public void test()
 }}
 ";
 
-			VerifyDiagnostic(string.Format(template, declaration, countLengthMethod));
+			VerifySuccessfulCompilation(string.Format(template, declaration, countLengthMethod));
 		}
 
 		#endregion

--- a/Philips.CodeAnalysis.Test/MsTest/AvoidAttributeAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AvoidAttributeAnalyzerTest.cs
@@ -228,7 +228,7 @@ class Foo
 ";
 			string givenText = string.Format(baseline, test);
 
-			VerifyDiagnostic(givenText);
+			VerifySuccessfulCompilation(givenText);
 		}
 
 		[DataTestMethod]
@@ -251,7 +251,7 @@ class Foo
 ";
 			string givenText = string.Format(baseline, test);
 
-			VerifyDiagnostic(givenText);
+			VerifySuccessfulCompilation(givenText);
 		}
 		
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodsMustBeInTestClassAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodsMustBeInTestClassAnalyzerTest.cs
@@ -64,7 +64,7 @@ public {2} class Tests : {3}
 	public void Foo() {{ }}
 }}";
 
-			VerifyDiagnostic(string.Format(code, "[TestClass]", testType, classQualifier, baseClass));
+			VerifySuccessfulCompilation(string.Format(code, "[TestClass]", testType, classQualifier, baseClass));
 
 			DiagnosticResult[] expectedResult = Array.Empty<DiagnosticResult>();
 

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodsMustHaveTheCorrectNumberOfArgumentsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodsMustHaveTheCorrectNumberOfArgumentsAnalyzerTest.cs
@@ -59,7 +59,7 @@ public class Tests
 
 			if (isCorrect)
 			{
-				VerifyDiagnostic(string.Format(code, testType, parameterListString));
+				VerifySuccessfulCompilation(string.Format(code, testType, parameterListString));
 			}
 			else
 			{
@@ -95,7 +95,7 @@ public class Tests
 			}
 
 
-			VerifyDiagnostic(string.Format(code, parameterListString));
+			VerifySuccessfulCompilation(string.Format(code, parameterListString));
 		}
 
 		private static IEnumerable<object[]> DataRowVariants()

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodsShouldHaveUniqueNamesAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodsShouldHaveUniqueNamesAnalyzerTest.cs
@@ -46,19 +46,21 @@ public class Tests
 	public void Foo(object o, object y) { }
 }";
 
-			VerifyDiagnostic(code, new DiagnosticResult()
-			{
-				Id = Helper.ToDiagnosticId(DiagnosticIds.TestMethodsMustHaveUniqueNames),
-				Locations = new[] { new DiagnosticResultLocation("Test0.cs", 11, null) },
-				Message = new Regex(".*"),
-				Severity = DiagnosticSeverity.Error,
-			},
-			new DiagnosticResult()
-			{
-				Id = Helper.ToDiagnosticId(DiagnosticIds.TestMethodsMustHaveUniqueNames),
-				Locations = new[] { new DiagnosticResultLocation("Test0.cs", 15, null) },
-				Message = new Regex(".*"),
-				Severity = DiagnosticSeverity.Error,
+			VerifyDiagnostic(code, new []{ 
+				new DiagnosticResult()
+				{
+					Id = Helper.ToDiagnosticId(DiagnosticIds.TestMethodsMustHaveUniqueNames),
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 11, null) },
+					Message = new Regex(".*"),
+					Severity = DiagnosticSeverity.Error,
+				},
+				new DiagnosticResult()
+				{
+					Id = Helper.ToDiagnosticId(DiagnosticIds.TestMethodsMustHaveUniqueNames),
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 15, null) },
+					Message = new Regex(".*"),
+					Severity = DiagnosticSeverity.Error,
+				}
 			});
 		}
 

--- a/Philips.CodeAnalysis.Test/Verifiers/AssertCodeFixVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/AssertCodeFixVerifier.cs
@@ -70,7 +70,7 @@ namespace Philips.CodeAnalysis.Test
 		{
 			var test = _helper.GetText(methodBody, OtherClassSyntax, string.Empty);
 
-			VerifyDiagnostic(test);
+			VerifySuccessfulCompilation(test);
 		}
 
 		protected override MetadataReference[] GetMetadataReferences()

--- a/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
@@ -1,7 +1,9 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices.JavaScript;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -42,14 +44,25 @@ namespace Philips.CodeAnalysis.Test
 		/// </summary>
 		/// <param name="source">A class in the form of a string to run the analyzer on</param>
 		/// <param name="expected"> DiagnosticResults that should appear after the analyzer is run on the source</param>
-		protected void VerifyDiagnostic(string source, params DiagnosticResult[] expected)
+		protected void VerifyDiagnostic(string source, DiagnosticResult expected)
+		{
+			VerifyDiagnostic(source, null, new[] { expected });
+		}
+
+		/// <summary>
+		/// Called to test a C# DiagnosticAnalyzer when applied on the single inputted string as a source
+		/// Note: input a DiagnosticResult for each Diagnostic expected
+		/// </summary>
+		/// <param name="source">A class in the form of a string to run the analyzer on</param>
+		/// <param name="expected"> DiagnosticResults that should appear after the analyzer is run on the source</param>
+		protected void VerifyDiagnostic(string source, DiagnosticResult[] expected)
 		{
 			VerifyDiagnostic(source, null, expected);
 		}
 
 		protected void VerifySuccessfulCompilation(string source)
 		{
-			VerifyDiagnostic(source);
+			VerifyDiagnostic(source, Array.Empty<DiagnosticResult>());
 		}
 
 		/// <summary>


### PR DESCRIPTION
In many cases the test code was still calling `VerifyDiagnostics` instead of `VerifySuccessfulCompilation`

The reason was that that `VerifyDiagnostics` still allowed in a public method to have an empty array of `DiagnosticsResult`.
I feel we should force this to not be possible. Hence, I removed that overload and offered a better API to create arrays in the `DiagnosticResultHelper`.
This all should clearly indicate the intend of the test code and improve readability of the tests.