### PR TITLE
feat: Finalizer allows dispose but no other calls

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -80,4 +80,4 @@
 | PH2127  | Avoid changing loop variables                | Don't change loop variables, this gives unexpected loop iterations. Use continue and break instead.|
 | PH2128  | Split multi-line condition on logical operator | In case that the condition of an "if" or "?" statement covers more then one line, its line endings should be right after the logical operators (&& and ||). This is aligns with the mental split when reading the code. |
 | PH2129  | Return immutable collections                 | Return only immutable or readonly collections from a public method, otherwise these collections can be changed by the caller without the callee noticing.|
-| PH2130  | Avoid implementing finalizers                | Don't implement a finalizer, use Dispose instead.|
+| PH2130  | Avoid implementing finalizers                | Avoid implement a finalizer, use Dispose instead. If the class has unmanaged fields, finalizers are allowed if they only call Dispose.|

--- a/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/AvoidImplementingFinalizersAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/AvoidImplementingFinalizersAnalyzerTest.cs
@@ -55,8 +55,8 @@ namespace FinalizerTest {
 		}
 
 		[DataTestMethod]
-		[DataRow(WrongNoDispose, nameof(WrongNoDispose)),
-		 DataRow(WrongReferenceCall, nameof(WrongReferenceCall))]
+		[DataRow(WrongNoDispose, DisplayName = nameof(WrongNoDispose)),
+		 DataRow(WrongReferenceCall, DisplayName = nameof(WrongReferenceCall))]
 		public void WhenFinalizerMissesDisposeNoDiagnosticIsTriggered(string testCode)
 		{
 			VerifyDiagnostic(testCode, DiagnosticResultHelper.Create(DiagnosticIds.AvoidImplementingFinalizers));

--- a/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/AvoidImplementingFinalizersAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/RuntimeFailure/AvoidImplementingFinalizersAnalyzerTest.cs
@@ -20,7 +20,7 @@ namespace FinalizerTest {
         ~Program() {
             Dispose(false);
         }
-        protected Dispose(bool isDisposing) {
+        protected void Dispose(bool isDisposing) {
         }
     }
 }";
@@ -43,7 +43,31 @@ namespace FinalizerTest {
             Foo.Mo();
             Dispose(false);
         }
-        protected Dispose(bool isDisposing) {
+        protected void Dispose(bool isDisposing) {
+        }
+    }
+}";
+
+		private const string WrongFieldAssignment = @"
+namespace FinalizerTest {
+    class Program {
+        int i;
+        ~Program() {
+            i = 0;
+            Dispose(false);
+        }
+        protected void Dispose(bool isDisposing) {
+        }
+    }
+}";
+
+		private const string WrongOtherMethod = @"
+namespace FinalizerTest {
+    class Program {
+        ~Program() {
+            Cleanup();
+        }
+        protected void Cleanmup() {
         }
     }
 }";
@@ -56,7 +80,9 @@ namespace FinalizerTest {
 
 		[DataTestMethod]
 		[DataRow(WrongNoDispose, DisplayName = nameof(WrongNoDispose)),
-		 DataRow(WrongReferenceCall, DisplayName = nameof(WrongReferenceCall))]
+		 DataRow(WrongReferenceCall, DisplayName = nameof(WrongReferenceCall)),
+		 DataRow(WrongFieldAssignment, DisplayName = nameof(WrongFieldAssignment)),
+		 DataRow(WrongOtherMethod, DisplayName = nameof(WrongOtherMethod))]
 		public void WhenFinalizerMissesDisposeNoDiagnosticIsTriggered(string testCode)
 		{
 			VerifyDiagnostic(testCode, DiagnosticResultHelper.Create(DiagnosticIds.AvoidImplementingFinalizers));


### PR DESCRIPTION
This is an extension of PH2130, where we allow calls to `Dispose` methods of the same class.
Any calls to other types are not allowed, as you cannot rely on them still being alive during finalization (as the order is not defined).

In effect, this makes it check also rule [5@114](https://csviewer.tiobe.com/#/ruleset/rule?setid=4T_Jr6-VSX6fp6egDIhGow&status=CHECKED,UNCHECKED&tagid=6u27MkXORKaev0VNuWR_SA&ruleid=yjJN_03cRgqVaitDMYIEMg) of the Philips C# Coding Standard