### PR TITLE
fix: 265 avoid inline new ph2021 exclude tostring

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidInlineNewAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidInlineNewAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -16,10 +17,11 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 		private const string MessageFormat = @"Do not inline the constructor call for class {0}";
 		private const string Description = @"Create a local variable, or a field for the temporary instance of class '{0}'";
 		private const string Category = Categories.Readability;
+		private static readonly HashSet<string> AllowedMethods = new() { "ToString", "ToList", "ToArray" };
 
 		public static readonly DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticId.AvoidInlineNew), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
-		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 		public override void Initialize(AnalysisContext context)
 		{
@@ -39,6 +41,11 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 				return;
 			}
 
+			if (IsCallingAllowedMethod(parent))
+			{
+				return;
+			}
+
 			context.ReportDiagnostic(Diagnostic.Create(Rule, oce.GetLocation(), oce.Type.ToString()));
 		}
 
@@ -47,6 +54,17 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 			return 
 				node is MemberAccessExpressionSyntax || 
 				(node is ParenthesizedExpressionSyntax syntax && IsInlineNew(syntax.Parent));
+		}
+
+		private static bool IsCallingAllowedMethod(SyntaxNode node)
+		{
+			if (node is ParenthesizedExpressionSyntax syntax)
+			{
+				return IsCallingAllowedMethod(syntax.Parent);
+			}
+			return
+				node is MemberAccessExpressionSyntax memberAccess &&
+				AllowedMethods.Contains(memberAccess.Name.Identifier.Text);
 		}
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidInlineNewAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidInlineNewAnalyzer.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 		private const string MessageFormat = @"Do not inline the constructor call for class {0}";
 		private const string Description = @"Create a local variable, or a field for the temporary instance of class '{0}'";
 		private const string Category = Categories.Readability;
-		private static readonly HashSet<string> AllowedMethods = new() { "ToString", "ToList", "ToArray" };
+		private static readonly HashSet<string> AllowedMethods = new() { "ToString", "ToList", "ToArray", "AsSpan" };
 
 		public static readonly DiagnosticDescriptor Rule = new(Helper.ToDiagnosticId(DiagnosticId.AvoidInlineNew), Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidInlineNewAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidInlineNewAnalyzerTest.cs
@@ -40,9 +40,17 @@ class Foo
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
-		public void DontInlineNewCall()
+		public void NoErrorOnAllowedMethods()
 		{
 			var file = CreateFunction("string str = new object().ToString()");
+			VerifySuccessfulCompilation(file);
+		}
+
+		[TestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public void DontInlineNewCall()
+		{
+			var file = CreateFunction("int hash = new object().GetHashCode()");
 			Verify(file);
 		}
 
@@ -66,10 +74,20 @@ class Foo
 		[DataRow("(new Foo())")]
 		[DataTestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
-		public void DontInlineNewCallCustomType(string newVarient)
+		public void DontInlineNewCallCustomType(string newVariant)
 		{
-			var file = CreateFunction($"string str = {newVarient}.ToString()");
+			var file = CreateFunction($"int hash = {newVariant}.GetHashCode()");
 			Verify(file);
+		}
+
+		[DataRow("new Foo()")]
+		[DataRow("(new Foo())")]
+		[DataTestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public void NoErrorInlineNewCallCustomTypeAllowedMethod(string newVariant)
+		{
+			var file = CreateFunction($"string str = {newVariant}.ToString()");
+			VerifySuccessfulCompilation(file);
 		}
 
 		[TestMethod]
@@ -109,8 +127,16 @@ class Foo
 		[TestCategory(TestDefinitions.UnitTests)]
 		public void ErrorIfReturned()
 		{
-			var file = CreateFunction("return new object().ToString();");
+			var file = CreateFunction("return new object().GetHashCode();");
 			Verify(file);
+		}
+
+		[TestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public void NoErrorIfReturnedAllowedMethod()
+		{
+			var file = CreateFunction("return new object().ToString();");
+			VerifySuccessfulCompilation(file);
 		}
 
 		[TestMethod]

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidInlineNewAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/AvoidInlineNewAnalyzerTest.cs
@@ -155,6 +155,14 @@ class Foo
 			Verify(file);
 		}
 
+		[TestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public void NoErrorOnAsSpanMethod()
+		{
+			var file = CreateFunction("new string(\"\").AsSpan();");
+			VerifySuccessfulCompilation(file);
+		}
+
 		private void Verify(string file)
 		{
 			VerifyDiagnostic(file, new DiagnosticResult()


### PR DESCRIPTION
Allow the following methods:
- ToString()
- ToArray()
- ToList()
- AsSpan()