### PR TITLE
fix: remaining copyright issues

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
@@ -116,7 +116,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 		private bool CheckCopyrightStatement(SyntaxNodeAnalysisContext context, SyntaxTrivia trivia) {
 			var comment = trivia.ToFullString();
 			// Check the copyright mark itself
-			bool hasCopyright = comment.Contains('©') || comment.Contains("\\U00A9") || comment.Contains("Copyright");
+			bool hasCopyright = comment.Contains('©') || comment.Contains("\uFFFD") || comment.Contains("Copyright");
 			
 			// Check the year
 			bool hasYear = yearRegex.IsMatch(comment);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
@@ -19,7 +19,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 	{
 		private const string Title = @"Copyright Present";
 		private const string MessageFormat = 
-			@"File should start with a copyright statement, containing the company name, the year and either © or 'Copyright'. {0}";
+			@"File should start with a copyright statement, containing the company name, the year and either © or 'Copyright'.";
 		private const string Description =
 			@"File should start with a comment containing the company name, the year and either © or 'Copyright'.";
 		private const string Category = Categories.Documentation;

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
@@ -74,7 +74,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 			
 			if (!leadingTrivia.Any(SyntaxKind.SingleLineCommentTrivia) && !leadingTrivia.Any(SyntaxKind.RegionDirectiveTrivia))
 			{
-				CreateDiagnostic(context, location, "NoCommentInTrivia");
+				CreateDiagnostic(context, location);
 				return;
 			}
 
@@ -87,7 +87,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 			SyntaxTrivia syntaxTrivia = leadingTrivia.FirstOrDefault(t => t.IsKind(SyntaxKind.SingleLineCommentTrivia));
 			if (!CheckCopyrightStatement(context, syntaxTrivia))
 			{
-				CreateDiagnostic(context, location, syntaxTrivia.ToFullString());
+				CreateDiagnostic(context, location);
 			}
 		}
 
@@ -107,9 +107,9 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 			});
 		}
 
-		private void CreateDiagnostic(SyntaxNodeAnalysisContext context, Location location, string debug = "")
+		private void CreateDiagnostic(SyntaxNodeAnalysisContext context, Location location)
 		{
-			Diagnostic diagnostic = Diagnostic.Create(Rule, location, debug);
+			Diagnostic diagnostic = Diagnostic.Create(Rule, location);
 			context.ReportDiagnostic(diagnostic);
 		}
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
@@ -69,7 +69,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 			}
 
 			var location = GetSquiggleLocation(node.SyntaxTree);
-			var leadingTrivia = node.GetLeadingTrivia();
+			var docNode = FindFirstDocumentation(node);
+			var leadingTrivia = docNode.GetLeadingTrivia();
 
 			if (!leadingTrivia.Any(SyntaxKind.SingleLineCommentTrivia) && !leadingTrivia.Any(SyntaxKind.RegionDirectiveTrivia))
 			{
@@ -96,7 +97,11 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 			var location = Location.Create(tree, span);
 			return location;
 		}
