### PR TITLE
fix: Avoid multiple lambdas on single line Analyzer is overformatting

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidMultipleLambdasOnSingleLineCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidMultipleLambdasOnSingleLineCodeFixProvider.cs
@@ -93,7 +93,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 			SyntaxTriviaList newTrivia = lastToken.TrailingTrivia.Add(SyntaxFactory.EndOfLine("\r\n"));
 
 			var newNode = node.WithTrailingTrivia(newTrivia);
-			root = root.ReplaceNode(node, newNode).WithAdditionalAnnotations(Formatter.Annotation);
+			root = root.ReplaceNode(node, newNode.WithAdditionalAnnotations(Formatter.Annotation));
 
 			return document.WithSyntaxRoot(root);
 		}

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidMultipleLambdasOnSingleLineAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidMultipleLambdasOnSingleLineAnalyzerTest.cs
@@ -139,7 +139,7 @@ public static class Foo
 {
   public static void Method(List<int> data)
   {
-    data.Where((i) => i == 0).Select((d) => { return d.ToString();});
+    data.Where((i) => i == 0).Select((d) => { return d.ToString(); });
   }
 }
 ";


### PR DESCRIPTION
Restricted the formatting to the new node.