### PR TITLE
refactor: Single diagnostic code fix provider

### DIFF
--- a/Philips.CodeAnalysis.Common/SingleDiagnosticCodeFixProvider{TSyntax}.cs
+++ b/Philips.CodeAnalysis.Common/SingleDiagnosticCodeFixProvider{TSyntax}.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.Common
 	/// <typeparam name="TSyntax">The <see cref="SyntaxNode"/> type to fix.</typeparam>
 	public abstract class SingleDiagnosticCodeFixProvider<TSyntax> : CodeFixProvider where TSyntax : SyntaxNode
 	{
-		public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId));
+		public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId));
 
 		public sealed override FixAllProvider GetFixAllProvider()
 		{
@@ -39,7 +39,7 @@ namespace Philips.CodeAnalysis.Common
 				context.RegisterCodeFix(
 					CodeAction.Create(
 						title: Title,
-						createChangedDocument: c => ApplyFix(context.Document, node, c),
+						createChangedDocument: c => ApplyFix(context.Document, node, diagnostic.Properties, c),
 						equivalenceKey: Title),
 					diagnostic);
 			}
@@ -49,7 +49,7 @@ namespace Philips.CodeAnalysis.Common
 
 		protected abstract DiagnosticId DiagnosticId { get; }
 
-		protected abstract Task<Document> ApplyFix(Document document, TSyntax node, CancellationToken cancellationToken);
+		protected abstract Task<Document> ApplyFix(Document document, TSyntax node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken);
 
 		protected virtual TSyntax GetNode(SyntaxNode root, TextSpan diagnosticSpan)
 		{

--- a/Philips.CodeAnalysis.Common/SingleDiagnosticCodeFixProvider{TSyntax}.cs
+++ b/Philips.CodeAnalysis.Common/SingleDiagnosticCodeFixProvider{TSyntax}.cs
@@ -1,0 +1,60 @@
+﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Philips.CodeAnalysis.Common
+{
+	/// <summary>
+	/// Abstract base class for <see cref="CodeFixProvider"/> that fix a single Diagnostic in a source file.
+	/// </summary>
+	/// <typeparam name="TSyntax">The <see cref="SyntaxNode"/> type to fix.</typeparam>
+	public abstract class SingleDiagnosticCodeFixProvider<TSyntax> : CodeFixProvider where TSyntax : SyntaxNode
+	{
+		public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId));
+
+		public sealed override FixAllProvider GetFixAllProvider()
+		{
+			return WellKnownFixAllProviders.BatchFixer;
+		}
+
+		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+		{
+			SyntaxNode root =
+				await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+			Diagnostic diagnostic = context.Diagnostics.First();
+			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
+
+			if (root != null)
+			{
+				TSyntax node = GetNode(root, diagnosticSpan);
+
+				context.RegisterCodeFix(
+					CodeAction.Create(
+						title: Title,
+						createChangedDocument: c => ApplyFix(context.Document, node, c),
+						equivalenceKey: Title),
+					diagnostic);
+			}
+		}
+
+		protected abstract string Title { get; }
+
+		protected abstract DiagnosticId DiagnosticId { get; }
+
+		protected abstract Task<Document> ApplyFix(Document document, TSyntax node, CancellationToken cancellationToken);
+
+		protected virtual TSyntax GetNode(SyntaxNode root, TextSpan diagnosticSpan)
+		{
+			SyntaxToken token = root.FindToken(diagnosticSpan.Start);
+			return token.Parent?.AncestorsAndSelf().OfType<TSyntax>().FirstOrDefault();
+		}
+	}
+}

--- a/Philips.CodeAnalysis.Common/SolutionCodeFixProvider{TSyntax}.cs
+++ b/Philips.CodeAnalysis.Common/SolutionCodeFixProvider{TSyntax}.cs
@@ -1,0 +1,86 @@
+﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Philips.CodeAnalysis.Common
+{
+	/// <summary>
+	/// Abstract base class for <see cref="CodeFixProvider"/> that fix an entire solution.
+	/// </summary>
+	/// <typeparam name="TSyntax">The <see cref="SyntaxNode"/> type to fix.</typeparam>
+	public abstract class SolutionCodeFixProvider<TSyntax> : CodeFixProvider where TSyntax : SyntaxNode
+	{
+		public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId));
+
+		public sealed override FixAllProvider GetFixAllProvider()
+		{
+			return WellKnownFixAllProviders.BatchFixer;
+		}
+
+		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+		{
+			SyntaxNode root =
+				await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+			var additionalFile = GetAdditionalFileName();
+			if (!string.IsNullOrEmpty(additionalFile))
+			{
+				AdditionalFileDocument = GetDocument(context.Document.Project, additionalFile);
+
+				if (AdditionalFileDocument == null)
+				{
+					return;
+				}
+			}
+
+			Diagnostic diagnostic = context.Diagnostics.First();
+			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
+
+			if (root != null)
+			{
+				SyntaxNode token = root.FindToken(diagnosticSpan.Start).Parent;
+				if (token != null)
+				{
+					TSyntax node = GetNode(token);
+
+					context.RegisterCodeFix(
+						CodeAction.Create(
+							title: Title,
+							createChangedSolution: c => ApplyFix(context.Document, node, c),
+							equivalenceKey: Title),
+						diagnostic);
+				}
+			}
+		}
+
+		protected TextDocument AdditionalFileDocument { get; private set; }
+
+		protected abstract string Title { get; }
+
+		protected abstract DiagnosticId DiagnosticId { get; }
+
+		protected abstract Task<Solution> ApplyFix(Document document, TSyntax node, CancellationToken cancellationToken);
+
+		protected virtual string GetAdditionalFileName()
+		{
+			return null;
+		}
+
+		protected virtual TSyntax GetNode(SyntaxNode token)
+		{
+			return token.AncestorsAndSelf().OfType<TSyntax>().First();
+		}
+
+		private static TextDocument GetDocument(Project project, string fileName)
+		{
+			return project.AdditionalDocuments.FirstOrDefault(doc => doc.Name.Equals(fileName, StringComparison.Ordinal));
+		}
+	}
+}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidArrayListCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidArrayListCodeFixProvider.cs
@@ -19,7 +19,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 	public class AvoidArrayListCodeFixProvider : CodeFixProvider
 	{
 		private const string Title = "Replace ArrayList with List<T>";
-		private readonly SyntaxAnnotation annotation = new("ReplaceArrayList");
+		private readonly SyntaxAnnotation _annotation = new("ReplaceArrayList");
 
 		public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId.AvoidArrayList));
 
@@ -52,11 +52,9 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			{
 				TypeSyntax type = variable?.Type;
 				root = ReplaceTypeWithList(root, type);
-				VariableDeclarationSyntax replacedVariable = root.GetAnnotatedNodes(annotation).FirstOrDefault()?.Ancestors()
+				VariableDeclarationSyntax replacedVariable = root.GetAnnotatedNodes(_annotation).FirstOrDefault()?.Ancestors()
 					.OfType<VariableDeclarationSyntax>().FirstOrDefault();
-				if (
-					replacedVariable != null &&
-					replacedVariable.Variables[0]?.Initializer?.Value is ObjectCreationExpressionSyntax creation)
+				if (replacedVariable?.Variables[0]?.Initializer?.Value is ObjectCreationExpressionSyntax creation)
 				{
 					root = ReplaceTypeWithList(root, creation.Type);
 				}
@@ -73,7 +71,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			if (root != null && existingType != null)
 			{
 				TypeSyntax parameterType = SyntaxFactory.ParseTypeName("int")
-					.WithAdditionalAnnotations(RenameAnnotation.Create(), annotation);
+					.WithAdditionalAnnotations(RenameAnnotation.Create(), _annotation);
 				TypeSyntax list = CreateGenericTypeSyntax(StringConstants.List, parameterType).WithTriviaFrom(existingType).WithAdditionalAnnotations(Formatter.Annotation);
 
 				newRoot = root.ReplaceNode(existingType, list);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidArrayListCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidArrayListCodeFixProvider.cs
@@ -3,6 +3,7 @@
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -10,59 +11,35 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Text;
 using Philips.CodeAnalysis.Common;
 
 namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 {
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AvoidArrayListCodeFixProvider)), Shared]
-	public class AvoidArrayListCodeFixProvider : CodeFixProvider
+	public class AvoidArrayListCodeFixProvider : SingleDiagnosticCodeFixProvider<VariableDeclarationSyntax>
 	{
-		private const string Title = "Replace ArrayList with List<T>";
 		private readonly SyntaxAnnotation _annotation = new("ReplaceArrayList");
 
-		public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId.AvoidArrayList));
+		protected override string Title => "Replace ArrayList with List<T>";
 
-		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+		protected override DiagnosticId DiagnosticId => DiagnosticId.AvoidArrayList;
+
+		protected override async Task<Document> ApplyFix(Document document, VariableDeclarationSyntax node, ImmutableDictionary<string, string> properties,
+			CancellationToken cancellationToken)
 		{
-			SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+			SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken);
 
