### PR TITLE
fix: Prevent false positive

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AlignOperatorsCountAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AlignOperatorsCountAnalyzer.cs
@@ -144,7 +144,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 				context.ReportDiagnostic(Diagnostic.Create(ShiftRightAndLeftRule, location));
 			}
 
-			if (visitor.PlusCount != visitor.EqualCount)
+			if ((visitor.PlusCount > 0 || visitor.MinusCount > 0) && visitor.PlusCount != visitor.EqualCount)
 			{
 				var location = identifier.GetLocation();
 				context.ReportDiagnostic(Diagnostic.Create(PlusAndEqualRule, location));

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AlignOperatorsCountAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AlignOperatorsCountAnalyzerTest.cs
@@ -145,6 +145,21 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
         }
     }";
 
+		private const string CorrectOnlyEqual = @"
+    namespace AssignmentInConditionUnitTests {
+        public class Number {
+			private int n;
+            public static Number operator ==(Number num1, Number num2)
+            {
+                return num1.n == num2.n;
+            }
+            public static Number operator !=(Number num1, Number num2)
+            {
+                return num1.n != num2.n;
+            }
+        }
+    }";
+
 		private const string WrongNumberOfIncrementDecrement = @"
     namespace AssignmentInConditionUnitTests {
         public class Number {
@@ -257,7 +272,8 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		 DataRow(CorrectNumberOfGreaterLessThan, DisplayName = nameof(CorrectNumberOfGreaterLessThan)),
 		 DataRow(CorrectNumberOfGreaterLessThanOrEqual, DisplayName = nameof(CorrectNumberOfGreaterLessThanOrEqual)),
 		 DataRow(CorrectNumberOfRightLeftShift, DisplayName = nameof(CorrectNumberOfRightLeftShift)),
-		 DataRow(CorrectNumberOfPlusEqual, DisplayName = nameof(CorrectNumberOfPlusEqual))]
+		 DataRow(CorrectNumberOfPlusEqual, DisplayName = nameof(CorrectNumberOfPlusEqual)),
+		 DataRow(CorrectOnlyEqual, DisplayName = nameof(CorrectOnlyEqual))]
 		[TestCategory(TestDefinitions.UnitTests)]
 		public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
 		{


### PR DESCRIPTION
Only raise PH2125 if there is at least one `+` or `-` operator declared.