### PR TITLE
ci: initial semver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       with:
         dry_run: true
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        pre_release_branches: "*"
+        pre_release_branches: "**"
         tag_prefix: ""
         release_branches: ""
         append_to_pre_release_tag: "beta"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
         release_branches: ""
         append_to_pre_release_tag: "beta"
 #        custom_tag: TODO for first release
+    - name: Results
+      run: |
+        echo New Tag:  ${{ steps.tag_version.outputs.new_tag }}
+        echo New Version:  ${{ steps.tag_version.outputs.new_version }}
 
   outputstuff:
     runs-on: ubuntu-latest
@@ -60,8 +64,8 @@ jobs:
     steps:
     - name: Results
       run: |
-        echo New Tag:  ${{ steps.tagversion.outputs.new_tag }}
-        echo New Version:  ${{ steps.tagversion.outputs.new_version }}
+        echo New Tag:  ${{ steps.tag_version.outputs.new_tag }}
+        echo New Version:  ${{ steps.tag_version.outputs.new_version }}
 
 
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
       id: tag_version
       uses: mathieudutour/github-tag-action@v6.1
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        pre_release_branches: 'bcollamore-semver'
-        tag_prefix: ''
-        append_to_pre_release_tag: '-alpha'
         dry_run: true
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        pre_release_branches: ${{ GITHUB_REF }}
+        tag_prefix: ''
+        append_to_pre_release_tag: -alpha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,14 @@ jobs:
     runs-on: ubuntu-latest
 #    needs: build
     steps:
-    - run: echo ${{ github.ref_name }}
+    - run: echo ${{ github.head_ref || github.ref_name }}
     - name: Bump version
       id: tag_version
       uses: mathieudutour/github-tag-action@v6.1
       with:
         dry_run: true
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        pre_release_branches: "${{ github.ref_name }}"
+        pre_release_branches: "${{ github.head_ref || github.ref_name }}"
         tag_prefix: ""
         append_to_pre_release_tag: "beta"
 #        custom_tag: TODO for first release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,14 +45,3 @@ jobs:
   performance:
     uses: philips-software/roslyn-analyzers/.github/workflows/performance.yml@master
 
-  outputstuff:
-    runs-on: ubuntu-latest
-    needs: tagversion
-    steps:
-    - name: Results
-      run: |
-        echo New Tag:  ${{ needs.tagversion.outputs.new_tag }}
-        echo New Version:  ${{ needs.tagversion.outputs.new_version }}
-
-
-        

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,11 @@ on:
   pull_request:
     branches: [master]
 jobs:
-  codeql:
-    if: ${{ github.event_name == 'pull_request' }}
-    uses: philips-software/roslyn-analyzers/.github/workflows/codeql-analysis.yml@master
+
+# CodeQL is slow and has yet to find anything
+#  codeql:
+#    if: ${{ github.event_name == 'pull_request' }}
+#    uses: philips-software/roslyn-analyzers/.github/workflows/codeql-analysis.yml@master
 
 #  format:
 #    if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
     runs-on: ubuntu-latest
 #    needs: build
     steps:
-    - run: echo ${{ github.head_ref || github.ref_name }}
     - name: Bump version
       id: tag_version
       uses: mathieudutour/github-tag-action@v6.1
@@ -51,6 +50,18 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         pre_release_branches: "${{ github.head_ref || github.ref_name }}"
         tag_prefix: ""
+        release_branches: ""
         append_to_pre_release_tag: "beta"
 #        custom_tag: TODO for first release
+
+  outputstuff:
+    runs-on: ubuntu-latest
+    needs: tagversion
+    steps:
+    - name: Results
+      run: |
+        echo New Tag:  ${{ steps.tagversion.outputs.new_tag }}
+        echo New Version:  ${{ steps.tagversion.outputs.new_version }}
+
+
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,15 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     uses: philips-software/roslyn-analyzers/.github/workflows/pinned-actions.yml@master
 
+  tagversion:
+    uses: philips-software/roslyn-analyzers/.github/workflows/tagversion.yml@bcollamore-semver
+  
   build:
+    needs: tagversion
     uses: philips-software/roslyn-analyzers/.github/workflows/dotnetcore.yml@master
+    with:
+      new_tag: ${{ needs.tagversion.outputs.new_tag }}
+      new_version: ${{ needs.tagversion.outputs.new_version }}
 
   sonarcloud:
     uses: philips-software/roslyn-analyzers/.github/workflows/sonarcloud.yml@master
