### PR TITLE
fix: AvoidMagicNumbers too aggressive

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidMagicNumbersAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidMagicNumbersAnalyzer.cs
@@ -51,13 +51,21 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 				return;
 			}
 
-			// The magic number should be defined in a static field.
+			// If in a field, the magic number should be defined in a static field.
 			var field = Node.Ancestors().OfType<FieldDeclarationSyntax>().FirstOrDefault();
-			if (field == null || !IsStaticOrConst(field))
+			if (field != null && IsStaticOrConst(field))
 			{
-				var location = Node.GetLocation();
-				ReportDiagnostic(location);
+				return;
 			}
+
+			var local = Node.Ancestors().OfType<LocalDeclarationStatementSyntax>().FirstOrDefault();
+			if (local != null && local.Modifiers.Any(SyntaxKind.ConstKeyword))
+			{
+				return;
+			}
+
+			var location = Node.GetLocation();
+			ReportDiagnostic(location);
 		}
 
 		private static bool IsAllowedNumber(string text)

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidMagicNumbersAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidMagicNumbersAnalyzerTest.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using Philips.CodeAnalysis.Common;
 using Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability;
 using Philips.CodeAnalysis.Test.Helpers;
 using Philips.CodeAnalysis.Test.Verifiers;
@@ -125,19 +124,19 @@ namespace DontUseMagicNumbersTests {
     }
 }";
 
-		private const string WrongInstanceField = @"
-namespace DontUseMagicNumbersTests {
-    public class Number {
-        private int Magic = 5;
-    }
-}";
-
-		private const string WrongConstLocal = @"
+		private const string CorrectConstLocal = @"
 namespace DontUseMagicNumbersTests {
     public class Number {
         public void Main() {
             const int Magic = 5;
         }
+    }
+}";
+
+		private const string WrongInstanceField = @"
+namespace DontUseMagicNumbersTests {
+    public class Number {
+        private int Magic = 5;
     }
 }";
 
@@ -176,6 +175,7 @@ namespace DontUseMagicNumbersTests {
 		 DataRow(CorrectPowerOf2, DisplayName = nameof(CorrectPowerOf2)),
 		 DataRow(CorrectAngle, DisplayName = nameof(CorrectAngle)),
 		 DataRow(CorrectInEnum, DisplayName = nameof(CorrectInEnum)),
+		 DataRow(CorrectConstLocal, DisplayName = nameof(CorrectConstLocal)),
 		 DataRow(CorrectInTestClass, DisplayName = nameof(CorrectInTestClass))]
 		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task WhenTestCodeIsValidNoDiagnosticIsTriggeredAsync(string testCode)
@@ -188,7 +188,6 @@ namespace DontUseMagicNumbersTests {
 		/// </summary>
 		[DataTestMethod]
 		[DataRow(WrongInstanceField, DisplayName = nameof(WrongInstanceField)),
-		 DataRow(WrongConstLocal, DisplayName = nameof(WrongConstLocal)),
 		 DataRow(WrongLocal, DisplayName = nameof(WrongLocal)),
 		 DataRow(WrongPropertyInitializer, DisplayName = nameof(WrongPropertyInitializer))]
 		[TestCategory(TestDefinitions.UnitTests)]


### PR DESCRIPTION
I agree that `const` local variables are OK.
But named arguments are not in my opinion, so those are still not allowed.