-			Diagnostic diagnostic = context.Diagnostics.First();
-			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
-
-			if (root != null)
+			VariableDeclarationSyntax variable = node;
+			TypeSyntax type = variable?.Type;
+			root = ReplaceTypeWithList(root, type);
+			VariableDeclarationSyntax replacedVariable = root.GetAnnotatedNodes(_annotation).FirstOrDefault()?.Ancestors()
+				.OfType<VariableDeclarationSyntax>().FirstOrDefault();
+			if (replacedVariable?.Variables[0]?.Initializer?.Value is ObjectCreationExpressionSyntax creation)
 			{
-				SyntaxToken token = root.FindToken(diagnosticSpan.Start);
-
-				// Register a code action that will invoke the fix.
-				context.RegisterCodeFix(
-					CodeAction.Create(
-						title: Title,
-						createChangedDocument: c => SwapType(context.Document, token),
-						equivalenceKey: Title),
-					diagnostic);
-			}
-		}
-
-		private async Task<Document> SwapType(Document document, SyntaxToken token)
-		{
-			SyntaxNode root = await document.GetSyntaxRootAsync();
-
-			if (token.Parent?.Parent is VariableDeclarationSyntax variable)
-			{
-				TypeSyntax type = variable?.Type;
-				root = ReplaceTypeWithList(root, type);
-				VariableDeclarationSyntax replacedVariable = root.GetAnnotatedNodes(_annotation).FirstOrDefault()?.Ancestors()
-					.OfType<VariableDeclarationSyntax>().FirstOrDefault();
-				if (replacedVariable?.Variables[0]?.Initializer?.Value is ObjectCreationExpressionSyntax creation)
-				{
-					root = ReplaceTypeWithList(root, creation.Type);
-				}
-
-				return document.WithSyntaxRoot(root);
+				root = ReplaceTypeWithList(root, creation.Type);
 			}
 
-			return document;
+			return document.WithSyntaxRoot(root);
 		}
 
 		private SyntaxNode ReplaceTypeWithList(SyntaxNode root, TypeSyntax existingType)
@@ -78,11 +55,6 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			}
 
 			return newRoot;
-		}
-
-		public override FixAllProvider GetFixAllProvider()
-		{
-			return WellKnownFixAllProviders.BatchFixer;
 		}
 
 		/// <summary>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidEmptyStatementBlocksCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidEmptyStatementBlocksCodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,7 +20,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 		protected override DiagnosticId DiagnosticId => DiagnosticId.AvoidEmptyStatement;
 
-		protected override async Task<Document> ApplyFix(Document document, EmptyStatementSyntax node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, EmptyStatementSyntax node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
 		{
 			SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 			root = root.RemoveNode(node, SyntaxRemoveOptions.KeepExteriorTrivia).WithAdditionalAnnotations(Formatter.Annotation);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidEmptyStatementBlocksCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidEmptyStatementBlocksCodeFixProvider.cs
@@ -1,57 +1,25 @@
 ﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
 
-using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Text;
 using Philips.CodeAnalysis.Common;
 
 namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 {
 
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AvoidEmptyStatementBlocksCodeFixProvider)), Shared]
-	public class AvoidEmptyStatementBlocksCodeFixProvider : CodeFixProvider
+	public class AvoidEmptyStatementBlocksCodeFixProvider : SingleDiagnosticCodeFixProvider<EmptyStatementSyntax>
 	{
-		private const string Title = "Remove empty statement";
+		protected override string Title => "Remove empty statement";
 
-		public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId.AvoidEmptyStatement));
-		public sealed override FixAllProvider GetFixAllProvider()
-		{
-			return WellKnownFixAllProviders.BatchFixer;
-		}
+		protected override DiagnosticId DiagnosticId => DiagnosticId.AvoidEmptyStatement;
 
-		public override async Task RegisterCodeFixesAsync(CodeFixContext context)
-		{
-			SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-
-			Diagnostic diagnostic = context.Diagnostics.First();
-
-			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
-
-			if (root != null)
-			{
-				if (root.FindNode(diagnosticSpan) is not EmptyStatementSyntax node)
-				{
-					return;
-				}
-
-				context.RegisterCodeFix(
-					CodeAction.Create(
-						title: Title,
-						createChangedDocument: c => RemoveEmptyStatement(context.Document, node, c),
-						equivalenceKey: Title),
-					diagnostic);
-			}
-		}
-
-		private async Task<Document> RemoveEmptyStatement(Document document, EmptyStatementSyntax node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, EmptyStatementSyntax node, CancellationToken cancellationToken)
 		{
 			SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 			root = root.RemoveNode(node, SyntaxRemoveOptions.KeepExteriorTrivia).WithAdditionalAnnotations(Formatter.Annotation);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidEmptyTypeInitializerCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidEmptyTypeInitializerCodeFixProvider.cs
@@ -1,61 +1,34 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
-using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Philips.CodeAnalysis.Common;
 
 namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 {
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AvoidEmptyTypeInitializerCodeFixProvider)), Shared]
-	public class AvoidEmptyTypeInitializerCodeFixProvider : CodeFixProvider
+	public class AvoidEmptyTypeInitializerCodeFixProvider : SingleDiagnosticCodeFixProvider<ConstructorDeclarationSyntax>
 	{
-		private const string Title = "Don't have empty constructors";
+		protected override string Title => "Don't have empty constructors";
 
-		public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId.AvoidEmptyTypeInitializer));
+		protected override DiagnosticId DiagnosticId => DiagnosticId.AvoidEmptyTypeInitializer;
 
-		public sealed override FixAllProvider GetFixAllProvider()
+		protected override async Task<Document> ApplyFix(Document document, ConstructorDeclarationSyntax node, CancellationToken cancellationToken)
 		{
-			return WellKnownFixAllProviders.BatchFixer;
-		}
+			SyntaxNode rootNode = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
-		public override async Task RegisterCodeFixesAsync(CodeFixContext context)
-		{
-			SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+			SyntaxTrivia[] leadingTrivia = node.GetLeadingTrivia().Where(x => !(x.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia) || x.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia))).ToArray();
+			ConstructorDeclarationSyntax newCtor = node.WithLeadingTrivia(leadingTrivia);
 
-			Diagnostic diagnostic = context.Diagnostics.First();
-			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
+			rootNode = rootNode.ReplaceNode(node, newCtor);
 
-			// Find the method declaration identified by the diagnostic.
-			var token = (ConstructorDeclarationSyntax)root.FindNode(diagnosticSpan);
-
-			// Register a code action that will invoke the fix.
-			context.RegisterCodeFix(
-				CodeAction.Create(
-					title: Title,
-					createChangedDocument: c => RemoveConstructor(context.Document, token, c),
-					equivalenceKey: Title),
-				diagnostic);
-		}
-
-		private async Task<Document> RemoveConstructor(Document document, ConstructorDeclarationSyntax ctor, CancellationToken c)
-		{
-			SyntaxNode rootNode = await document.GetSyntaxRootAsync(c).ConfigureAwait(false);
-
-			SyntaxTrivia[] leadingTrivia = ctor.GetLeadingTrivia().Where(x => !(x.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia) || x.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia))).ToArray();
-			ConstructorDeclarationSyntax newCtor = ctor.WithLeadingTrivia(leadingTrivia);
-
-			rootNode = rootNode.ReplaceNode(ctor, newCtor);
-
-			ClassDeclarationSyntax cls = rootNode.DescendantNodesAndSelf().OfType<ClassDeclarationSyntax>().First(x => x.Identifier.Text == ctor.Identifier.Text);
+			ClassDeclarationSyntax cls = rootNode.DescendantNodesAndSelf().OfType<ClassDeclarationSyntax>().First(x => x.Identifier.Text == node.Identifier.Text);
 
 			var newConstructor = (ConstructorDeclarationSyntax)cls.Members.First(x => x.IsKind(SyntaxKind.ConstructorDeclaration) && ((ConstructorDeclarationSyntax)x).Modifiers.Any(SyntaxKind.StaticKeyword));
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidEmptyTypeInitializerCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidEmptyTypeInitializerCodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
@@ -19,7 +20,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 		protected override DiagnosticId DiagnosticId => DiagnosticId.AvoidEmptyTypeInitializer;
 
-		protected override async Task<Document> ApplyFix(Document document, ConstructorDeclarationSyntax node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, ConstructorDeclarationSyntax node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
 		{
 			SyntaxNode rootNode = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidInvocationAsArgumentCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidInvocationAsArgumentCodeFixProvider.cs
@@ -1,9 +1,7 @@
 ﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -19,23 +17,14 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 {
 
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AvoidInvocationAsArgumentCodeFixProvider)), Shared]
-	public class AvoidInvocationAsArgumentCodeFixProvider : CodeFixProvider
+	public class AvoidInvocationAsArgumentCodeFixProvider : SingleDiagnosticCodeFixProvider<ExpressionSyntax>
 	{
-		private const string Title = "Extract local variable";
+		protected override string Title => "Extract local variable";
 
-		public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId.AvoidInvocationAsArgument));
-		public sealed override FixAllProvider GetFixAllProvider()
+		protected override DiagnosticId DiagnosticId => DiagnosticId.AvoidInvocationAsArgument;
+
+		protected override ExpressionSyntax GetNode(SyntaxNode root, TextSpan diagnosticSpan)
 		{
-			return WellKnownFixAllProviders.BatchFixer;
-		}
-
-		public override async Task RegisterCodeFixesAsync(CodeFixContext context)
-		{
-			SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-
-			Diagnostic diagnostic = context.Diagnostics.First();
-			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
-
 			// Find the nested method call identified by the diagnostic.
 			SyntaxNode node = root.FindNode(diagnosticSpan, false, true);
 			var expressionNode = node as ExpressionSyntax;
@@ -52,27 +41,18 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			fullExistingExpressionSyntax ??= expressionNode.FirstAncestorOrSelf<IfStatementSyntax>();
 			fullExistingExpressionSyntax ??= expressionNode.FirstAncestorOrSelf<WhileStatementSyntax>();
 
-			if (fullExistingExpressionSyntax != null)
-			{
-				// Register a code action that will invoke the fix.
-				context.RegisterCodeFix(
-					CodeAction.Create(
-						title: Title,
-						createChangedDocument: c => ExtractLocalVariable(context.Document, expressionNode, c),
-						equivalenceKey: Title),
-					diagnostic);
-			}
+			return fullExistingExpressionSyntax == null ? null : expressionNode;
 		}
 