@@ -36,9 +43,6 @@ jobs:
   performance:
     uses: philips-software/roslyn-analyzers/.github/workflows/performance.yml@master
 
-  tagversion:
-    uses: philips-software/roslyn-analyzers/.github/workflows/tagversion.yml@bcollamore-semver
-  
   outputstuff:
     runs-on: ubuntu-latest
     needs: tagversion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,12 @@ jobs:
 #    if: ${{ github.event_name == 'push' }}
 # paths:
     runs-on: ubuntu-latest
-    needs: build
+#    needs: build
     steps:
     - name: Bump version and push tag
       id: tag_version
       uses: mathieudutour/github-tag-action@v6.1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        previous_tag: '2.0.0'
         pre_release_branches: 'master'
         dry_run: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,13 @@ jobs:
 #    if: ${{ github.event_name == 'push' }}
 # paths:
     runs-on: ubuntu-latest
+    needs: build
     steps:
     - name: Bump version and push tag
       id: tag_version
       uses: mathieudutour/github-tag-action@v6.1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        previous_tag: '2.0.0'
+        pre_release_branches: 'master'
         dry_run: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,30 +37,8 @@ jobs:
     uses: philips-software/roslyn-analyzers/.github/workflows/performance.yml@master
 
   tagversion:
-#    if: ${{ github.event_name == 'push' }}
-# paths:
-    runs-on: ubuntu-latest
-#    needs: build
-    steps:
-    - name: Bump version
-      id: tag_version
-      uses: mathieudutour/github-tag-action@v6.0
-      with:
-        dry_run: true
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        pre_release_branches: "${{ github.head_ref || github.ref_name }},master,main"
-        tag_prefix: ""
-        release_branches: ""
-        append_to_pre_release_tag: prerelease
-#        custom_tag: TODO for first release
-    - name: Results
-      run: |
-        echo New Tag:  ${{ steps.tag_version.outputs.new_tag }}
-        echo New Version:  ${{ steps.tag_version.outputs.new_version }}
-    outputs:
-      new_tag: ${{ steps.tag_version.outputs.new_tag }}
-      new_version: ${{ steps.tag_version.outputs.new_version }}
-
+    uses: philips-software/roslyn-analyzers/.github/workflows/tagversion.yml@bcollamore-semver
+  
   outputstuff:
     runs-on: ubuntu-latest
     needs: tagversion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,6 @@ jobs:
       with:
         dry_run: true
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        pre_release_branches: ${{ env.GITHUB_REF }}
+        pre_release_branches: ${{ env.GITHUB_REF_NAME }}
         tag_prefix: ''
         append_to_pre_release_tag: -alpha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       with:
         dry_run: true
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        pre_release_branches: "${{ github.head_ref || github.ref_name }}"
+        pre_release_branches: "${{ github.head_ref || github.ref_name }},master"
         tag_prefix: ""
         release_branches: ""
         append_to_pre_release_tag: "beta"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
 #    needs: build
     steps:
-    - name: Bump version and push tag
+    - name: Bump version
       id: tag_version
       uses: mathieudutour/github-tag-action@v6.1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,19 +44,22 @@ jobs:
     steps:
     - name: Bump version
       id: tag_version
-      uses: mathieudutour/github-tag-action@v6.1
+      uses: mathieudutour/github-tag-action@v6.0
       with:
         dry_run: true
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        pre_release_branches: "${{ github.head_ref || github.ref_name }}"
+        pre_release_branches: "${{ github.head_ref || github.ref_name }},master,main"
         tag_prefix: ""
         release_branches: ""
-        append_to_pre_release_tag: "-beta"
+        append_to_pre_release_tag: prerelease
 #        custom_tag: TODO for first release
     - name: Results
       run: |
         echo New Tag:  ${{ steps.tag_version.outputs.new_tag }}
         echo New Version:  ${{ steps.tag_version.outputs.new_version }}
+    outputs:
+      new_tag: ${{ steps.tag_version.outputs.new_tag }}
+      new_version: ${{ steps.tag_version.outputs.new_version }}
 
   outputstuff:
     runs-on: ubuntu-latest
@@ -64,8 +67,8 @@ jobs:
     steps:
     - name: Results
       run: |
