### PR TITLE
fix: Handle generic classes

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/AlignFilenameAndClassNameAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/AlignFilenameAndClassNameAnalyzer.cs
@@ -67,7 +67,12 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 			{
 				filename = filename.Substring(0,indexOfDot);
 			}
-			if (StringComparer.OrdinalIgnoreCase.Compare(identifier.Text, filename) != 0)
+			int indexOfCurly = filename.IndexOf('{');
+			if(indexOfCurly != -1)
+			{
+				filename = filename.Substring(0, indexOfCurly);
+			}
+			if(StringComparer.OrdinalIgnoreCase.Compare(identifier.Text, filename) != 0)
 			{
 				var location = identifier.GetLocation();
 				Diagnostic diagnostic = Diagnostic.Create(Rule, location, identifier.Text, typeKind);

--- a/Philips.CodeAnalysis.Test/Maintainability/Naming/AlignFilenameAndClassNameAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Naming/AlignFilenameAndClassNameAnalyzerTest.cs
@@ -37,6 +37,24 @@ namespace AlignFilenameAndClassName {{
 		}
 
 		/// <summary>
+		/// No diagnostics expected to show up
+		/// </summary>
+		[DataTestMethod]
+		[DataRow("Program"),
+		 DataRow("Program{T}")]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public void WhenGenericTestCodeIsValidNoDiagnosticIsTriggered(string filePath)
+		{
+			const string sourceCode = @"
+namespace AlignFilenameAndClassName {{
+    class Program<T> {{
+    }}
+}}";
+			VerifySuccessfulCompilation(sourceCode, filePath);
+		}
+
+
+		/// <summary>
 		/// Diagnostics should show up hare.
 		/// </summary>
 		[DataTestMethod]

--- a/Philips.CodeAnalysis.Test/Maintainability/Naming/NamespaceMatchAssemblyNameAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Naming/NamespaceMatchAssemblyNameAnalyzerTest.cs
@@ -2,7 +2,6 @@
 
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Philips.CodeAnalysis.Common;
 using Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming;
 using Philips.CodeAnalysis.Test.Helpers;
 using Philips.CodeAnalysis.Test.Verifiers;

--- a/Philips.CodeAnalysis.Test/Maintainability/Naming/NamespaceMatchFilePathAnalyzerNoFolderTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Naming/NamespaceMatchFilePathAnalyzerNoFolderTest.cs
@@ -52,6 +52,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Naming
 
 		[DataTestMethod]
 		[DataRow("Philips.Test", "C:\\development\\Philips.Test\\code\\MyTest.cs", DisplayName = "Namespace Match, Folder Does not")]
+		[DataRow("Philips.CodeAnalysis.Common", "C:\\Philips.CodeAnalysis.Common\\SingleDiagnosticAnalyzer{TU}.cs", DisplayName = "Generic filename")]
 		[DataRow("Philips.CodeAnalysis.Test", "C:\\Philips.CodeAnalysis.Test\\src\\MyTest.cs", DisplayName = "Namespace Match, Folder Does not")]
 		[TestCategory(TestDefinitions.UnitTests)]
 		public void DoNotReportANamespaceSupersetMatch(string ns, string path)


### PR DESCRIPTION
Allow generic classes to be in filenames like: `SingleDiagnosticAnalyzer{TU}.cs`