-		private async Task<Document> ExtractLocalVariable(Document document, ExpressionSyntax argumentSyntax, CancellationToken c)
+		protected override async Task<Document> ApplyFix(Document document, ExpressionSyntax node, CancellationToken cancellationToken)
 		{
-			SyntaxNode rootNode = await document.GetSyntaxRootAsync(c).ConfigureAwait(false);
-
-			SemanticModel semanticModel = await document.GetSemanticModelAsync(c).ConfigureAwait(false);
+			SyntaxNode rootNode = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+			SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+			ExpressionSyntax argumentSyntax = node;
 
 			string newName;
 			SyntaxToken identifier;
-			IOperation operation = semanticModel.GetOperation(argumentSyntax, c);
+			IOperation operation = semanticModel.GetOperation(argumentSyntax, cancellationToken);
 			if (operation?.Parent is IArgumentOperation argumentOperation)
 			{
 				IParameterSymbol parameterSymbol = argumentOperation.Parameter;

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidInvocationAsArgumentCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidInvocationAsArgumentCodeFixProvider.cs
@@ -1,6 +1,7 @@
 ﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -44,7 +45,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			return fullExistingExpressionSyntax == null ? null : expressionNode;
 		}
 
-		protected override async Task<Document> ApplyFix(Document document, ExpressionSyntax node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, ExpressionSyntax node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
 		{
 			SyntaxNode rootNode = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 			SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidStaticMethodCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidStaticMethodCodeFixProvider.cs
@@ -1,68 +1,31 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
-using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Philips.CodeAnalysis.Common;
 
 namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 {
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AvoidStaticMethodAnalyzer)), Shared]
-	public class AvoidStaticMethodCodeFixProvider : CodeFixProvider
+	public class AvoidStaticMethodCodeFixProvider : SingleDiagnosticCodeFixProvider<MethodDeclarationSyntax>
 	{
-		private const string Title = "Remove static modifier from method";
+		protected override string Title => "Remove static modifier from method";
 
-		public sealed override ImmutableArray<string> FixableDiagnosticIds
-		{
-			get { return ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId.AvoidStaticMethods)); }
-		}
+		protected override DiagnosticId DiagnosticId => DiagnosticId.AvoidStaticMethods;
 
-		public sealed override FixAllProvider GetFixAllProvider()
-		{
-			return WellKnownFixAllProviders.BatchFixer;
-		}
-
-		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
-		{
-			SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-
-			Diagnostic diagnostic = context.Diagnostics.First();
-			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
-
-			// Find the method declaration identified by the diagnostic.
-			if (root != null)
-			{
-				SyntaxNode syntaxNode = root.FindToken(diagnosticSpan.Start).Parent;
-				if (syntaxNode != null)
-				{
-					MethodDeclarationSyntax methodDeclarationList
-						= syntaxNode.AncestorsAndSelf().OfType<MethodDeclarationSyntax>().First();
-
-					// Register a code action that will invoke the fix.
-					context.RegisterCodeFix(
-						CodeAction.Create(
-							title: Title,
-							createChangedDocument: c => RemoveModifier(context.Document, methodDeclarationList, c),
-							equivalenceKey: Title),
-						diagnostic);
-				}
-			}
-		}
-		private async Task<Document> RemoveModifier(Document document, MethodDeclarationSyntax method, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, MethodDeclarationSyntax node, CancellationToken cancellationToken)
 		{
 			SyntaxNode rootNode = await document.GetSyntaxRootAsync(cancellationToken);
-			SyntaxToken modifierToRemove = method.Modifiers.First(m => m.ValueText == @"static");
-			SyntaxTokenList newModifiers = method.Modifiers.Remove(modifierToRemove);
+			SyntaxToken modifierToRemove = node.Modifiers.First(m => m.ValueText == @"static");
+			SyntaxTokenList newModifiers = node.Modifiers.Remove(modifierToRemove);
 
-			MethodDeclarationSyntax newMethod = method.WithModifiers(newModifiers);
-			SyntaxNode newRoot = rootNode.ReplaceNode(method, newMethod);
+			MethodDeclarationSyntax newMethod = node.WithModifiers(newModifiers);
+			SyntaxNode newRoot = rootNode.ReplaceNode(node, newMethod);
 			Document newDocument = document.WithSyntaxRoot(newRoot);
 			return newDocument;
 		}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidStaticMethodCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidStaticMethodCodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
@@ -18,7 +19,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 		protected override DiagnosticId DiagnosticId => DiagnosticId.AvoidStaticMethods;
 