-        echo New Tag:  ${{ steps.tag_version.outputs.new_tag }}
-        echo New Version:  ${{ steps.tag_version.outputs.new_version }}
+        echo New Tag:  ${{ needs.tagversion.outputs.new_tag }}
+        echo New Version:  ${{ needs.tagversion.outputs.new_version }}
 
 
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,15 @@ jobs:
 
   performance:
     uses: philips-software/roslyn-analyzers/.github/workflows/performance.yml@master
+
+  tagversion:
+#    if: ${{ github.event_name == 'push' }}
+# paths:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Bump version and push tag
+      id: tag_version
+      uses: mathieudutour/github-tag-action@v6.1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        dry_run: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       with:
         dry_run: true
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        pre_release_branches: "${{ github.head_ref || github.ref_name }},master"
+        pre_release_branches: "*"
         tag_prefix: ""
         release_branches: ""
         append_to_pre_release_tag: "beta"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
   dogfood:
     if: ${{ github.event_name == 'pull_request' }}
-    uses: philips-software/roslyn-analyzers/.github/workflows/dogfood.yml@master
+    uses: philips-software/roslyn-analyzers/.github/workflows/dogfood.yml@bcollamore-semver
 
   performance:
     uses: philips-software/roslyn-analyzers/.github/workflows/performance.yml@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,14 @@ jobs:
     runs-on: ubuntu-latest
 #    needs: build
     steps:
-    - run: echo ${{ env.GITHUB_REF_NAME }}
+    - run: echo ${{ github.ref_name }}
     - name: Bump version
       id: tag_version
       uses: mathieudutour/github-tag-action@v6.1
       with:
         dry_run: true
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        pre_release_branches: "${{ env.GITHUB_REF_NAME }}"
+        pre_release_branches: "${{ github.ref_name }}"
         tag_prefix: ""
         append_to_pre_release_tag: "beta"
 #        custom_tag: TODO for first release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,6 @@ jobs:
       with:
         dry_run: true
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        pre_release_branches: ${{ GITHUB_REF }}
+        pre_release_branches: ${{ env.GITHUB_REF }}
         tag_prefix: ''
         append_to_pre_release_tag: -alpha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,6 @@ on:
   pull_request:
     branches: [master]
 jobs:
-
-# CodeQL is slow and has yet to find anything
-#  codeql:
-#    if: ${{ github.event_name == 'pull_request' }}
-#    uses: philips-software/roslyn-analyzers/.github/workflows/codeql-analysis.yml@master
-
   format:
     if: ${{ github.event_name == 'pull_request' }}
     uses: philips-software/roslyn-analyzers/.github/workflows/format.yml@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,15 @@ jobs:
     runs-on: ubuntu-latest
 #    needs: build
     steps:
+    - run: echo ${{ env.GITHUB_REF_NAME }}
     - name: Bump version
       id: tag_version
       uses: mathieudutour/github-tag-action@v6.1
       with:
         dry_run: true
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        pre_release_branches: ${{ env.GITHUB_REF_NAME }}
-        tag_prefix: ''
-        append_to_pre_release_tag: -alpha
+        pre_release_branches: "${{ env.GITHUB_REF_NAME }}"
+        tag_prefix: ""
+        append_to_pre_release_tag: "beta"
 #        custom_tag: TODO for first release
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,5 +47,7 @@ jobs:
       uses: mathieudutour/github-tag-action@v6.1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        pre_release_branches: 'master,bcollamore-semver'
+        pre_release_branches: 'bcollamore-semver'
+        tag_prefix: ''
+        append_to_pre_release_tag: '-alpha'
         dry_run: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
   
   build:
     needs: tagversion
