### PR TITLE
ci: Run dogfood in net7 only

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -23,6 +23,7 @@ jobs:
             <PropertyGroup>
               <PackageId>$(MSBuildProjectName).Dogfood</PackageId>
               <PackageVersion>1.0.3</PackageVersion>
+              <TargetFrameworks>net7.0</TargetFrameworks>
             </PropertyGroup>
           </Project>
           EOF

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -23,7 +23,6 @@ jobs:
             <PropertyGroup>
               <PackageId>$(MSBuildProjectName).Dogfood</PackageId>
               <PackageVersion>1.0.3</PackageVersion>
-              <TargetFrameworks>net7.0</TargetFrameworks>
             </PropertyGroup>
           </Project>
           EOF
@@ -61,4 +60,4 @@ jobs:
           EOF
 
       - name: Eat the Dogfood
-        run: dotnet build --configuration Debug
+        run: dotnet build --configuration Debug --framework net7.0


### PR DESCRIPTION
Restrict the dogfood build to NET 7.0 only, to prevent reporting every finding twice.