-		protected override async Task<Document> ApplyFix(Document document, MethodDeclarationSyntax node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, MethodDeclarationSyntax node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
 		{
 			SyntaxNode rootNode = await document.GetSyntaxRootAsync(cancellationToken);
 			SyntaxToken modifierToRemove = node.Modifiers.First(m => m.ValueText == @"static");

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidTaskResultCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidTaskResultCodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿// © 2021 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,7 +21,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 		protected override DiagnosticId DiagnosticId => DiagnosticId.AvoidTaskResult;
 
-		protected override async Task<Document> ApplyFix(Document document, MemberAccessExpressionSyntax node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, MemberAccessExpressionSyntax node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
 		{
 			SyntaxNode rootNode = await document.GetSyntaxRootAsync(cancellationToken);
 			SyntaxTriviaList trivia = node.GetLeadingTrivia();

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidThreadSleepCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidThreadSleepCodeFixProvider.cs
@@ -1,62 +1,25 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
-using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Philips.CodeAnalysis.Common;
 
 namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 {
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AvoidThreadSleepCodeFixProvider)), Shared]
-	public class AvoidThreadSleepCodeFixProvider : CodeFixProvider
+	public class AvoidThreadSleepCodeFixProvider : SingleDiagnosticCodeFixProvider<InvocationExpressionSyntax>
 	{
-		private const string Title = "Remove Thread.Sleep.";
+		protected override string Title => "Remove Thread.Sleep.";
 
-		public sealed override ImmutableArray<string> FixableDiagnosticIds
+		protected override DiagnosticId DiagnosticId => DiagnosticId.AvoidThreadSleep;
+
+		protected override async Task<Document> ApplyFix(Document document, InvocationExpressionSyntax node, CancellationToken cancellationToken)
 		{
-			get { return ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId.AvoidThreadSleep)); }
-		}
-
-		public sealed override FixAllProvider GetFixAllProvider()
-		{
-			return WellKnownFixAllProviders.BatchFixer;
-		}
-
-		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
-		{
-			SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-
-			Diagnostic diagnostic = context.Diagnostics.First();
-			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
-
-			// Find the method declaration identified by the diagnostic.
-			if (root != null)
-			{
-				SyntaxNode node = root.FindToken(diagnosticSpan.Start).Parent;
-				if (node != null)
-				{
-					InvocationExpressionSyntax invocationExpression = node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().First();
-
-					// Register a code action that will invoke the fix.
-					context.RegisterCodeFix(
-						CodeAction.Create(
-							title: Title,
-							createChangedDocument: c => ThreadSleepFix(context.Document, invocationExpression.Parent, c),
-							equivalenceKey: Title),
-						diagnostic);
-				}
-			}
-		}
-
-		private async Task<Document> ThreadSleepFix(Document document, SyntaxNode syntaxNodeExpression, CancellationToken cancellationToken)
-		{
+			SyntaxNode syntaxNodeExpression = node.Parent;
 			SyntaxNode rootNode = await document.GetSyntaxRootAsync(cancellationToken);
 			SyntaxNode newRoot = rootNode.RemoveNode(syntaxNodeExpression, SyntaxRemoveOptions.KeepDirectives);
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidThreadSleepCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidThreadSleepCodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,7 +18,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 		protected override DiagnosticId DiagnosticId => DiagnosticId.AvoidThreadSleep;
 
-		protected override async Task<Document> ApplyFix(Document document, InvocationExpressionSyntax node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, InvocationExpressionSyntax node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
 		{
 			SyntaxNode syntaxNodeExpression = node.Parent;
 			SyntaxNode rootNode = await document.GetSyntaxRootAsync(cancellationToken);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/CallExtensionMethodsAsInstanceMethodsCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/CallExtensionMethodsAsInstanceMethodsCodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
@@ -19,7 +20,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 		protected override DiagnosticId DiagnosticId => DiagnosticId.ExtensionMethodsCalledLikeInstanceMethods;
 
-		protected override async Task<Document> ApplyFix(Document document, InvocationExpressionSyntax node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, InvocationExpressionSyntax node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
 		{
 			InvocationExpressionSyntax invocation = node;
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/CallExtensionMethodsAsInstanceMethodsCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/CallExtensionMethodsAsInstanceMethodsCodeFixProvider.cs
@@ -1,52 +1,29 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
-using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Philips.CodeAnalysis.Common;
 
 namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 {
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(CallExtensionMethodsAsInstanceMethodsAnalyzer)), Shared]
-	public class CallExtensionMethodsAsInstanceMethodsCodeFixProvider : CodeFixProvider
+	public class CallExtensionMethodsAsInstanceMethodsCodeFixProvider : SingleDiagnosticCodeFixProvider<InvocationExpressionSyntax>
 	{
-		public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId.ExtensionMethodsCalledLikeInstanceMethods));
+		protected override string Title => "Call extension methods as if they were instance methods";
 
-		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+		protected override DiagnosticId DiagnosticId => DiagnosticId.ExtensionMethodsCalledLikeInstanceMethods;
+
+		protected override async Task<Document> ApplyFix(Document document, InvocationExpressionSyntax node, CancellationToken cancellationToken)
 		{
-			const string Title = "Call extension methods as if they were instance methods";
+			InvocationExpressionSyntax invocation = node;
 
-			SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-
-			Diagnostic diagnostic = context.Diagnostics.First();
-			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
-
-			if (root != null)
-			{
-				SyntaxToken token = root.FindToken(diagnosticSpan.Start);
-
-				// Register a code action that will invoke the fix.
-				context.RegisterCodeFix(
-					CodeAction.Create(
-						title: Title,
-						createChangedDocument: c => AdjustCallingMechanism(context.Document, token),
-						equivalenceKey: Title),
-					diagnostic);
-			}
-		}
-
-		private async Task<Document> AdjustCallingMechanism(Document document, SyntaxToken token)
-		{
-			InvocationExpressionSyntax invocation = token.Parent.Ancestors().OfType<InvocationExpressionSyntax>().First();
-
-			SyntaxNode root = await document.GetSyntaxRootAsync();
+			SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken);
 
 			SimpleNameSyntax name;
 			if (invocation.Expression is MemberAccessExpressionSyntax memberAccessExpressionSyntax)
@@ -75,11 +52,6 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			root = root.ReplaceNode(invocation, newInvocationWithLeadingTrivia);
 
 			return document.WithSyntaxRoot(root);
-		}
-
-		public sealed override FixAllProvider GetFixAllProvider()
-		{
-			return WellKnownFixAllProviders.BatchFixer;
 		}
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/DisallowDisposeRegistrationCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/DisallowDisposeRegistrationCodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,7 +19,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 		protected override DiagnosticId DiagnosticId => DiagnosticId.DisallowDisposeRegistration;
 
-		protected override async Task<Document> ApplyFix(Document document, AssignmentExpressionSyntax node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, AssignmentExpressionSyntax node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
 		{
 			AssignmentExpressionSyntax newAssignmentExpression = SyntaxFactory.AssignmentExpression(SyntaxKind.SubtractAssignmentExpression, node.Left, node.Right);
 			SyntaxNode oldRoot = await document.GetSyntaxRootAsync(cancellationToken);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/DisallowDisposeRegistrationCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/DisallowDisposeRegistrationCodeFixProvider.cs
@@ -1,66 +1,28 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
-using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Philips.CodeAnalysis.Common;
 
 namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 {
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(DisallowDisposeRegistrationCodeFixProvider)), Shared]
-	public class DisallowDisposeRegistrationCodeFixProvider : CodeFixProvider
+	public class DisallowDisposeRegistrationCodeFixProvider : SingleDiagnosticCodeFixProvider<AssignmentExpressionSyntax>
 	{
-		private const string Title = "Unregister instead of registering";
+		protected override string Title => "Unregister instead of registering";
 
-		public sealed override ImmutableArray<string> FixableDiagnosticIds
+		protected override DiagnosticId DiagnosticId => DiagnosticId.DisallowDisposeRegistration;
+
+		protected override async Task<Document> ApplyFix(Document document, AssignmentExpressionSyntax node, CancellationToken cancellationToken)
 		{
-			get { return ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId.DisallowDisposeRegistration)); }
-		}
-
-		public sealed override FixAllProvider GetFixAllProvider()
-		{
-			return WellKnownFixAllProviders.BatchFixer;
-		}
-
-		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
-		{
-			SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-
-			Diagnostic diagnostic = context.Diagnostics.First();
-			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
-
-			// Find the method declaration identified by the diagnostic.
-			if (root != null)
-			{
-				SyntaxNode syntaxNode = root.FindToken(diagnosticSpan.Start).Parent;
-				if (syntaxNode != null)
-				{
-					AssignmentExpressionSyntax assignmentExpression = syntaxNode.AncestorsAndSelf().OfType<AssignmentExpressionSyntax>().First();
-
-					// Register a code action that will invoke the fix.
-					context.RegisterCodeFix(
-						CodeAction.Create(
-							title: Title,
-							createChangedDocument: c => DisallowDisposeRegistrationFix(context.Document, assignmentExpression, c),
-							equivalenceKey: Title),
-						diagnostic);
-				}
-			}
-		}
-
-		private async Task<Document> DisallowDisposeRegistrationFix(Document document, AssignmentExpressionSyntax assignmentExpression, CancellationToken cancellationToken)
-		{
-			AssignmentExpressionSyntax newAssignmentExpression = SyntaxFactory.AssignmentExpression(SyntaxKind.SubtractAssignmentExpression, assignmentExpression.Left, assignmentExpression.Right);
+			AssignmentExpressionSyntax newAssignmentExpression = SyntaxFactory.AssignmentExpression(SyntaxKind.SubtractAssignmentExpression, node.Left, node.Right);
 			SyntaxNode oldRoot = await document.GetSyntaxRootAsync(cancellationToken);
-			SyntaxNode newRoot = oldRoot.ReplaceNode(assignmentExpression, newAssignmentExpression);
+			SyntaxNode newRoot = oldRoot.ReplaceNode(node, newAssignmentExpression);
 			return document.WithSyntaxRoot(newRoot);
 		}
 	}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/MergeIfStatementsCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/MergeIfStatementsCodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,7 +21,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 		protected override DiagnosticId DiagnosticId => DiagnosticId.MergeIfStatements;
 
-		protected override async Task<Document> ApplyFix(Document document, IfStatementSyntax node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, IfStatementSyntax node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
 		{
 			SyntaxNode rootNode = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/PassSenderToEventHandlerCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/PassSenderToEventHandlerCodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,7 +20,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 		protected override DiagnosticId DiagnosticId => DiagnosticId.PassSenderToEventHandler;
 
-		protected override async Task<Document> ApplyFix(Document document, ArgumentSyntax node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, ArgumentSyntax node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
 		{
 			ArgumentSyntax argument = node;
 			SyntaxNode rootNode = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/PassSenderToEventHandlerCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/PassSenderToEventHandlerCodeFixProvider.cs
@@ -1,53 +1,28 @@
 ﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
 
-using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Philips.CodeAnalysis.Common;
 
 namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 {
 
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(PassSenderToEventHandlerCodeFixProvider)), Shared]
-	public class PassSenderToEventHandlerCodeFixProvider : CodeFixProvider
+	public class PassSenderToEventHandlerCodeFixProvider : SingleDiagnosticCodeFixProvider<ArgumentSyntax>
 	{
-		private const string Title = "Pass sender to EventHandler";
+		protected override string Title => "Pass sender to EventHandler";
 
-		public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId.PassSenderToEventHandler));
-		public sealed override FixAllProvider GetFixAllProvider()
+		protected override DiagnosticId DiagnosticId => DiagnosticId.PassSenderToEventHandler;
+
+		protected override async Task<Document> ApplyFix(Document document, ArgumentSyntax node, CancellationToken cancellationToken)
 		{
-			return WellKnownFixAllProviders.BatchFixer;
-		}
-
-		public override async Task RegisterCodeFixesAsync(CodeFixContext context)
-		{
-			SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-
-			Diagnostic diagnostic = context.Diagnostics.First();
-			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
-
-			var argument = root.FindNode(diagnosticSpan) as ArgumentSyntax;
-
-			// Register a code action that will invoke the fix.
-			context.RegisterCodeFix(
-				CodeAction.Create(
-					title: Title,
-					createChangedDocument: c => ReplaceArgument(context.Document, argument, c),
-					equivalenceKey: Title),
-				diagnostic);
-		}
-
-		private async Task<Document> ReplaceArgument(Document document, ArgumentSyntax argument, CancellationToken c)
-		{
-			SyntaxNode rootNode = await document.GetSyntaxRootAsync(c).ConfigureAwait(false);
+			ArgumentSyntax argument = node;
+			SyntaxNode rootNode = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
 			if (argument.Parent is ArgumentListSyntax argumentList)
 			{
@@ -59,8 +34,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 				}
 				else if (index == 1)
 				{
-					SemanticModel semanticModel = await document.GetSemanticModelAsync(c);
-					var typeName = semanticModel?.GetTypeInfo(argument, c).Type?.Name ?? "EventArgs";
+					SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+					var typeName = semanticModel?.GetTypeInfo(argument, cancellationToken).Type?.Name ?? "EventArgs";
 					ArgumentSyntax emptyArgument = SyntaxFactory.Argument(SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SyntaxFactory.IdentifierName(typeName), SyntaxFactory.IdentifierName("Empty"))).WithTriviaFrom(argument);
 					rootNode = rootNode.ReplaceNode(argument, emptyArgument);
 				}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/ReturnImmutableCollectionsCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/ReturnImmutableCollectionsCodeFixProvider.cs
@@ -1,6 +1,7 @@
 ﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -42,7 +43,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			return root.FindNode(diagnosticSpan) as TypeSyntax;
 		}
 
-		protected override async Task<Document> ApplyFix(Document document, TypeSyntax node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, TypeSyntax node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
 		{
 			SyntaxNode rootNode = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 			var origTypeName = ReturnImmutableCollectionsAnalyzer.GetTypeName(node);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/ReturnImmutableCollectionsCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/ReturnImmutableCollectionsCodeFixProvider.cs
@@ -1,13 +1,10 @@
 ﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -18,9 +15,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 {
 
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ReturnImmutableCollectionsCodeFixProvider)), Shared]
-	public class ReturnImmutableCollectionsCodeFixProvider : CodeFixProvider
+	public class ReturnImmutableCollectionsCodeFixProvider : SingleDiagnosticCodeFixProvider<TypeSyntax>
 	{
-		private const string Title = "Return immutable collections";
 		private const string ReadonlyCollection = "IReadOnlyCollection";
 		private const string ReadonlyDictionary = "IReadOnlyDictionary";
 		private const string ReadonlyList = "IReadOnlyList";
@@ -37,44 +33,28 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			{StringConstants.IDictionaryInterfaceName, ReadonlyDictionary}
 		};
 
-		public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId.ReturnImmutableCollections));
+		protected override string Title => "Return immutable collections";
 
-		public sealed override FixAllProvider GetFixAllProvider()
+		protected override DiagnosticId DiagnosticId => DiagnosticId.ReturnImmutableCollections;
+
+		protected override TypeSyntax GetNode(SyntaxNode root, TextSpan diagnosticSpan)
 		{
-			return WellKnownFixAllProviders.BatchFixer;
+			return root.FindNode(diagnosticSpan) as TypeSyntax;
 		}
 
-		public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+		protected override async Task<Document> ApplyFix(Document document, TypeSyntax node, CancellationToken cancellationToken)
 		{
-			SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-
-			Diagnostic diagnostic = context.Diagnostics.First();
-			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
-
-			var type = root.FindNode(diagnosticSpan) as TypeSyntax;
-
-			// Register a code action that will invoke the fix.
-			context.RegisterCodeFix(
-				CodeAction.Create(
-					title: Title,
-					createChangedDocument: c => ReplaceType(context.Document, type, c),
-					equivalenceKey: Title),
-				diagnostic);
-		}
-
-		private async Task<Document> ReplaceType(Document document, TypeSyntax type, CancellationToken c)
-		{
-			SyntaxNode rootNode = await document.GetSyntaxRootAsync(c).ConfigureAwait(false);
-			var origTypeName = ReturnImmutableCollectionsAnalyzer.GetTypeName(type);
+			SyntaxNode rootNode = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+			var origTypeName = ReturnImmutableCollectionsAnalyzer.GetTypeName(node);
 			string newTypeName;
-			if (type is ArrayTypeSyntax arrayType)
+			if (node is ArrayTypeSyntax arrayType)
 			{
 				var elementTypeName = arrayType.ElementType.ToString();
 				newTypeName = $"IReadOnlyList<{elementTypeName}>";
 			}
 			else if (CollectionsMap.TryGetValue(origTypeName, out var newCollectionType))
 			{
-				var genericTypeNames = GetGenericTypeNames(type);
+				var genericTypeNames = GetGenericTypeNames(node);
 				newTypeName = $"{newCollectionType}{genericTypeNames}";
 
 			}
@@ -82,8 +62,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			{
 				return document;
 			}
-			TypeSyntax newType = SyntaxFactory.ParseTypeName(newTypeName).WithTriviaFrom(type);
-			rootNode = rootNode.ReplaceNode(type, newType);
+			TypeSyntax newType = SyntaxFactory.ParseTypeName(newTypeName).WithTriviaFrom(node);
+			rootNode = rootNode.ReplaceNode(node, newType);
 			return document.WithSyntaxRoot(rootNode);
 		}
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidMultipleLambdasOnSingleLineCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidMultipleLambdasOnSingleLineCodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
@@ -36,7 +37,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 			return firstLambdaOnLine?.Parent?.Parent;
 		}
 
