### PR TITLE
feat: Align filename and class name

### DIFF
--- a/Philips.CodeAnalysis.Common/DiagnosticIds.cs
+++ b/Philips.CodeAnalysis.Common/DiagnosticIds.cs
@@ -123,5 +123,6 @@ namespace Philips.CodeAnalysis.Common
 		SplitMultiLineConditionOnLogicalOperator = 2128,
 		ReturnImmutableCollections = 2129,
 		AvoidImplementingFinalizers = 2130,
+		AlignFilenameAndClassName = 2131,
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/AlignFilenameAndClassNameAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/AlignFilenameAndClassNameAnalyzer.cs
@@ -1,0 +1,91 @@
+﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class AlignFilenameAndClassNameAnalyzer : DiagnosticAnalyzer
+	{
+		private const string Title = @"Align filename and class name";
+		private const string MessageFormat = @"Name the file {0}.cs to align with the name of the {1} it contains.";
+		private const string Description = @"Name the file after the class, struct or enum it contains";
+		private const string Category = Categories.Naming;
+
+		private static readonly DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.AlignFilenameAndClassName),
+			Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true,
+			description: Description);
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		public override void Initialize(AnalysisContext context)
+		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.EnableConcurrentExecution();
+			context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.ClassDeclaration);
+			context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.StructDeclaration);
+			context.RegisterSyntaxNodeAction(AnalyzeEnum, SyntaxKind.EnumDeclaration);
+		}
+
+		private void Analyze(SyntaxNodeAnalysisContext context)
+		{
+			GeneratedCodeDetector generatedCodeDetector = new();
+			if (generatedCodeDetector.IsGeneratedCode(context))
+			{
+				return;
+			}
+
+			TypeDeclarationSyntax typeDeclaration = (TypeDeclarationSyntax)context.Node;
+			string typeKind = null;
+			if(typeDeclaration is ClassDeclarationSyntax)
+			{
+				typeKind = "class";
+			}
+			else if(typeDeclaration is StructDeclarationSyntax)
+			{
+				typeKind = "struct";
+			}
+
+			if (string.IsNullOrEmpty(typeKind))
+			{
+				return;
+			}
+			Check(context, typeDeclaration.Identifier, typeKind);
+		}
+
+		private void AnalyzeEnum(SyntaxNodeAnalysisContext context)
+		{
+			GeneratedCodeDetector generatedCodeDetector = new();
+			if(generatedCodeDetector.IsGeneratedCode(context))
+			{
+				return;
+			}
+
+			EnumDeclarationSyntax enumDeclaration = (EnumDeclarationSyntax)context.Node;
+			Check(context, enumDeclaration.Identifier, "enum");
+		}
+
+		private static void Check(SyntaxNodeAnalysisContext context, SyntaxToken identifier, string typeKind)
+		{
+			var filename = Path.GetFileNameWithoutExtension(context.Node.SyntaxTree.FilePath);
+			int indexOfDot = filename.LastIndexOf('.');
+			if (indexOfDot != -1)
+			{
+				filename = filename.Substring(0,indexOfDot);
+			}
+			if (StringComparer.OrdinalIgnoreCase.Compare(identifier.Text, filename) != 0)
+			{
+				var location = identifier.GetLocation();
+				Diagnostic diagnostic = Diagnostic.Create(Rule, location, identifier.Text, typeKind);
+				context.ReportDiagnostic(diagnostic);
+			}
+		}
+	}
+}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/AlignFilenameAndClassNameAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/AlignFilenameAndClassNameAnalyzer.cs
@@ -36,12 +36,6 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 
 		private void Analyze(SyntaxNodeAnalysisContext context)
 		{
-			GeneratedCodeDetector generatedCodeDetector = new();
-			if (generatedCodeDetector.IsGeneratedCode(context))
-			{
-				return;
-			}
-
 			TypeDeclarationSyntax typeDeclaration = (TypeDeclarationSyntax)context.Node;
 			string typeKind = null;
 			if(typeDeclaration is ClassDeclarationSyntax)
@@ -62,18 +56,18 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 
 		private void AnalyzeEnum(SyntaxNodeAnalysisContext context)
 		{
-			GeneratedCodeDetector generatedCodeDetector = new();
-			if(generatedCodeDetector.IsGeneratedCode(context))
-			{
-				return;
-			}
-
 			EnumDeclarationSyntax enumDeclaration = (EnumDeclarationSyntax)context.Node;
 			Check(context, enumDeclaration.Identifier, "enum");
 		}
 
 		private static void Check(SyntaxNodeAnalysisContext context, SyntaxToken identifier, string typeKind)
 		{
+			GeneratedCodeDetector generatedCodeDetector = new();
+			if(generatedCodeDetector.IsGeneratedCode(context))
+			{
+				return;
+			}
+
 			var filename = Path.GetFileNameWithoutExtension(context.Node.SyntaxTree.FilePath);
 			int indexOfDot = filename.LastIndexOf('.');
 			if (indexOfDot != -1)

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/AlignFilenameAndClassNameAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/AlignFilenameAndClassNameAnalyzer.cs
@@ -69,7 +69,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 			}
 
 			var filename = Path.GetFileNameWithoutExtension(context.Node.SyntaxTree.FilePath);
-			int indexOfDot = filename.LastIndexOf('.');
+			int indexOfDot = filename.IndexOf('.');
 			if (indexOfDot != -1)
 			{
 				filename = filename.Substring(0,indexOfDot);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -111,6 +111,7 @@
       * Introduce PH2129: Return immutable collections.
       * Increased the test coverage.
       * Introduce PH2130: Avoid implementing finalizers.
+      * Introduce PH2131: Align filename and class name.
     </PackageReleaseNotes>
 	  <Copyright>© 2019-2023 Koninklijke Philips N.V.</Copyright>
 	  <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -81,3 +81,4 @@
 | PH2128  | Split multi-line condition on logical operator | In case that the condition of an "if" or "?" statement covers more then one line, its line endings should be right after the logical operators (&& and ||). This is aligns with the mental split when reading the code. |
 | PH2129  | Return immutable collections                 | Return only immutable or readonly collections from a public method, otherwise these collections can be changed by the caller without the callee noticing.|
 | PH2130  | Avoid implementing finalizers                | Don't implement a finalizer, use Dispose instead.|
+| PH2131  | Align filename and class name                | Name the file after the class, struct or enum it contains. |

--- a/Philips.CodeAnalysis.Test/Maintainability/Naming/AlignFilenameAndClassNameAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Naming/AlignFilenameAndClassNameAnalyzerTest.cs
@@ -1,0 +1,54 @@
+﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Philips.CodeAnalysis.Common;
+using Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming;
+
+namespace Philips.CodeAnalysis.Test.Maintainability.Naming
+{
+	/// <summary>
+	/// Test class for <see cref="AlignFilenameAndClassNameAnalyzer"/>.
+	/// </summary>
+	[TestClass]
+	public class AlignFilenameAndClassNameAnalyzerTest : DiagnosticVerifier
+	{
+		private const string SourceCodeTemplate = @"
+namespace AlignFilenameAndClassName {{
+    {0} Program {{
+    }}
+}}";
+
+		/// <summary>
+		/// No diagnostics expected to show up
+		/// </summary>
+		[TestMethod]
+		[DataRow("class", "Program"),
+		 DataRow("class", "Program.Part"),
+		 DataRow("struct", "Program"),
+		 DataRow("enum", "Program")]
+		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string typeKind, string filePath)
+		{
+			VerifyDiagnostic(string.Format(SourceCodeTemplate, typeKind), filePath);
+		}
+
+		/// <summary>
+		/// Diagnostics should show up hare.
+		/// </summary>
+		[TestMethod]
+		[DataRow("class", "Program2"),
+		 DataRow("struct", "SomethingElse"),
+		 DataRow("enum", "Prog")]
+		public void WhenPathIsTooLongDiagnosticIsRaised(string typeKind, string filePath)
+		{
+			var expected = DiagnosticResultHelper.Create(DiagnosticIds.AlignFilenameAndClassName);
+			VerifyDiagnostic(string.Format(SourceCodeTemplate, typeKind), filePath, expected);
+		}
+
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
+		{
+			return new AlignFilenameAndClassNameAnalyzer();
+		}
+	}
+}

--- a/Philips.CodeAnalysis.Test/Maintainability/Naming/AlignFilenameAndClassNameAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Naming/AlignFilenameAndClassNameAnalyzerTest.cs
@@ -27,7 +27,7 @@ namespace AlignFilenameAndClassName {{
 		[DataRow("class", "Program"),
 		 DataRow("class", "Program.Part"),
 		 DataRow("struct", "Program"),
-		 DataRow("enum", "Program")]
+		 DataRow("enum", "Program.Part.Of.Many.Things")]
 		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string typeKind, string filePath)
 		{
 			VerifyDiagnostic(string.Format(SourceCodeTemplate, typeKind), filePath);
@@ -40,7 +40,7 @@ namespace AlignFilenameAndClassName {{
 		[DataRow("class", "Program2"),
 		 DataRow("struct", "SomethingElse"),
 		 DataRow("enum", "Prog")]
-		public void WhenPathIsTooLongDiagnosticIsRaised(string typeKind, string filePath)
+		public void WhenNamesDontAlignDiagnosticIsRaised(string typeKind, string filePath)
 		{
 			var expected = DiagnosticResultHelper.Create(DiagnosticIds.AlignFilenameAndClassName);
 			VerifyDiagnostic(string.Format(SourceCodeTemplate, typeKind), filePath, expected);


### PR DESCRIPTION
This new analyzer checks rule [3@504](https://csviewer.tiobe.com/#/ruleset/rule?setid=4T_Jr6-VSX6fp6egDIhGow&status=CHECKED,UNCHECKED&tagid=6u27MkXORKaev0VNuWR_SA&ruleid=n6-OtgaBSmWcGY7gu_iFGA) of the Philips C# Coding Standard