### PR TITLE
fix: Update TestClassMustBePublicAnalyzer

### DIFF
--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestClassMustBePublicAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestClassMustBePublicAnalyzer.cs
@@ -31,34 +31,6 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 				context.ReportDiagnostic(Diagnostic.Create(Rule, location, classDeclaration.Identifier));
 				return;
 			}
-
-			//this is an error, unless the class contains an "AssemblyInitialize" within it.  If it does, it _must_ be static.
-			var hasAttributeThatMustBeStatic = CheckForStaticAttributesOnMethods(context, classDeclaration);
-			var isClassStatic = classDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword);
-
-			if (hasAttributeThatMustBeStatic != isClassStatic)
-			{
-				Location location = classDeclaration.Identifier.GetLocation();
-				context.ReportDiagnostic(Diagnostic.Create(Rule, location, classDeclaration.Identifier));
-			}
-		}
-
-		private bool CheckForStaticAttributesOnMethods(SyntaxNodeAnalysisContext context, ClassDeclarationSyntax classDeclaration)
-		{
-			foreach (MethodDeclarationSyntax method in classDeclaration.Members.OfType<MethodDeclarationSyntax>())
-			{
-				if (!method.Modifiers.Any(SyntaxKind.StaticKeyword))
-				{
-					continue;
-				}
-
-				if (AttributeHelper.HasAnyAttribute(method.AttributeLists, context, MsTestFrameworkDefinitions.AssemblyInitializeAttribute, MsTestFrameworkDefinitions.AssemblyCleanupAttribute))
-				{
-					return true;
-				}
-			}
-
-			return false;
 		}
 	}
 }

--- a/Philips.CodeAnalysis.Test/MsTest/TestClassMustBePublicAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestClassMustBePublicAnalyzerTest.cs
@@ -22,7 +22,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 
 		[DataRow("", false)]
 		[DataRow("static", false)]
-		[DataRow("public static", false)]
+		[DataRow("public static", true)]
 		[DataRow("private static", false)]
 		[DataRow("private", false)]
 		[DataRow("protected", false)]
@@ -62,15 +62,16 @@ namespace Philips.CodeAnalysis.Test.MsTest
 			}
 		}
 
-		[DataRow("", true)]
-		[DataRow("static", true)]
+		[DataRow("", false)]
+		[DataRow("static", false)]
 		[DataRow("public static", true)]
-		[DataRow("private static", true)]
-		[DataRow("private", true)]
-		[DataRow("protected", true)]
-		[DataRow("protected static", true)]
+		[DataRow("private static", false)]
+		[DataRow("private", false)]
+		[DataRow("protected", false)]
+		[DataRow("protected static", false)]
 		[DataRow("public", true)]
-		[DataRow("sealed", true)]
+		[DataRow("sealed", false)]
+		[DataRow("public sealed", true)]
 		[DataTestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task TestClassWithAssemblyInitializeMustBePublicStaticAsync(string modifier, bool isCorrect)

--- a/Philips.CodeAnalysis.Test/MsTest/TestClassMustBePublicAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestClassMustBePublicAnalyzerTest.cs
@@ -27,6 +27,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 		[DataRow("private", false)]
 		[DataRow("protected", false)]
 		[DataRow("public", true)]
+        [DataRow("sealed", false)]
 		[DataTestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task TestClassMustBePublicAsync(string modifier, bool isCorrect)
@@ -61,14 +62,15 @@ namespace Philips.CodeAnalysis.Test.MsTest
 			}
 		}
 
-		[DataRow("", false)]
-		[DataRow("static", false)]
+		[DataRow("", true)]
+		[DataRow("static", true)]
 		[DataRow("public static", true)]
-		[DataRow("private static", false)]
-		[DataRow("private", false)]
-		[DataRow("protected", false)]
-		[DataRow("protected static", false)]
-		[DataRow("public", false)]
+		[DataRow("private static", true)]
+		[DataRow("private", true)]
+		[DataRow("protected", true)]
+		[DataRow("protected static", true)]
+		[DataRow("public", true)]
+		[DataRow("sealed", true)]
 		[DataTestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task TestClassWithAssemblyInitializeMustBePublicStaticAsync(string modifier, bool isCorrect)

--- a/Philips.CodeAnalysis.Test/MsTest/TestClassMustBePublicAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestClassMustBePublicAnalyzerTest.cs
@@ -27,7 +27,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 		[DataRow("private", false)]
 		[DataRow("protected", false)]
 		[DataRow("public", true)]
-        [DataRow("sealed", false)]
+		[DataRow("sealed", false)]
 		[DataTestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task TestClassMustBePublicAsync(string modifier, bool isCorrect)


### PR DESCRIPTION
It does not seem necessary to enforce class "staticness" for the test discovery