-		protected override async Task<Document> ApplyFix(Document document, SyntaxNode node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, SyntaxNode node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
 		{
 			SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 			SyntaxNode oldNode = node;

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidMultipleLambdasOnSingleLineCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidMultipleLambdasOnSingleLineCodeFixProvider.cs
@@ -1,12 +1,10 @@
 ﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
 
-using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -17,48 +15,44 @@ using Philips.CodeAnalysis.Common;
 namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 {
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AvoidMultipleLambdasOnSingleLineCodeFixProvider)), Shared]
-	public class AvoidMultipleLambdasOnSingleLineCodeFixProvider : CodeFixProvider
+	public class AvoidMultipleLambdasOnSingleLineCodeFixProvider : SingleDiagnosticCodeFixProvider<SyntaxNode>
 	{
-		private const string Title = "Put every lambda on a separate line";
+		protected override string Title => "Put every lambda on a separate line";
 
-		public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId.AvoidMultipleLambdasOnSingleLine));
+		protected override DiagnosticId DiagnosticId => DiagnosticId.AvoidMultipleLambdasOnSingleLine;
 
-		public sealed override FixAllProvider GetFixAllProvider()
+		protected override SyntaxNode GetNode(SyntaxNode root, TextSpan diagnosticSpan)
 		{
-			return WellKnownFixAllProviders.BatchFixer;
+			SyntaxNode diagnosticNode = root.FindNode(diagnosticSpan);
+			LambdaExpressionSyntax secondLambda = diagnosticNode.ChildNodes().OfType<LambdaExpressionSyntax>().FirstOrDefault();
+			SyntaxNode parent = GetParentOnHigherLine(secondLambda);
+			if (secondLambda is null || parent is null)
+			{
+				// Apparently, the code is different than what we expect.
+				return null;
+			}
+			LambdaExpressionSyntax firstLambdaOnLine = GetOtherLambdaOnSameLine(parent, secondLambda);
+			// Nice location to break the line, after the closing parenthesis of the ArgumentList where the first lambda is part of.
+			return firstLambdaOnLine?.Parent?.Parent;
 		}
 
-		public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+		protected override async Task<Document> ApplyFix(Document document, SyntaxNode node, CancellationToken cancellationToken)
 		{
-			SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-
-			Diagnostic diagnostic = context.Diagnostics.First();
-
-			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
-
-			if (root != null)
+			SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+			SyntaxNode oldNode = node;
+			SyntaxToken lastToken = oldNode.GetLastToken();
+			// If the 2 lambdas are distinct statements, put the new line after the semicolon.
+			if (lastToken.GetNextToken().IsKind(SyntaxKind.SemicolonToken))
 			{
-				SyntaxNode diagnosticNode = root.FindNode(diagnosticSpan);
-				LambdaExpressionSyntax secondLambda = diagnosticNode.ChildNodes().OfType<LambdaExpressionSyntax>().FirstOrDefault();
-				SyntaxNode parent = GetParentOnHigherLine(secondLambda);
-				if (secondLambda is null || parent is null)
-				{
-					// Apparently, the code is different than what we expect.
-					return;
-				}
-				LambdaExpressionSyntax firstLambdaOnLine = GetOtherLambdaOnSameLine(parent, secondLambda);
-				// Nice location to break the line, after the closing parenthesis of the ArgumentList where the first lambda is part of.
-				SyntaxNode parentOfFirst = firstLambdaOnLine?.Parent?.Parent;
-				if (parentOfFirst is not null)
-				{
-					context.RegisterCodeFix(
-						CodeAction.Create(
-							title: Title,
-							createChangedDocument: c => AddNewLineAfter(context.Document, parentOfFirst, c),
-							equivalenceKey: Title),
-						diagnostic);
-				}
+				lastToken = lastToken.GetNextToken();
+				oldNode = lastToken.Parent;
 			}
+			SyntaxTriviaList newTrivia = lastToken.TrailingTrivia.Add(SyntaxFactory.EndOfLine(StringConstants.WindowsNewLine));
+
+			SyntaxNode newNode = oldNode.WithTrailingTrivia(newTrivia).WithAdditionalAnnotations(Formatter.Annotation);
+			root = root.ReplaceNode(oldNode, newNode);
+
+			return document.WithSyntaxRoot(root);
 		}
 
 		private SyntaxNode GetParentOnHigherLine(SyntaxNode node)
@@ -77,25 +71,6 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 				.OfType<LambdaExpressionSyntax>()
 				.Where(k => !ReferenceEquals(k, second))
 				.FirstOrDefault(l => l.GetLocation().GetLineSpan().StartLinePosition.Line == lineNumber);
-		}
-
-		private async Task<Document> AddNewLineAfter(Document document, SyntaxNode node, CancellationToken cancellationToken)
-		{
-			SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-			SyntaxNode oldNode = node;
-			SyntaxToken lastToken = oldNode.GetLastToken();
-			// If the 2 lambdas are distinct statements, put the new line after the semicolon.
-			if (lastToken.GetNextToken().IsKind(SyntaxKind.SemicolonToken))
-			{
-				lastToken = lastToken.GetNextToken();
-				oldNode = lastToken.Parent;
-			}
-			SyntaxTriviaList newTrivia = lastToken.TrailingTrivia.Add(SyntaxFactory.EndOfLine(StringConstants.WindowsNewLine));
-
-			SyntaxNode newNode = oldNode.WithTrailingTrivia(newTrivia).WithAdditionalAnnotations(Formatter.Annotation);
-			root = root.ReplaceNode(oldNode, newNode);
-
-			return document.WithSyntaxRoot(root);
 		}
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EveryLinqStatementOnSeparateLineCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EveryLinqStatementOnSeparateLineCodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,7 +26,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 			return root.FindNode(diagnosticSpan) as QueryClauseSyntax;
 		}
 