-    uses: philips-software/roslyn-analyzers/.github/workflows/dotnetcore.yml@master
+    uses: philips-software/roslyn-analyzers/.github/workflows/dotnetcore.yml@bcollamore-semver
     with:
       new_tag: ${{ needs.tagversion.outputs.new_tag }}
       new_version: ${{ needs.tagversion.outputs.new_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,5 +47,5 @@ jobs:
       uses: mathieudutour/github-tag-action@v6.1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        pre_release_branches: 'master'
+        pre_release_branches: 'master,bcollamore-semver'
         dry_run: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,10 @@ jobs:
       with:
         dry_run: true
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        pre_release_branches: "**"
+        pre_release_branches: "${{ github.head_ref || github.ref_name }}"
         tag_prefix: ""
         release_branches: ""
-        append_to_pre_release_tag: "beta"
+        append_to_pre_release_tag: "-beta"
 #        custom_tag: TODO for first release
     - name: Results
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,35 +7,35 @@ on:
 jobs:
   format:
     if: ${{ github.event_name == 'pull_request' }}
-    uses: philips-software/roslyn-analyzers/.github/workflows/format.yml@master
+    uses: ./.github/workflows/format.yml
 
   pinnedactions:
     if: ${{ github.event_name == 'pull_request' }}
-    uses: philips-software/roslyn-analyzers/.github/workflows/pinned-actions.yml@master
+    uses: ./.github/workflows/pinned-actions.yml
 
   tagversion:
-    uses: philips-software/roslyn-analyzers/.github/workflows/tagversion.yml@bcollamore-semver
+    uses: ./.github/workflows/tagversion.yml
     
   build:
     needs: tagversion
-    uses: philips-software/roslyn-analyzers/.github/workflows/dotnetcore.yml@bcollamore-semver
+    uses: ./.github/workflows/dotnetcore.yml
     with:
       new_tag: ${{ needs.tagversion.outputs.new_tag }}
       new_version: ${{ needs.tagversion.outputs.new_version }}
 
   sonarcloud:
-    uses: philips-software/roslyn-analyzers/.github/workflows/sonarcloud.yml@master
+    uses: ./.github/workflows/sonarcloud.yml
     secrets:
       sonar-auth-token: ${{ secrets.SONAR_TOKEN }}
       
   docupdate:
     if: ${{ github.event_name == 'pull_request' }}
-    uses: philips-software/roslyn-analyzers/.github/workflows/doc-update.yml@master
+    uses: ./.github/workflows/doc-update.yml
 
   dogfood:
     if: ${{ github.event_name == 'pull_request' }}
-    uses: philips-software/roslyn-analyzers/.github/workflows/dogfood.yml@bcollamore-semver
+    uses: ./.github/workflows/dogfood.yml
 
   performance:
-    uses: philips-software/roslyn-analyzers/.github/workflows/performance.yml@master
+    uses: ./.github/workflows/performance.yml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,5 @@ jobs:
         pre_release_branches: ${{ env.GITHUB_REF_NAME }}
         tag_prefix: ''
         append_to_pre_release_tag: -alpha
+#        custom_tag: TODO for first release
+        

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -22,7 +22,6 @@ jobs:
           <Project>
             <PropertyGroup>
               <PackageId>$(MSBuildProjectName).Dogfood</PackageId>
-              <Version>1.0.3</Version>
             </PropertyGroup>
           </Project>
           EOF
@@ -35,23 +34,23 @@ jobs:
           cat > ./Directory.Build.props << EOF
           <Project>
             <ItemGroup>
-              <PackageReference Include="Philips.CodeAnalysis.MaintainabilityAnalyzers.Dogfood" Version="1.0.3">
+              <PackageReference Include="Philips.CodeAnalysis.MaintainabilityAnalyzers.Dogfood" Version="1.0.0">
                 <PrivateAssets>all</PrivateAssets>
                 <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
               </PackageReference>
-              <PackageReference Include="Philips.CodeAnalysis.DuplicateCodeAnalyzer.Dogfood" Version="1.0.3">
+              <PackageReference Include="Philips.CodeAnalysis.DuplicateCodeAnalyzer.Dogfood" Version="1.0.0">
                 <PrivateAssets>all</PrivateAssets>
                 <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
               </PackageReference>
-              <PackageReference Include="Philips.CodeAnalysis.SecurityAnalyzers.Dogfood" Version="1.0.3">
+              <PackageReference Include="Philips.CodeAnalysis.SecurityAnalyzers.Dogfood" Version="1.0.0">
                 <PrivateAssets>all</PrivateAssets>
                 <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
               </PackageReference>
-              <PackageReference Include="Philips.CodeAnalysis.MsTestAnalyzers.Dogfood" Version="1.0.3">
+              <PackageReference Include="Philips.CodeAnalysis.MsTestAnalyzers.Dogfood" Version="1.0.0">
                 <PrivateAssets>all</PrivateAssets>
                 <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
               </PackageReference>
-              <PackageReference Include="Philips.CodeAnalysis.MoqAnalyzers.Dogfood" Version="1.0.3">
+              <PackageReference Include="Philips.CodeAnalysis.MoqAnalyzers.Dogfood" Version="1.0.0">
                 <PrivateAssets>all</PrivateAssets>
                 <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
               </PackageReference>

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -34,6 +34,9 @@ jobs:
           rm -f ./Directory.Build.props
           cat > ./Directory.Build.props << EOF
           <Project>
+            <PropertyGroup>
+              <FileVersion>1.0.0</FileVersion>
+            </PropertyGroup>
             <ItemGroup>
               <PackageReference Include="Philips.CodeAnalysis.MaintainabilityAnalyzers.Dogfood" Version="1.0.0">
                 <PrivateAssets>all</PrivateAssets>

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -22,6 +22,7 @@ jobs:
           <Project>
             <PropertyGroup>
               <PackageId>$(MSBuildProjectName).Dogfood</PackageId>
+              <FileVersion>1.0.0</FileVersion>
             </PropertyGroup>
           </Project>
           EOF

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -22,7 +22,7 @@ jobs:
           <Project>
             <PropertyGroup>
               <PackageId>$(MSBuildProjectName).Dogfood</PackageId>
-              <FileVersion>1.0.0</FileVersion>
+              <FileVersion>1.0.0.0</FileVersion>
             </PropertyGroup>
           </Project>
           EOF

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -22,7 +22,6 @@ jobs:
           <Project>
             <PropertyGroup>
               <PackageId>$(MSBuildProjectName).Dogfood</PackageId>
-              <FileVersion>1.0.0</FileVersion>
             </PropertyGroup>
           </Project>
           EOF

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -22,7 +22,6 @@ jobs:
           <Project>
             <PropertyGroup>
               <PackageId>$(MSBuildProjectName).Dogfood</PackageId>
-              <PackageVersion>1.0.3</PackageVersion>
             </PropertyGroup>
           </Project>
           EOF
@@ -35,23 +34,23 @@ jobs:
           cat > ./Directory.Build.props << EOF
           <Project>
             <ItemGroup>
-              <PackageReference Include="Philips.CodeAnalysis.MaintainabilityAnalyzers.Dogfood" Version="1.0.3">
+              <PackageReference Include="Philips.CodeAnalysis.MaintainabilityAnalyzers.Dogfood" Version="1.0.0">
                 <PrivateAssets>all</PrivateAssets>
                 <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
               </PackageReference>
-              <PackageReference Include="Philips.CodeAnalysis.DuplicateCodeAnalyzer.Dogfood" Version="1.0.3">
+              <PackageReference Include="Philips.CodeAnalysis.DuplicateCodeAnalyzer.Dogfood" Version="1.0.0">
                 <PrivateAssets>all</PrivateAssets>
                 <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
               </PackageReference>
-              <PackageReference Include="Philips.CodeAnalysis.SecurityAnalyzers.Dogfood" Version="1.0.3">
+              <PackageReference Include="Philips.CodeAnalysis.SecurityAnalyzers.Dogfood" Version="1.0.0">
                 <PrivateAssets>all</PrivateAssets>
                 <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
               </PackageReference>
-              <PackageReference Include="Philips.CodeAnalysis.MsTestAnalyzers.Dogfood" Version="1.0.3">
+              <PackageReference Include="Philips.CodeAnalysis.MsTestAnalyzers.Dogfood" Version="1.0.0">
                 <PrivateAssets>all</PrivateAssets>
                 <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
               </PackageReference>
-              <PackageReference Include="Philips.CodeAnalysis.MoqAnalyzers.Dogfood" Version="1.0.3">
+              <PackageReference Include="Philips.CodeAnalysis.MoqAnalyzers.Dogfood" Version="1.0.0">
                 <PrivateAssets>all</PrivateAssets>
                 <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
               </PackageReference>

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -22,6 +22,7 @@ jobs:
           <Project>
             <PropertyGroup>
               <PackageId>$(MSBuildProjectName).Dogfood</PackageId>
+              <Version>1.0.0</Version>
               <FileVersion>1.0.0</FileVersion>
             </PropertyGroup>
           </Project>

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -22,7 +22,6 @@ jobs:
           <Project>
             <PropertyGroup>
               <PackageId>$(MSBuildProjectName).Dogfood</PackageId>
-              <FileVersion>1.0.0.0</FileVersion>
             </PropertyGroup>
           </Project>
           EOF

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -22,8 +22,7 @@ jobs:
           <Project>
             <PropertyGroup>
               <PackageId>$(MSBuildProjectName).Dogfood</PackageId>
-              <Version>1.0.0</Version>
-              <FileVersion>1.0.0</FileVersion>
+              <Version>1.0.3</Version>
             </PropertyGroup>
           </Project>
           EOF
@@ -36,23 +35,23 @@ jobs:
           cat > ./Directory.Build.props << EOF
           <Project>
             <ItemGroup>
-              <PackageReference Include="Philips.CodeAnalysis.MaintainabilityAnalyzers.Dogfood" Version="1.0.0">
+              <PackageReference Include="Philips.CodeAnalysis.MaintainabilityAnalyzers.Dogfood" Version="1.0.3">
                 <PrivateAssets>all</PrivateAssets>
                 <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
               </PackageReference>
-              <PackageReference Include="Philips.CodeAnalysis.DuplicateCodeAnalyzer.Dogfood" Version="1.0.0">
+              <PackageReference Include="Philips.CodeAnalysis.DuplicateCodeAnalyzer.Dogfood" Version="1.0.3">
                 <PrivateAssets>all</PrivateAssets>
                 <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
               </PackageReference>
-              <PackageReference Include="Philips.CodeAnalysis.SecurityAnalyzers.Dogfood" Version="1.0.0">
+              <PackageReference Include="Philips.CodeAnalysis.SecurityAnalyzers.Dogfood" Version="1.0.3">
                 <PrivateAssets>all</PrivateAssets>
                 <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
               </PackageReference>
-              <PackageReference Include="Philips.CodeAnalysis.MsTestAnalyzers.Dogfood" Version="1.0.0">
+              <PackageReference Include="Philips.CodeAnalysis.MsTestAnalyzers.Dogfood" Version="1.0.3">
                 <PrivateAssets>all</PrivateAssets>
                 <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
               </PackageReference>
-              <PackageReference Include="Philips.CodeAnalysis.MoqAnalyzers.Dogfood" Version="1.0.0">
+              <PackageReference Include="Philips.CodeAnalysis.MoqAnalyzers.Dogfood" Version="1.0.3">
                 <PrivateAssets>all</PrivateAssets>
                 <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
               </PackageReference>

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -28,7 +28,7 @@ jobs:
           cat > ./Directory.Build.props << 'EOF'
           <Project>
             <PropertyGroup>
-              <PackageVersion>${{ inputs.new_tag }}</PackageVersion>
+              <Version>${{ inputs.new_tag }}</Version>
             </PropertyGroup>
           </Project>
           EOF

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -1,6 +1,13 @@
 name: .NET Core
 on:
   workflow_call:
+    inputs:
+      new_tag:
+        type: string
+        required: false
+      new_version:
+        type: string
+        required: false
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -11,7 +18,12 @@ jobs:
         with:
           dotnet-version: |
             7.0.x
-            
+
+      - name: Set version
+        run: |
+          echo New Tag:  ${{ inputs.new_tag }}
+          echo New Version:  ${{ inputs.new_version }}
+          
       - name: Build
         run: |
           dotnet build --configuration Release

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -41,10 +41,38 @@ jobs:
       - name: Test
         run: dotnet test --configuration Release --logger "trx;LogFileName=test-results.trx"
         
-      - name: Upload Artifact
+      - name: Upload MaintainabilityAnalyzers Artifact
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
         with:
           name: MaintainabilityAnalyzers 
           retention-days: 1
           path: ./Packages/Philips.CodeAnalysis.MaintainabilityAnalyzers.*.nupkg
+
+      - name: Upload DuplicateCodeAnalyzer Artifact
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
+        with:
+          name: DuplicateCodeAnalyzer
+          retention-days: 1
+          path: ./Packages/Philips.CodeAnalysis.DuplicateCodeAnalyzer.*.nupkg
+
+      - name: Upload MoqAnalyzers Artifact
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
+        with:
+          name: MoqAnalyzers
+          retention-days: 1
+          path: ./Packages/Philips.CodeAnalysis.MoqAnalyzers.*.nupkg
+
+      - name: Upload MsTestAnalyzers Artifact
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
+        with:
+          name: MsTestAnalyzers
+          retention-days: 1
+          path: ./Packages/Philips.CodeAnalysis.MsTestAnalyzers.*.nupkg
+
+      - name: Upload SecurityAnalyzers Artifact
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
+        with:
+          name: SecurityAnalyzers
+          retention-days: 1
+          path: ./Packages/Philips.CodeAnalysis.SecurityAnalyzers.*.nupkg
     

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -42,7 +42,7 @@ jobs:
         run: dotnet test --configuration Release --logger "trx;LogFileName=test-results.trx"
         
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
         with:
           name: MaintainabilityAnalyzers 
           retention-days: 1

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -20,13 +20,25 @@ jobs:
             7.0.x
 
       - name: Set version
+        if: ${{ inputs.new_tag }}
         run: |
           echo New Tag:  ${{ inputs.new_tag }}
           echo New Version:  ${{ inputs.new_version }}
           
+          cat > ./Directory.Build.props << 'EOF'
+          <Project>
+            <PropertyGroup>
+              <PackageVersion>${{ inputs.new_tag }}</PackageVersion>
+            </PropertyGroup>
+          </Project>
+          EOF
+          
       - name: Build
         run: |
           dotnet build --configuration Release
+          cd ./Packages
+          ls
+          cd ../
           
       - name: Test
         run: dotnet test --configuration Release --logger "trx;LogFileName=test-results.trx"

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -36,10 +36,14 @@ jobs:
       - name: Build
         run: |
           dotnet build --configuration Release
-          cd ./Packages
-          ls
-          cd ../
           
       - name: Test
         run: dotnet test --configuration Release --logger "trx;LogFileName=test-results.trx"
         
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: MaintainabilityAnalyzers 
+          retention-days: 1
+          path: ./Packages/Philips.CodeAnalysis.MaintainabilityAnalyzers.*.nupkg
+    

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -29,6 +29,7 @@ jobs:
           <Project>
             <PropertyGroup>
               <Version>${{ inputs.new_tag }}</Version>
+              <FileVersion>${{ inputs.new_tag }}</FileVersion>
             </PropertyGroup>
           </Project>
           EOF

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -20,7 +20,6 @@ jobs:
           <Project>
             <PropertyGroup>
               <PackageId>$(MSBuildProjectName).Dogfood</PackageId>
-              <PackageVersion>1.0.0</PackageVersion>
             </PropertyGroup>
           </Project>
           EOF
@@ -67,6 +66,9 @@ jobs:
           rm -f ./Directory.Build.props
           cat > ./Directory.Build.props << EOF
           <Project>
+            <PropertyGroup>
+              <FileVersion>1.0.0</FileVersion>
+            </PropertyGroup>
             <ItemGroup>
               <PackageReference Include="Philips.CodeAnalysis.MaintainabilityAnalyzers.Dogfood" Version="1.0.0">
                 <PrivateAssets>all</PrivateAssets>

--- a/.github/workflows/tagversion.yml
+++ b/.github/workflows/tagversion.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - name: Bump version
       id: tag_version
-      uses: mathieudutour/github-tag-action@fcfbdceb3093f6d85a3b194740f8c6cec632f4e2 // 6.1
+      uses: mathieudutour/github-tag-action@fcfbdceb3093f6d85a3b194740f8c6cec632f4e2 # 6.1
       with:
         dry_run: true
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tagversion.yml
+++ b/.github/workflows/tagversion.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - name: Bump version
       id: tag_version
-      uses: mathieudutour/github-tag-action@v6.1
+      uses: mathieudutour/github-tag-action@fcfbdceb3093f6d85a3b194740f8c6cec632f4e2 // 6.1
       with:
         dry_run: true
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tagversion.yml
+++ b/.github/workflows/tagversion.yml
@@ -1,0 +1,28 @@
+name: TagVersion
+
+on:
+  workflow_call:
+      
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Tag Version
+    steps:
+    - name: Bump version
+      id: tag_version
+      uses: mathieudutour/github-tag-action@v6.1
+      with:
+        dry_run: true
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        pre_release_branches: "${{ github.head_ref || github.ref_name }},master,main"
+        tag_prefix: ""
+        release_branches: ""
+        append_to_pre_release_tag: prerelease
+    - name: Results
+      run: |
+        echo New Tag:  ${{ steps.tag_version.outputs.new_tag }}
+        echo New Version:  ${{ steps.tag_version.outputs.new_version }}
+        
+    outputs:
+      new_tag: ${{ steps.tag_version.outputs.new_tag }}
+      new_version: ${{ steps.tag_version.outputs.new_version }}

--- a/.github/workflows/tagversion.yml
+++ b/.github/workflows/tagversion.yml
@@ -2,9 +2,13 @@ name: TagVersion
 
 on:
   workflow_call:
-      
+    outputs:
+      new_tag:
+        value: ${{ jobs.tagversion.outputs.new_tag }}
+      new_version:
+        value: ${{ jobs.tagversion.outputs.new_version }}      
 jobs:
-  build:
+  tagversion:
     runs-on: ubuntu-latest
     name: Tag Version
     steps:

--- a/Philips.CodeAnalysis.AnalyzerPerformance/Philips.CodeAnalysis.AnalyzerPerformance.csproj
+++ b/Philips.CodeAnalysis.AnalyzerPerformance/Philips.CodeAnalysis.AnalyzerPerformance.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.0.3.0</Version>
+    <AssemblyVersion>1.0.3.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Philips.CodeAnalysis.Benchmark/Philips.CodeAnalysis.Benchmark.csproj
+++ b/Philips.CodeAnalysis.Benchmark/Philips.CodeAnalysis.Benchmark.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.0.3.0</Version>
+    <AssemblyVersion>1.0.3.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Philips.CodeAnalysis.Common/Philips.CodeAnalysis.Common.csproj
+++ b/Philips.CodeAnalysis.Common/Philips.CodeAnalysis.Common.csproj
@@ -9,7 +9,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <ReportAnalyzer>true</ReportAnalyzer>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.0.3.0</Version>
+    <AssemblyVersion>1.0.3.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />

--- a/Philips.CodeAnalysis.DuplicateCodeAnalyzer/Philips.CodeAnalysis.DuplicateCodeAnalyzer.csproj
+++ b/Philips.CodeAnalysis.DuplicateCodeAnalyzer/Philips.CodeAnalysis.DuplicateCodeAnalyzer.csproj
@@ -33,8 +33,6 @@
     <PackageTags>CSharp MsTest Roslyn CodeAnalysis analyzers cpd duplicate Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <Version>1.1.7</Version>
-    <FileVersion>1.1.7</FileVersion>
     <AssemblyVersion>1.0.3.0</AssemblyVersion>
   </PropertyGroup>
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -122,12 +122,10 @@
 	    * Introduce PH2136: Avoid duplicate strings.
       * Introduce PH2139: Enable documentation creation.
     </PackageReleaseNotes>
-	  <Copyright>© 2019-2023 Koninklijke Philips N.V.</Copyright>
-	  <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>
+    <Copyright>© 2019-2023 Koninklijke Philips N.V.</Copyright>
+    <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <Version>1.2.32</Version>
-    <FileVersion>1.2.32</FileVersion>
     <AssemblyVersion>1.0.3.0</AssemblyVersion>
   </PropertyGroup>
 

--- a/Philips.CodeAnalysis.MoqAnalyzers/Philips.CodeAnalysis.MoqAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MoqAnalyzers/Philips.CodeAnalysis.MoqAnalyzers.csproj
@@ -29,8 +29,6 @@
     <PackageTags>CSharp MsTest Roslyn CodeAnalysis analyzers moq Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <Version>1.1.0</Version>
-    <FileVersion>1.1.0.0</FileVersion>
     <AssemblyVersion>1.0.3.0</AssemblyVersion>
   </PropertyGroup>
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/Philips.CodeAnalysis.MsTestAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/Philips.CodeAnalysis.MsTestAnalyzers.csproj
@@ -29,8 +29,6 @@
     <PackageTags>CSharp MsTest Roslyn CodeAnalysis analyzers Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <Version>1.1.7</Version>
-    <FileVersion>1.1.7</FileVersion>
     <AssemblyVersion>1.0.3.0</AssemblyVersion>
   </PropertyGroup>
   

--- a/Philips.CodeAnalysis.SecurityAnalyzers/Philips.CodeAnalysis.SecurityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.SecurityAnalyzers/Philips.CodeAnalysis.SecurityAnalyzers.csproj
@@ -32,8 +32,6 @@
     <PackageTags>CSharp Security Roslyn CodeAnalysis analyzers Philips</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <Version>1.0.0</Version>
-    <FileVersion>1.0.0</FileVersion>
     <AssemblyVersion>1.0.3.0</AssemblyVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
This first step creates the artifacts based on the "next" version (which isn't initialized properly yet) and publishes them as a GitHub artifact for 1 day. This will enable local debugging with the packages as desired. The true versioning isn't setup yet (ie dryrun: false). A subsequent step will publish the artifacts to Nuget for main line (still as prerelease) based on the "files" filter.