### PR TITLE
docs: describe the avoidvoidreturn analyzer

### DIFF
--- a/Documentation/Diagnostics/PH2138.md
+++ b/Documentation/Diagnostics/PH2138.md
@@ -12,33 +12,40 @@
 
 ## Introduction
 
-This analyzer...
+This analyzer warns about methods or functions that have no return value. Whenever the return value is void it means that the purpose of the method is not directly observable. It either modifies some external state (file, database, etc), or silently modifies an input parameter.
+
+This makes the method hard to test as you will need to mock either the external state or peak at the original input. Here is a [dzone article](https://dzone.com/articles/void-methods-considered-anti-pattern) with more details.
+
+Consider returning a value instead and have the external state modified in as few locations as possible.
 
 ## How to solve
 
-...
+Return an object, instead of running an action. Consider returning an object you can use in a unit test.
+
+Ultimately we will need to execute changes onto the code's environment. For these (later) situations
+[here](https://github.com/louthy/language-ext/wiki/How-to-deal-with-side-effects#building-a-test-runtime) is a more thorough explanation of extracting file io operations for testing (without an actual file system).
 
 ## Example
 
 Code that triggers 2 diagnostics:
 ``` cs
         class MyClass
-        {   
-            public void BadExample() {}
+        {
+            public void ProduceMeasurement(String measurementField) {}
         }
 ```
 
 And the corrected code:
 ``` cs
         class MyClass
-        {   
-            public bool GoodExample() {}
+        {
+            public Measurement ProductMeasurement(String measurementField) {}
         }
 ```
 
 ## Exceptions
 
-Overridden methods, i.e., those having the `override` keyword, are exempt.
+Overridden methods, i.e., those having the `override` keyword, are exempt since they are beyond the developers control.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Introduction 
+# Introduction
 Roslyn Diagnostic Analyzers are customized compiler errors providing real-time feedback to C# developers. Many Analyzers include an automatic Code Fixer. While Microsoft (and other organizations) offer many analyzers, the market is nascent. Moreover, many tools offer a rich set of rules, but lack the shift-left integration that Roslyn achieves.
 
 We have a policy whereby Code Reviewers ask themselves if a review comment can be automated.  If so, and if a Diagnostic Analyzer is the right tool for the scenario in question, and if an Analyzer does not readily exist in the market already, an issue is created to track the need. That is, all analyzers herein are based on real-world code review feedback. This project is the result. It was open-sourced in 2020.
@@ -15,7 +15,7 @@ Consult the following for details on the available rules:
 * [Philips.CodeAnalysis.MsTestAnalyzers](./Philips.CodeAnalysis.MsTestAnalyzers/Philips.CodeAnalysis.MsTestAnalyzers.md)
 
 * [Philips.CodeAnalysis.SecurityAnalyzers](./Philips.CodeAnalysis.SecurityAnalyzers/Philips.CodeAnalysis.SecurityAnalyzers.md)
-  
+
 
 ## Getting Started
 


### PR DESCRIPTION
I don't know what the policy is for external links; but here is a brief documentation on the reasoning behind this rule