-		protected override async Task<Document> ApplyFix(Document document, QueryClauseSyntax node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, QueryClauseSyntax node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
 		{
 			SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/PreventUnnecessaryRangeChecksCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/PreventUnnecessaryRangeChecksCodeFixProvider.cs
@@ -1,6 +1,7 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -27,7 +28,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 			return root.FindNode(diagnosticSpan) as IfStatementSyntax;
 		}
 
-		protected override async Task<Document> ApplyFix(Document document, IfStatementSyntax node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, IfStatementSyntax node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
 		{
 			SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken);
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/SplitMultiLineConditionOnLogicalOperatorCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/SplitMultiLineConditionOnLogicalOperatorCodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
@@ -28,7 +29,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 			return root.FindNode(diagnosticSpan);
 		}
 
-		protected override async Task<Document> ApplyFix(Document document, SyntaxNode node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, SyntaxNode node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
 		{
 			SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 			if (root == null)

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/SplitMultiLineConditionOnLogicalOperatorCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/SplitMultiLineConditionOnLogicalOperatorCodeFixProvider.cs
@@ -1,12 +1,10 @@
 ﻿// © 2023 Koninklijke Philips N.V. See License.md in the project root for license information.
 
-using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Formatting;
@@ -17,40 +15,20 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 {
 	[ExportCodeFixProvider(LanguageNames.CSharp,
 		 Name = nameof(SplitMultiLineConditionOnLogicalOperatorCodeFixProvider)), Shared]
-	public class SplitMultiLineConditionOnLogicalOperatorCodeFixProvider : CodeFixProvider
+	public class SplitMultiLineConditionOnLogicalOperatorCodeFixProvider : SingleDiagnosticCodeFixProvider<SyntaxNode>
 	{
-		private const string Title = "Split multiline conditions on logical operators";
-		private static readonly SyntaxAnnotation annotation = new($"SplitCondition");
+		private static readonly SyntaxAnnotation Annotation = new($"SplitCondition");
 
-		public override ImmutableArray<string> FixableDiagnosticIds =>
-			ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId.SplitMultiLineConditionOnLogicalOperator));
+		protected override string Title => "Split multiline conditions on logical operators";
 
-		public sealed override FixAllProvider GetFixAllProvider()
+		protected override DiagnosticId DiagnosticId => DiagnosticId.SplitMultiLineConditionOnLogicalOperator;
+
+		protected override SyntaxNode GetNode(SyntaxNode root, TextSpan diagnosticSpan)
 		{
-			return WellKnownFixAllProviders.BatchFixer;
+			return root.FindNode(diagnosticSpan);
 		}
 
-		public override async Task RegisterCodeFixesAsync(CodeFixContext context)
-		{
-			SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-
-			Diagnostic diagnostic = context.Diagnostics.First();
-
-			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
-
-			if (root != null)
-			{
-				SyntaxNode node = root.FindNode(diagnosticSpan);
-				context.RegisterCodeFix(
-					CodeAction.Create(
-						title: Title,
-						createChangedDocument: c => ApplyCodeFix(context.Document, node, c),
-						equivalenceKey: Title),
-					diagnostic);
-			}
-		}
-
-		private async Task<Document> ApplyCodeFix(Document document, SyntaxNode node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, SyntaxNode node, CancellationToken cancellationToken)
 		{
 			SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 			if (root == null)
@@ -65,12 +43,12 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 			{
 				SyntaxTriviaList newTrivia = oldTrivia.RemoveAt(index);
 				SyntaxNode replacementNode = node.WithTrailingTrivia(newTrivia)
-					.WithAdditionalAnnotations(Formatter.Annotation, annotation);
+					.WithAdditionalAnnotations(Formatter.Annotation, Annotation);
 				root = root.ReplaceNode(node, replacementNode);
 			}
 
 			// Next add EOL to the || or && token immediately following.
-			SyntaxNode newNode = root.GetAnnotatedNodes(annotation).FirstOrDefault() ?? node;
+			SyntaxNode newNode = root.GetAnnotatedNodes(Annotation).FirstOrDefault() ?? node;
 			SyntaxToken logicalToken = newNode.GetLastToken().GetNextToken();
 			if (logicalToken.Text is "||" or "&&")
 			{

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualCodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -29,7 +30,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 		protected override DiagnosticId DiagnosticId => DiagnosticId.AssertAreEqual;
 
-		protected override async Task<Document> ApplyFix(Document document, InvocationExpressionSyntax node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, InvocationExpressionSyntax node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
 		{
 			Document newDocument = document;
 			SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken);

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualLiteralCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualLiteralCodeFixProvider.cs
@@ -1,6 +1,7 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,7 +20,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 		protected override DiagnosticId DiagnosticId => DiagnosticId.AssertAreEqualLiteral;
 
-		protected override async Task<Document> ApplyFix(Document document, InvocationExpressionSyntax node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, InvocationExpressionSyntax node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
 		{
 			SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken);
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualLiteralCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertAreEqualLiteralCodeFixProvider.cs
@@ -1,87 +1,41 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
 using System;
-using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Philips.CodeAnalysis.Common;
 
 namespace Philips.CodeAnalysis.MsTestAnalyzers
 {
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AssertAreEqualLiteralAnalyzer)), Shared]
-	public class AssertAreEqualLiteralCodeFixProvider : CodeFixProvider
+	public class AssertAreEqualLiteralCodeFixProvider : SingleDiagnosticCodeFixProvider<InvocationExpressionSyntax>
 	{
-		private const string Title = "Refactor AreEqual(<literal true/false>, other) into IsTrue/IsFalse";
+		protected override string Title => "Refactor AreEqual(<literal true/false>, other) into IsTrue/IsFalse";
 
-		public sealed override ImmutableArray<string> FixableDiagnosticIds
-		{
-			get { return ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId.AssertAreEqualLiteral)); }
-		}
+		protected override DiagnosticId DiagnosticId => DiagnosticId.AssertAreEqualLiteral;
 
-		public sealed override FixAllProvider GetFixAllProvider()
-		{
-			return WellKnownFixAllProviders.BatchFixer;
-		}
-
-		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
-		{
-			SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-
-			Diagnostic diagnostic = context.Diagnostics.First();
-			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
-
-			// Find the method declaration identified by the diagnostic.
-			if (root != null)
-			{
-				SyntaxNode syntaxNode = root.FindToken(diagnosticSpan.Start).Parent;
-				if (syntaxNode != null)
-				{
-					InvocationExpressionSyntax invocationExpression = syntaxNode.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().First();
-
-					ArgumentSyntax arg = invocationExpression.ArgumentList.Arguments[0];
-
-					Helper helper = new();
-					if (!helper.IsLiteralTrueFalse(arg.Expression))
-					{
-						return;
-					}
-
-					// Register a code action that will invoke the fix.
-					context.RegisterCodeFix(
-						CodeAction.Create(
-							title: Title,
-							createChangedDocument: c => AssertAreEqualFix(context.Document, invocationExpression, c),
-							equivalenceKey: Title),
-						diagnostic);
-				}
-			}
-		}
-
-		private async Task<Document> AssertAreEqualFix(Document document, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, InvocationExpressionSyntax node, CancellationToken cancellationToken)
 		{
 			SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken);
 
-			ArgumentSyntax literalExpected = invocationExpression.ArgumentList.Arguments[0];
-			ArgumentSyntax actual = invocationExpression.ArgumentList.Arguments[1];
+			ArgumentSyntax literalExpected = node.ArgumentList.Arguments[0];
+			ArgumentSyntax actual = node.ArgumentList.Arguments[1];
 
 			ArgumentSyntax message = null;
-			if (invocationExpression.ArgumentList.Arguments.Count > 2)
+			if (node.ArgumentList.Arguments.Count > 2)
 			{
-				message = invocationExpression.ArgumentList.Arguments[2];
+				message = node.ArgumentList.Arguments[2];
 			}
 
-			InvocationExpressionSyntax newInvocation = ConvertToInvocation(((MemberAccessExpressionSyntax)invocationExpression.Expression).Name, literalExpected.Expression, actual.Expression, message?.Expression);
-			SyntaxTriviaList trivia = invocationExpression.GetLeadingTrivia();
+			InvocationExpressionSyntax newInvocation = ConvertToInvocation(((MemberAccessExpressionSyntax)node.Expression).Name, literalExpected.Expression, actual.Expression, message?.Expression);
+			SyntaxTriviaList trivia = node.GetLeadingTrivia();
 			InvocationExpressionSyntax newInvocationWithTrivia = newInvocation.WithLeadingTrivia(trivia);
-			root = root.ReplaceNode(invocationExpression, newInvocationWithTrivia);
+			root = root.ReplaceNode(node, newInvocationWithTrivia);
 
 			return document.WithSyntaxRoot(root);
 		}

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueCodeFixProvider.cs
@@ -1,6 +1,7 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
@@ -20,7 +21,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 		protected override DiagnosticId DiagnosticId => DiagnosticId.AssertIsEqual;
 
-		protected override async Task<Document> ApplyFix(Document document, InvocationExpressionSyntax node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, InvocationExpressionSyntax node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
 		{
 			var calledMethod = ((MemberAccessExpressionSyntax)node.Expression).Name.Identifier.Text;
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueCodeFixProvider.cs
@@ -1,68 +1,34 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
 using System;
-using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Philips.CodeAnalysis.Common;
 
 namespace Philips.CodeAnalysis.MsTestAnalyzers
 {
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AssertIsTrueCodeFixProvider)), Shared]
-	public class AssertIsTrueCodeFixProvider : CodeFixProvider
+	public class AssertIsTrueCodeFixProvider : SingleDiagnosticCodeFixProvider<InvocationExpressionSyntax>
 	{
-		private const string Title = "Refactor IsTrue/IsFalse";
+		protected override string Title => "Refactor IsTrue/IsFalse";
 
-		public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId.AssertIsEqual));
+		protected override DiagnosticId DiagnosticId => DiagnosticId.AssertIsEqual;
 
-		public sealed override FixAllProvider GetFixAllProvider()
+		protected override async Task<Document> ApplyFix(Document document, InvocationExpressionSyntax node, CancellationToken cancellationToken)
 		{
-			return WellKnownFixAllProviders.BatchFixer;
-		}
-
-		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
-		{
-			SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-
-			Diagnostic diagnostic = context.Diagnostics.First();
-			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
-
-			// Find the method declaration identified by the diagnostic.
-			if (root != null)
-			{
-				SyntaxNode syntaxNode = root.FindToken(diagnosticSpan.Start).Parent;
-				if (syntaxNode != null)
-				{
-					InvocationExpressionSyntax invocationExpression = syntaxNode.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().First();
-
-					// Register a code action that will invoke the fix.
-					context.RegisterCodeFix(
-						CodeAction.Create(
-							title: Title,
-							createChangedDocument: c => AssertIsTrueFix(context.Document, invocationExpression, c),
-							equivalenceKey: Title),
-						diagnostic);
-				}
-			}
-		}
-
-		private async Task<Document> AssertIsTrueFix(Document document, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken)
-		{
-			var calledMethod = ((MemberAccessExpressionSyntax)invocationExpression.Expression).Name.Identifier.Text;
+			var calledMethod = ((MemberAccessExpressionSyntax)node.Expression).Name.Identifier.Text;
 
 			var isIsTrue = calledMethod == StringConstants.IsTrue;
 
-			ArgumentSyntax arg = invocationExpression.ArgumentList.Arguments[0];
+			ArgumentSyntax arg = node.ArgumentList.Arguments[0];
 
-			return await HandleArgument(document, arg.Expression, invocationExpression, isIsTrue, cancellationToken);
+			return await HandleArgument(document, arg.Expression, node, isIsTrue, cancellationToken);
 		}
 
 		private async Task<Document> HandleArgument(Document document, ExpressionSyntax arg, InvocationExpressionSyntax invocationExpression, bool isIsTrue, CancellationToken cancellationToken)

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueParenthesisCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueParenthesisCodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,7 +18,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 		protected override DiagnosticId DiagnosticId => DiagnosticId.AssertIsTrueParenthesis;
 
-		protected override async Task<Document> ApplyFix(Document document, InvocationExpressionSyntax node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, InvocationExpressionSyntax node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
 		{
 			ArgumentSyntax arg = node.ArgumentList.Arguments[0];
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueParenthesisCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueParenthesisCodeFixProvider.cs
@@ -1,63 +1,25 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
-using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Philips.CodeAnalysis.Common;
 
 namespace Philips.CodeAnalysis.MsTestAnalyzers
 {
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AssertIsTrueParenthesisCodeFixProvider)), Shared]
-	public class AssertIsTrueParenthesisCodeFixProvider : CodeFixProvider
+	public class AssertIsTrueParenthesisCodeFixProvider : SingleDiagnosticCodeFixProvider<InvocationExpressionSyntax>
 	{
-		private const string Title = "Refactor IsTrue/IsFalse parentheses usage";
+		protected override string Title => "Refactor IsTrue/IsFalse parentheses usage";
 
-		public sealed override ImmutableArray<string> FixableDiagnosticIds
+		protected override DiagnosticId DiagnosticId => DiagnosticId.AssertIsTrueParenthesis;
+
+		protected override async Task<Document> ApplyFix(Document document, InvocationExpressionSyntax node, CancellationToken cancellationToken)
 		{
-			get { return ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId.AssertIsTrueParenthesis)); }
-		}
-
-		public sealed override FixAllProvider GetFixAllProvider()
-		{
-			return WellKnownFixAllProviders.BatchFixer;
-		}
-
-		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
-		{
-			SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-
-			Diagnostic diagnostic = context.Diagnostics.First();
-			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
-
-			// Find the method declaration identified by the diagnostic.
-			if (root != null)
-			{
-				SyntaxNode node = root.FindToken(diagnosticSpan.Start).Parent;
-				if (node != null)
-				{
-					InvocationExpressionSyntax invocationExpression = node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().First();
-
-					// Register a code action that will invoke the fix.
-					context.RegisterCodeFix(
-						CodeAction.Create(
-							title: Title,
-							createChangedDocument: c => AssertIsTrueParenthesisFix(context.Document, invocationExpression, c),
-							equivalenceKey: Title),
-						diagnostic);
-				}
-			}
-		}
-
-		private async Task<Document> AssertIsTrueParenthesisFix(Document document, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken)
-		{
-			ArgumentSyntax arg = invocationExpression.ArgumentList.Arguments[0];
+			ArgumentSyntax arg = node.ArgumentList.Arguments[0];
 
 			var expression = (ParenthesizedExpressionSyntax)arg.Expression;
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AvoidOwnerAttributeCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AvoidOwnerAttributeCodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
@@ -18,7 +19,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 		protected override DiagnosticId DiagnosticId => DiagnosticId.AvoidOwnerAttribute;
 
-		protected override async Task<Document> ApplyFix(Document document, MethodDeclarationSyntax node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, MethodDeclarationSyntax node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
 		{
 			SyntaxNode rootNode = await document.GetSyntaxRootAsync(cancellationToken);
 			var newAttributes = new SyntaxList<AttributeListSyntax>();

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AvoidOwnerAttributeCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AvoidOwnerAttributeCodeFixProvider.cs
@@ -1,77 +1,40 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
-using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Philips.CodeAnalysis.Common;
 
 namespace Philips.CodeAnalysis.MsTestAnalyzers
 {
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AvoidOwnerAttributeCodeFixProvider)), Shared]
-	public class AvoidOwnerAttributeCodeFixProvider : CodeFixProvider
+	public class AvoidOwnerAttributeCodeFixProvider : SingleDiagnosticCodeFixProvider<MethodDeclarationSyntax>
 	{
-		private const string Title = "Remove Owner Attribute";
+		protected override string Title => "Remove Owner Attribute";
 
-		public sealed override ImmutableArray<string> FixableDiagnosticIds
-		{
-			get { return ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId.AvoidOwnerAttribute)); }
-		}
+		protected override DiagnosticId DiagnosticId => DiagnosticId.AvoidOwnerAttribute;
 
-		public sealed override FixAllProvider GetFixAllProvider()
-		{
-			return WellKnownFixAllProviders.BatchFixer;
-		}
-
-		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
-		{
-			SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-
-			Diagnostic diagnostic = context.Diagnostics.First();
-			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
-
-			// Find the method declaration identified by the diagnostic.
-			if (root != null)
-			{
-				SyntaxNode node = root.FindToken(diagnosticSpan.Start).Parent;
-				if (node != null)
-				{
-					MethodDeclarationSyntax attributeList = node.AncestorsAndSelf().OfType<MethodDeclarationSyntax>().First();
-
-					// Register a code action that will invoke the fix.
-					context.RegisterCodeFix(
-						CodeAction.Create(
-							title: Title,
-							createChangedDocument: c => RemoveOwnerAttribute(context.Document, attributeList, c),
-							equivalenceKey: Title),
-						diagnostic);
-				}
-			}
-		}
-
-		private async Task<Document> RemoveOwnerAttribute(Document document, MethodDeclarationSyntax method, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, MethodDeclarationSyntax node, CancellationToken cancellationToken)
 		{
 			SyntaxNode rootNode = await document.GetSyntaxRootAsync(cancellationToken);
 			var newAttributes = new SyntaxList<AttributeListSyntax>();
-			foreach (AttributeListSyntax attributelist in method.AttributeLists)
+			foreach (AttributeListSyntax attributeList in node.AttributeLists)
 			{
-				AttributeSyntax[] nodesToRemove = attributelist.Attributes.Where(att => (att.Name as IdentifierNameSyntax).Identifier.Text.StartsWith("Owner")).ToArray();
+				AttributeSyntax[] nodesToRemove = attributeList.Attributes.Where(att => (att.Name as IdentifierNameSyntax).Identifier.Text.StartsWith("Owner")).ToArray();
 
-				if (nodesToRemove.Length != attributelist.Attributes.Count)
+				if (nodesToRemove.Length != attributeList.Attributes.Count)
 				{
-					AttributeListSyntax newAttribute = attributelist.RemoveNodes(nodesToRemove, SyntaxRemoveOptions.KeepNoTrivia);
+					AttributeListSyntax newAttribute = attributeList.RemoveNodes(nodesToRemove, SyntaxRemoveOptions.KeepNoTrivia);
 					newAttributes = newAttributes.Add(newAttribute);
 				}
 			}
 
-			MethodDeclarationSyntax newMethod = method.WithAttributeLists(newAttributes);
-			SyntaxNode newRoot = rootNode.ReplaceNode(method, newMethod);
+			MethodDeclarationSyntax newMethod = node.WithAttributeLists(newAttributes);
+			SyntaxNode newRoot = rootNode.ReplaceNode(node, newMethod);
 			Document newDocument = document.WithSyntaxRoot(newRoot);
 			return newDocument;
 		}

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestContextCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestContextCodeFixProvider.cs
@@ -1,6 +1,7 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
@@ -19,7 +20,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 		protected override DiagnosticId DiagnosticId => DiagnosticId.TestContext;
 
-		protected override async Task<Document> ApplyFix(Document document, SyntaxNode node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, SyntaxNode node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
 		{
 			SyntaxNode rootNode = await document.GetSyntaxRootAsync(cancellationToken);
 			if (rootNode == null)

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestContextCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestContextCodeFixProvider.cs
@@ -1,59 +1,25 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Philips.CodeAnalysis.Common;
 
 namespace Philips.CodeAnalysis.MsTestAnalyzers
 {
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(TestContextCodeFixProvider)), Shared]
-	public class TestContextCodeFixProvider : CodeFixProvider
+	public class TestContextCodeFixProvider : SingleDiagnosticCodeFixProvider<SyntaxNode>
 	{
-		private const string Title = "Remove Test Context declaration";
+		protected override string Title => "Remove Test Context declaration";
 
-		public sealed override ImmutableArray<string> FixableDiagnosticIds
-		{
-			get { return ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId.TestContext)); }
-		}
+		protected override DiagnosticId DiagnosticId => DiagnosticId.TestContext;
 
-		public sealed override FixAllProvider GetFixAllProvider()
-		{
-			return WellKnownFixAllProviders.BatchFixer;
-		}
-
-		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
-		{
-			SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-
-			Diagnostic diagnostic = context.Diagnostics.First();
-			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
-
-			// find the node which is the "TestContext" type identifier
-			// the parent of the parent is the declaration we want to remove
-			if (root != null)
-			{
-				SyntaxNode node = root.FindToken(diagnosticSpan.Start).Parent;
-
-				// Register a code action that will invoke the fix.
-				context.RegisterCodeFix(
-					CodeAction.Create(
-						title: Title,
-						createChangedDocument: c => TestContextFix(context.Document, node, c),
-						equivalenceKey: Title),
-					diagnostic);
-			}
-		}
-
-		private async Task<Document> TestContextFix(Document document, SyntaxNode declaration, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, SyntaxNode node, CancellationToken cancellationToken)
 		{
 			SyntaxNode rootNode = await document.GetSyntaxRootAsync(cancellationToken);
 			if (rootNode == null)
@@ -62,7 +28,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			}
 
 			// find the underlying variable
-			IEnumerable<SyntaxNode> propNodes = declaration.DescendantNodes();
+			IEnumerable<SyntaxNode> propNodes = node.DescendantNodes();
 			ReturnStatementSyntax returnStatement = propNodes.OfType<ReturnStatementSyntax>().First();
 			var varName = string.Empty;
 			if (returnStatement?.Expression is IdentifierNameSyntax returnVar)
@@ -71,7 +37,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			}
 
 			// remove the property
