### PR TITLE
feat: Set properties in any order

### DIFF
--- a/Philips.CodeAnalysis.Common/DiagnosticIds.cs
+++ b/Philips.CodeAnalysis.Common/DiagnosticIds.cs
@@ -125,5 +125,6 @@ namespace Philips.CodeAnalysis.Common
 		AvoidImplementingFinalizers = 2130,
 		AlignFilenameAndClassName = 2131,
 		RemoveCommentedCode = 2132,
+		SetPropertiesInAnyOrder = 2134,
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/SetPropertiesInAnyOrderAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/SetPropertiesInAnyOrderAnalyzer.cs
@@ -60,7 +60,17 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 		private static IEnumerable<string> GetProperties(BaseTypeDeclarationSyntax type)
 		{
-			return type.DescendantNodes().OfType<PropertyDeclarationSyntax>().Select(prop => prop.Identifier.Text);
+			return type.DescendantNodes().OfType<PropertyDeclarationSyntax>().Where(IsAssignable).Select(prop => prop.Identifier.Text);
+		}
+
+		private static bool IsAssignable(PropertyDeclarationSyntax property)
+		{
+			return property.Initializer != null || property.AccessorList.Accessors.Any(IsPublicSetter);
+		}
+
+		private static bool IsPublicSetter(AccessorDeclarationSyntax accessor)
+		{
+			return accessor.Keyword.Text == "set" && !accessor.Modifiers.Any(SyntaxKind.PrivateKeyword);
 		}
 
 		private static bool ReferencesOtherProperties(StatementSyntax statement, IEnumerable<string> otherProperties)

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/SetPropertiesInAnyOrderAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/SetPropertiesInAnyOrderAnalyzer.cs
@@ -29,7 +29,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		{
 			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 			context.EnableConcurrentExecution();
-			context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.GetAccessorDeclaration);
+			context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.SetAccessorDeclaration);
 		}
 		
 		private static void Analyze(SyntaxNodeAnalysisContext context)

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/SetPropertiesInAnyOrderAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/SetPropertiesInAnyOrderAnalyzer.cs
@@ -1,0 +1,73 @@
+﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class SetPropertiesInAnyOrderAnalyzer : DiagnosticAnalyzer
+	{
+		private const string Title = @"Set properties in any order";
+		private const string MessageFormat = @"Avoid getting other properties when setting property {0}.";
+		private const string Description = @"Getting other properties in a setter makes this setter dependant on the order in which these properties are set.";
+		private const string Category = Categories.Maintainability;
+
+		private static readonly DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.SetPropertiesInAnyOrder),
+			Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true,
+			description: Description);
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		public override void Initialize(AnalysisContext context)
+		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.EnableConcurrentExecution();
+			context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.GetAccessorDeclaration);
+		}
+		
+		private static void Analyze(SyntaxNodeAnalysisContext context)
+		{
+			var getMethod = (AccessorDeclarationSyntax)context.Node;
+			var prop = getMethod.Ancestors().OfType<PropertyDeclarationSyntax>().FirstOrDefault();
+			if (getMethod.Body == null || prop == null)
+			{
+				return;
+			}
+
+			var type = prop.Ancestors().OfType<BaseTypeDeclarationSyntax>().FirstOrDefault();
+			if (type == null)
+			{
+				return;
+			}
+
+			var propertiesInType = GetProperties(type);
+			var otherProperties = propertiesInType.Except(new[] { prop.Identifier.Text });
+
+			if (getMethod.Body.Statements.Any(s => ReferencesOtherProperties(s, otherProperties)))
+			{
+				var propertyName = prop.Identifier.Text;
+				var loc = getMethod.GetLocation();
+				context.ReportDiagnostic(Diagnostic.Create(Rule, loc, propertyName));
+			}
+		}
+
+		private static IEnumerable<string> GetProperties(BaseTypeDeclarationSyntax type)
+		{
+			return type.DescendantNodes().OfType<PropertyDeclarationSyntax>().Select(prop => prop.Identifier.Text);
+		}
+
+		private static bool ReferencesOtherProperties(StatementSyntax statement, IEnumerable<string> otherProperties)
+		{
+
+			return statement.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>()
+				.Any(name => otherProperties.Contains(name.Identifier.Text));
+		}
+	}
+}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/SetPropertiesInAnyOrderAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/SetPropertiesInAnyOrderAnalyzer.cs
@@ -16,7 +16,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 	{
 		private const string Title = @"Set properties in any order";
 		private const string MessageFormat = @"Avoid getting other properties when setting property {0}.";
-		private const string Description = @"Getting other properties in a setter makes this setter dependant on the order in which these properties are set.";
+		private const string Description = @"Getting other properties in a setter makes this setter dependent on the order in which these properties are set.";
 		private const string Category = Categories.Maintainability;
 
 		private static readonly DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticIds.SetPropertiesInAnyOrder),

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/PassByRefAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/PassByRefAnalyzer.cs
@@ -1,7 +1,6 @@
 ﻿// © 2021 Koninklijke Philips N.V. See License.md in the project root for license information.
 
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -20,7 +19,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 
 		public DiagnosticDescriptor Rule { get; } = new(Helper.ToDiagnosticId(DiagnosticIds.AvoidPassByReference), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
-		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 		public override void Initialize(AnalysisContext context)
 		{

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -112,7 +112,8 @@
       * Increased the test coverage.
       * Introduce PH2130: Avoid implementing finalizers.
       * Introduce PH2131: Align filename and class name.
-      * Introduce PH2131: Remvoe commented code.
+      * Introduce PH2131: Remove commented code.
+      * Introduce PH2134: Set properties in any order.
     </PackageReleaseNotes>
 	  <Copyright>© 2019-2023 Koninklijke Philips N.V.</Copyright>
 	  <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -83,3 +83,4 @@
 | PH2130  | Avoid implementing finalizers                | Avoid implement a finalizer, use Dispose instead. If the class has unmanaged fields, finalizers are allowed if they only call Dispose.|
 | PH2131  | Align filename and class name                | Name the file after the class, struct or enum it contains. |
 | PH2132  | Remove commented code                        | Remove commented code.|
+| PH2134  | Set properties in any order                  | Getting other properties in a setter makes this setter dependant on the order in which these properties are set. |

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -83,4 +83,4 @@
 | PH2130  | Avoid implementing finalizers                | Avoid implement a finalizer, use Dispose instead. If the class has unmanaged fields, finalizers are allowed if they only call Dispose.|
 | PH2131  | Align filename and class name                | Name the file after the class, struct or enum it contains. |
 | PH2132  | Remove commented code                        | Remove commented code.|
-| PH2134  | Set properties in any order                  | Getting other properties in a setter makes this setter dependant on the order in which these properties are set. |
+| PH2134  | Set properties in any order                  | Getting other properties in a setter makes this setter dependent on the order in which these properties are set. |

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/SetPropertiesInAnyOrderAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/SetPropertiesInAnyOrderAnalyzerTest.cs
@@ -19,20 +19,8 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		private const string CorrectAutoProperties = @"
 namespace PropertiesinOrderTests {
     public class Number {
-        private int One { get; }
-        private int Two { get; }
-    }
-}";
-
-		private const string WrongInReturn = @"
-namespace PropertiesinOrderTests {
-    public class Number {
-        private int One { get; }
-        private int Two {
-            get {
-                return One + 1;
-            }
-        }
+        private int One { get; set; }
+        private int Two { get; set; }
     }
 }";
 
@@ -41,9 +29,8 @@ namespace PropertiesinOrderTests {
     public class Number {
         private int One { get; }
         private int Two {
-            get {
-                int two = One + 1;
-                return two;
+            set {
+                One = value - 1;
             }
         }
     }
@@ -65,10 +52,9 @@ namespace PropertiesinOrderTests {
 		/// Diagnostics expected to show up
 		/// </summary>
 		[DataTestMethod]
-		[DataRow(WrongInReturn, DisplayName = nameof(WrongInReturn)),
-		 DataRow(WrongInAssignment, DisplayName = nameof(WrongInAssignment))]
+		[DataRow(WrongInAssignment, DisplayName = nameof(WrongInAssignment))]
 		[TestCategory(TestDefinitions.UnitTests)]
-		public void WhenRefereningOtherPropertiesDiagnosticIsRaised(string testCode) {
+		public void WhenReferencingOtherPropertiesDiagnosticIsRaised(string testCode) {
 			var expected = DiagnosticResultHelper.Create(DiagnosticIds.SetPropertiesInAnyOrder);
 			VerifyDiagnostic(testCode, expected);
 		}
@@ -81,7 +67,7 @@ namespace PropertiesinOrderTests {
 		[TestCategory(TestDefinitions.UnitTests)]
 		public void WhenSourceFileIsOutOfScopeNoDiagnosticIsTriggered(string filePath)
 		{
-			VerifyDiagnostic(WrongInReturn, filePath);
+			VerifyDiagnostic(WrongInAssignment, filePath);
 		}
 
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer() {

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/SetPropertiesInAnyOrderAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/SetPropertiesInAnyOrderAnalyzerTest.cs
@@ -1,0 +1,91 @@
+﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Philips.CodeAnalysis.Common;
+using Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability;
+using Philips.CodeAnalysis.Test.Helpers;
+using Philips.CodeAnalysis.Test.Verifiers;
+
+namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
+{
+	/// <summary>
+	/// Test class for <see cref="SetPropertiesInAnyOrderAnalyzer"/>.
+	/// </summary>
+	[TestClass]
+	public class SetPropertiesInAnyOrderAnalyzerTest : DiagnosticVerifier
+	{
+		private const string CorrectAutoProperties = @"
+namespace PropertiesinOrderTests {
+    public class Number {
+        private int One { get; }
+        private int Two { get; }
+    }
+}";
+
+		private const string WrongInReturn = @"
+namespace PropertiesinOrderTests {
+    public class Number {
+        private int One { get; }
+        private int Two {
+            get {
+                return One + 1;
+            }
+        }
+    }
+}";
+
+		private const string WrongInAssignment = @"
+namespace PropertiesinOrderTests {
+    public class Number {
+        private int One { get; }
+        private int Two {
+            get {
+                int two = One + 1;
+                return two;
+            }
+        }
+    }
+}";
+
+		/// <summary>
+		/// No diagnostics expected to show up
+		/// </summary>
+		[DataTestMethod]
+		[DataRow("", DisplayName = "Empty"),
+		 DataRow(CorrectAutoProperties, DisplayName = nameof(CorrectAutoProperties))]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
+		{
+			VerifySuccessfulCompilation(testCode);
+		}
+
+		/// <summary>
+		/// Diagnostics expected to show up
+		/// </summary>
+		[DataTestMethod]
+		[DataRow(WrongInReturn, DisplayName = nameof(WrongInReturn)),
+		 DataRow(WrongInAssignment, DisplayName = nameof(WrongInAssignment))]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public void WhenRefereningOtherPropertiesDiagnosticIsRaised(string testCode) {
+			var expected = DiagnosticResultHelper.Create(DiagnosticIds.SetPropertiesInAnyOrder);
+			VerifyDiagnostic(testCode, expected);
+		}
+
+		/// <summary>
+		/// No diagnostics expected to show up 
+		/// </summary>
+		[DataTestMethod]
+		[DataRow("File.g", DisplayName = "OutOfScopeSourceFile")]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public void WhenSourceFileIsOutOfScopeNoDiagnosticIsTriggered(string filePath)
+		{
+			VerifyDiagnostic(WrongInReturn, filePath);
+		}
+
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer() {
+			return new SetPropertiesInAnyOrderAnalyzer();
+		}
+	}
+}

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/SetPropertiesInAnyOrderAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/SetPropertiesInAnyOrderAnalyzerTest.cs
@@ -19,16 +19,40 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		private const string CorrectAutoProperties = @"
 namespace PropertiesinOrderTests {
     public class Number {
-        private int One { get; set; }
-        private int Two { get; set; }
+        public int One { get; set; }
+        public int Two { get; set; }
+    }
+}";
+
+		private const string CorrectInitializer = @"
+namespace PropertiesinOrderTests {
+    public class Number {
+        public int One { get; set; } = 1;
+        public int Two { get; set; }
+    }
+}";
+
+		private const string CorrectNoSetter = @"
+namespace PropertiesinOrderTests {
+    public class Number {
+        public int One { get; };
+        public int Two { get; set; }
+    }
+}";
+
+		private const string CorrectPrivateSetter = @"
+namespace PropertiesinOrderTests {
+    public class Number {
+        public int One { get; private set; };
+        public int Two { get; set; }
     }
 }";
 
 		private const string WrongInAssignment = @"
 namespace PropertiesinOrderTests {
     public class Number {
-        private int One { get; }
-        private int Two {
+        public int One { get; set; }
+        public int Two {
             set {
                 One = value - 1;
             }
@@ -41,7 +65,10 @@ namespace PropertiesinOrderTests {
 		/// </summary>
 		[DataTestMethod]
 		[DataRow("", DisplayName = "Empty"),
-		 DataRow(CorrectAutoProperties, DisplayName = nameof(CorrectAutoProperties))]
+		 DataRow(CorrectAutoProperties, DisplayName = nameof(CorrectAutoProperties)),
+		 DataRow(CorrectInitializer, DisplayName = nameof(CorrectInitializer)),
+		 DataRow(CorrectNoSetter, DisplayName = nameof(CorrectNoSetter)),
+		 DataRow(CorrectPrivateSetter, DisplayName = nameof(CorrectPrivateSetter))]
 		[TestCategory(TestDefinitions.UnitTests)]
 		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
 		{


### PR DESCRIPTION
The checks rule [7@601](https://csviewer.tiobe.com/#/ruleset/rule?setid=4T_Jr6-VSX6fp6egDIhGow&status=CHECKED,UNCHECKED&tagid=6u27MkXORKaev0VNuWR_SA&ruleid=XO9vkD5ZTfC01xb4GKhskw) of the Philips C# Coding Standard