-			
+
+		private static SyntaxNode FindFirstDocumentation(SyntaxNode root)
+		{
+			return root.DescendantNodesAndSelf().FirstOrDefault(n => n.HasLeadingTrivia);
+		}
 
 		private void CreateDiagnostic(SyntaxNodeAnalysisContext context, Location location)
 		{

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
@@ -111,6 +111,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 
 		private bool CheckCopyrightStatement(SyntaxNodeAnalysisContext context, SyntaxTrivia trivia) {
 			var comment = trivia.ToFullString();
+			Console.WriteLine($"Checking: {comment}");
 			// Check the copyright mark itself
 			bool hasCopyright = comment.Contains("©") || comment.Contains("Copyright");
 			

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
@@ -19,7 +19,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 	{
 		private const string Title = @"Copyright Present";
 		private const string MessageFormat = 
-			@"File should start with a copyright statement, containing the company name, the year and either © or 'Copyright'.";
+			@"File should start with a copyright statement, containing the company name, the year and either © or 'Copyright'. {0}";
 		private const string Description =
 			@"File should start with a comment containing the company name, the year and either © or 'Copyright'.";
 		private const string Category = Categories.Documentation;
@@ -87,7 +87,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 			SyntaxTrivia syntaxTrivia = leadingTrivia.FirstOrDefault(t => t.IsKind(SyntaxKind.SingleLineCommentTrivia));
 			if (!CheckCopyrightStatement(context, syntaxTrivia))
 			{
-				CreateDiagnostic(context, location);
+				CreateDiagnostic(context, location, syntaxTrivia.ToFullString());
 			}
 		}
 
@@ -103,15 +103,14 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 			return root.DescendantNodesAndTokensAndSelf().FirstOrDefault(n => n.HasLeadingTrivia);
 		}
 
-		private void CreateDiagnostic(SyntaxNodeAnalysisContext context, Location location)
+		private void CreateDiagnostic(SyntaxNodeAnalysisContext context, Location location, string debug = "")
 		{
-			Diagnostic diagnostic = Diagnostic.Create(Rule, location);
+			Diagnostic diagnostic = Diagnostic.Create(Rule, location, debug);
 			context.ReportDiagnostic(diagnostic);
 		}
 
 		private bool CheckCopyrightStatement(SyntaxNodeAnalysisContext context, SyntaxTrivia trivia) {
 			var comment = trivia.ToFullString();
-			Console.WriteLine($"Checking: {comment}");
 			// Check the copyright mark itself
 			bool hasCopyright = comment.Contains("©") || comment.Contains("Copyright");
 			

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
@@ -116,7 +116,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 		private bool CheckCopyrightStatement(SyntaxNodeAnalysisContext context, SyntaxTrivia trivia) {
 			var comment = trivia.ToFullString();
 			// Check the copyright mark itself
-			bool hasCopyright = comment.Contains("©", StringComparison.Ordinal) || comment.Contains("Copyright");
+			bool hasCopyright = comment.Contains('©') || comment.Contains("Copyright");
 			
 			// Check the year
 			bool hasYear = yearRegex.IsMatch(comment);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
@@ -116,7 +116,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 		private bool CheckCopyrightStatement(SyntaxNodeAnalysisContext context, SyntaxTrivia trivia) {
 			var comment = trivia.ToFullString();
 			// Check the copyright mark itself
-			bool hasCopyright = comment.Contains('©') || comment.Contains("Copyright");
+			bool hasCopyright = comment.Contains('©') || comment.Contains("\\U00A9") || comment.Contains("Copyright");
 			
 			// Check the year
 			bool hasYear = yearRegex.IsMatch(comment);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
@@ -74,7 +74,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 			
 			if (!leadingTrivia.Any(SyntaxKind.SingleLineCommentTrivia) && !leadingTrivia.Any(SyntaxKind.RegionDirectiveTrivia))
 			{
-				CreateDiagnostic(context, location);
+				CreateDiagnostic(context, location, "NoCommentInTrivia");
 				return;
 			}
 
@@ -100,7 +100,11 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 
 		private static SyntaxNodeOrToken FindFirstWithLeadingTrivia(SyntaxNode root)
 		{
-			return root.DescendantNodesAndTokensAndSelf().FirstOrDefault(n => n.HasLeadingTrivia);
+			return root.DescendantNodesAndTokensAndSelf().FirstOrDefault(n =>
+			{
+				var trivia = n.GetLeadingTrivia();
+				return trivia.Any(SyntaxKind.SingleLineCommentTrivia) || trivia.Any(SyntaxKind.RegionDirectiveTrivia);
+			});
 		}
 
 		private void CreateDiagnostic(SyntaxNodeAnalysisContext context, Location location, string debug = "")

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
@@ -116,7 +116,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 		private bool CheckCopyrightStatement(SyntaxNodeAnalysisContext context, SyntaxTrivia trivia) {
 			var comment = trivia.ToFullString();
 			// Check the copyright mark itself
-			bool hasCopyright = comment.Contains("©") || comment.Contains("Copyright");
+			bool hasCopyright = comment.Contains("©", StringComparison.Ordinal) || comment.Contains("Copyright");
 			
 			// Check the year
 			bool hasYear = yearRegex.IsMatch(comment);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/CopyrightPresentAnalyzer.cs
@@ -69,9 +69,9 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 			}
 
 			var location = GetSquiggleLocation(node.SyntaxTree);
-			var docNode = FindFirstDocumentation(node);
-			var leadingTrivia = docNode.GetLeadingTrivia();
-
+			var nodeOrToken = FindFirstWithLeadingTrivia(node);
+			var leadingTrivia = nodeOrToken.GetLeadingTrivia();
+			
 			if (!leadingTrivia.Any(SyntaxKind.SingleLineCommentTrivia) && !leadingTrivia.Any(SyntaxKind.RegionDirectiveTrivia))
 			{
 				CreateDiagnostic(context, location);
@@ -98,9 +98,9 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 			return location;
 		}
 
-		private static SyntaxNode FindFirstDocumentation(SyntaxNode root)
+		private static SyntaxNodeOrToken FindFirstWithLeadingTrivia(SyntaxNode root)
 		{
-			return root.DescendantNodesAndSelf().FirstOrDefault(n => n.HasLeadingTrivia);
+			return root.DescendantNodesAndTokensAndSelf().FirstOrDefault(n => n.HasLeadingTrivia);
 		}
 
 		private void CreateDiagnostic(SyntaxNodeAnalysisContext context, Location location)

--- a/Philips.CodeAnalysis.MsTestAnalyzers/MsTestAttributeDefinitions.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/MsTestAttributeDefinitions.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// © 2022 Koninklijke Philips N.V. See License.md in the project root for license information.
+
 using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Philips.CodeAnalysis.Common;
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestAttributeDiagnosticAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestAttributeDiagnosticAnalyzer.cs
@@ -1,8 +1,6 @@
-﻿using System;
+﻿// © 2022 Koninklijke Philips N.V. See License.md in the project root for license information.
+
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis;

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/CopyrightPresentAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/CopyrightPresentAnalyzerTest.cs
@@ -203,9 +203,17 @@ using System.Reflection;
 
 		[DataTestMethod]
 		[DataRow("RuntimeFailure", "DereferenceNullAnalyzer")]
-		public void DogFood(string folder, string analyzerName)
+		public void DogFoodMaintainability(string folder, string analyzerName)
 		{
 			var path = Path.Combine("..", "..", "..", "..", "Philips.CodeAnalysis.MaintainabilityAnalyzers", folder, $"{analyzerName}.cs");
+			VerifySuccessfulCompilationFromFile(path);
+		}
+
+		[DataTestMethod]
+		[DataRow("MsTestAttributeDefinitions")]
+		public void DogFoodMsTest(string analyzerName)
+		{
+			var path = Path.Combine("..", "..", "..", "..", "Philips.CodeAnalysis.MsTestAnalyzers", $"{analyzerName}.cs");
 			VerifySuccessfulCompilationFromFile(path);
 		}
 	}

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/CopyrightPresentAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/CopyrightPresentAnalyzerTest.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -198,6 +199,14 @@ using System.Reflection;
 			DiagnosticResult[] expected = Array.Empty<DiagnosticResult>();
 
 			VerifyDiagnostic(text, filenamePrefix, expected);
+		}
+
+		[DataTestMethod]
+		[DataRow("RuntimeFailure", "DereferenceNullAnalyzer")]
+		public void DogFood(string folder, string analyzerName)
+		{
+			var path = Path.Combine("..", "..", "..", "..", "Philips.CodeAnalysis.MaintainabilityAnalyzers", folder, $"{analyzerName}.cs");
+			VerifySuccessfulCompilationFromFile(path);
 		}
 	}
 }

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/CopyrightPresentAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/CopyrightPresentAnalyzerTest.cs
@@ -81,6 +81,11 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Documentation
 		[DataRow(@"/* Copyright Koninklijke Philips N.V. 2021", true, -1)]
 		[DataRow(@"// © Koninklijke Philips N.V. 2021", true, -1)]
 		[DataRow(@"/* © Koninklijke Philips N.V. 2021", true, -1)]