-			rootNode = rootNode.RemoveNode(declaration, SyntaxRemoveOptions.KeepNoTrivia);
+			rootNode = rootNode.RemoveNode(node, SyntaxRemoveOptions.KeepNoTrivia);
 
 			if (!string.IsNullOrEmpty(varName))
 			{

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestHasCategoryCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestHasCategoryCodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
@@ -19,7 +20,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 		protected override DiagnosticId DiagnosticId => DiagnosticId.TestHasCategoryAttribute;
 
-		protected override async Task<Document> ApplyFix(Document document, MethodDeclarationSyntax node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, MethodDeclarationSyntax node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
 		{
 			SyntaxList<AttributeListSyntax> attributeLists = node.AttributeLists;
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestHasCategoryCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestHasCategoryCodeFixProvider.cs
@@ -1,64 +1,27 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
-using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Philips.CodeAnalysis.Common;
 
 namespace Philips.CodeAnalysis.MsTestAnalyzers
 {
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(TestHasCategoryCodeFixProvider)), Shared]
-	public class TestHasCategoryCodeFixProvider : CodeFixProvider
+	public class TestHasCategoryCodeFixProvider : SingleDiagnosticCodeFixProvider<MethodDeclarationSyntax>
 	{
-		private const string Title = "Add Test Category";
+		protected override string Title => "Add Test Category";
 
-		public sealed override ImmutableArray<string> FixableDiagnosticIds
+		protected override DiagnosticId DiagnosticId => DiagnosticId.TestHasCategoryAttribute;
+
+		protected override async Task<Document> ApplyFix(Document document, MethodDeclarationSyntax node, CancellationToken cancellationToken)
 		{
-			get { return ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId.TestHasCategoryAttribute)); }
-		}
-
-		public sealed override FixAllProvider GetFixAllProvider()
-		{
-			return WellKnownFixAllProviders.BatchFixer;
-		}
-
-		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
-		{
-			SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-
-			Diagnostic diagnostic = context.Diagnostics.First();
-			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
-
-			// Find the method declaration identified by the diagnostic.
-			if (root != null)
-			{
-				SyntaxNode syntaxNode = root.FindToken(diagnosticSpan.Start).Parent;
-				if (syntaxNode != null)
-				{
-					MethodDeclarationSyntax attributeList = syntaxNode.AncestorsAndSelf().OfType<MethodDeclarationSyntax>().First();
-
-					// Register a code action that will invoke the fix.
-					context.RegisterCodeFix(
-						CodeAction.Create(
-							title: Title,
-							createChangedDocument: c => AddTestCategory(context.Document, attributeList, c),
-							equivalenceKey: Title),
-						diagnostic);
-				}
-			}
-		}
-
-		private async Task<Document> AddTestCategory(Document document, MethodDeclarationSyntax method, CancellationToken cancellationToken)
-		{
-			SyntaxList<AttributeListSyntax> attributeLists = method.AttributeLists;
+			SyntaxList<AttributeListSyntax> attributeLists = node.AttributeLists;
 
 			if (attributeLists.Any(list =>
 					list.Attributes.Any(attributeSyntax => attributeSyntax.Name.ToString().Contains(@"TestCategory"))))
@@ -75,10 +38,10 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			AttributeListSyntax attributeList = SyntaxFactory.AttributeList(
 				SyntaxFactory.SingletonSeparatedList(attribute));
 
-			attributeLists = method.AttributeLists.Add(attributeList);
-			MethodDeclarationSyntax newMethod = method.WithAttributeLists(attributeLists);
+			attributeLists = node.AttributeLists.Add(attributeList);
+			MethodDeclarationSyntax newMethod = node.WithAttributeLists(attributeLists);
 
-			SyntaxNode newRoot = rootNode.ReplaceNode(method, newMethod);
+			SyntaxNode newRoot = rootNode.ReplaceNode(node, newMethod);
 			Document newDocument = document.WithSyntaxRoot(newRoot);
 			return newDocument;
 		}

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestHasDescriptionCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestHasDescriptionCodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
@@ -18,7 +19,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 		protected override DiagnosticId DiagnosticId => DiagnosticId.AvoidDescriptionAttribute;
 
-		protected override async Task<Document> ApplyFix(Document document, MethodDeclarationSyntax node, CancellationToken cancellationToken)
+		protected override async Task<Document> ApplyFix(Document document, MethodDeclarationSyntax node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
 		{
 			SyntaxNode rootNode = await document.GetSyntaxRootAsync(cancellationToken);
 			var newAttributes = new SyntaxList<AttributeListSyntax>();

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodNameCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodNameCodeFixProvider.cs
@@ -1,63 +1,28 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
-using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Rename;
-using Microsoft.CodeAnalysis.Text;
 using Philips.CodeAnalysis.Common;
 
 namespace Philips.CodeAnalysis.MsTestAnalyzers
 {
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(TestMethodNameCodeFixProvider)), Shared]
-	public class TestMethodNameCodeFixProvider : CodeFixProvider
+	public class TestMethodNameCodeFixProvider : SolutionCodeFixProvider<MethodDeclarationSyntax>
 	{
-		private const string Title = "Remove invalid prefix";
+		protected override string Title => "Remove invalid prefix";
 
-		public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Helper.ToDiagnosticId(DiagnosticId.TestMethodName));
+		protected override DiagnosticId DiagnosticId => DiagnosticId.TestMethodName;
 
-		public sealed override FixAllProvider GetFixAllProvider()
-		{
-			return WellKnownFixAllProviders.BatchFixer;
-		}
-
-		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
-		{
-			SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-
-			Diagnostic diagnostic = context.Diagnostics.First();
-			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
-
-			// Find the method declaration identified by the diagnostic.
-			if (root != null)
-			{
-				SyntaxNode syntaxNode = root.FindToken(diagnosticSpan.Start).Parent;
-				if (syntaxNode != null)
-				{
-					MethodDeclarationSyntax declaration = syntaxNode.AncestorsAndSelf().OfType<MethodDeclarationSyntax>().First();
-
-					// Register a code action that will invoke the fix.
-					context.RegisterCodeFix(
-						CodeAction.Create(
-							title: Title,
-							createChangedSolution: c => DoNotBeginWithTest(context.Document, declaration, c),
-							equivalenceKey: Title),
-						diagnostic);
-				}
-			}
-		}
-
-		private async Task<Solution> DoNotBeginWithTest(Document document, MethodDeclarationSyntax methodDeclaration, CancellationToken cancellationToken)
+		protected override async Task<Solution> ApplyFix(Document document, MethodDeclarationSyntax node, CancellationToken cancellationToken)
 		{
 			// Compute new name.
-			var name = methodDeclaration.Identifier.Text;
+			var name = node.Identifier.Text;
 
 			while (name.Contains(StringConstants.TestAttributeName))
 			{
@@ -76,7 +41,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 			// Get the symbol representing the type to be renamed.
 			SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken);
-			IMethodSymbol typeSymbol = semanticModel.GetDeclaredSymbol(methodDeclaration, cancellationToken);
+			IMethodSymbol typeSymbol = semanticModel.GetDeclaredSymbol(node, cancellationToken);
 
 			// Produce a new solution that has all references to that type renamed, including the declaration.
 			Solution originalSolution = document.Project.Solution;


### PR DESCRIPTION
Provide base classes for `CodeFixProvider` implementations for both source file and solution level.