+		[DataRow(@"// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+namespace Philips.CodeAnalysis.Common
+{
+}", true, -1)]
 		[DataRow(@"", false, 2)]
 		[DataTestMethod]
 		public void HeaderIsDetected(string content, bool isGood, int errorStartLine)

--- a/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.JavaScript;
 using System.Text;
@@ -60,9 +61,24 @@ namespace Philips.CodeAnalysis.Test
 			VerifyDiagnostic(source, null, expected);
 		}
 
+		/// <summary>
+		/// Called to test a C# DiagnosticAnalyzer when applied on the single inputted string as a source
+		/// </summary>
+		/// <param name="source">A class in the form of a string to run the analyzer on</param>
 		protected void VerifySuccessfulCompilation(string source)
 		{
 			VerifyDiagnostic(source, Array.Empty<DiagnosticResult>());
+		}
+
+		/// <summary>
+		/// Called to test a C# DiagnosticAnalyzer when applied on the inputted file as a source
+		/// </summary>
+		/// <param name="path">The file on disk to run the analyzer on</param>
+		protected void VerifySuccessfulCompilationFromFile(string path)
+		{
+			var content = File.ReadAllText(path);
+			var fileName = Path.GetFileNameWithoutExtension(path);
+			VerifyDiagnostic(content, fileName, Array.Empty<DiagnosticResult>());
 		}
 
 		/// <summary>


### PR DESCRIPTION
This should solve the dog food issues around Copyright.

There were three separate issues:

1. Missing copyright in 2 files
2. Comment was not placed on root Node, but on first token
3. Copyright character gets mangled in some encodings of the source code file

All 3 are fixed in the PR.