### PR TITLE
fix: PH2134 Support read only arrow properties

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/SetPropertiesInAnyOrderAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/SetPropertiesInAnyOrderAnalyzer.cs
@@ -41,7 +41,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			}
 
 			var propertyName = prop.Identifier.Text;
-			IEnumerable<string> propertiesInType = GetPropertieNames(type);
+			IEnumerable<string> propertiesInType = GetPropertyNames(type);
 			IEnumerable<string> otherProperties = propertiesInType.Except(new[] { propertyName });
 
 			if (Node.Body.Statements.Any(s => ReferencesOtherProperties(s, otherProperties)))
@@ -51,7 +51,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			}
 		}
 
-		private static IEnumerable<string> GetPropertieNames(BaseTypeDeclarationSyntax type)
+		private static IEnumerable<string> GetPropertyNames(BaseTypeDeclarationSyntax type)
 		{
 			return type.DescendantNodes().OfType<PropertyDeclarationSyntax>().Where(IsAssignable).Select(prop => prop.Identifier.Text);
 		}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/SetPropertiesInAnyOrderAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/SetPropertiesInAnyOrderAnalyzer.cs
@@ -40,25 +40,25 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 				return;
 			}
 
-			IEnumerable<string> propertiesInType = GetProperties(type);
-			IEnumerable<string> otherProperties = propertiesInType.Except(new[] { prop.Identifier.Text });
+			var propertyName = prop.Identifier.Text;
+			IEnumerable<string> propertiesInType = GetPropertieNames(type);
+			IEnumerable<string> otherProperties = propertiesInType.Except(new[] { propertyName });
 
 			if (Node.Body.Statements.Any(s => ReferencesOtherProperties(s, otherProperties)))
 			{
-				var propertyName = prop.Identifier.Text;
 				Location loc = Node.GetLocation();
 				ReportDiagnostic(loc, propertyName);
 			}
 		}
 
-		private static IEnumerable<string> GetProperties(BaseTypeDeclarationSyntax type)
+		private static IEnumerable<string> GetPropertieNames(BaseTypeDeclarationSyntax type)
 		{
 			return type.DescendantNodes().OfType<PropertyDeclarationSyntax>().Where(IsAssignable).Select(prop => prop.Identifier.Text);
 		}
 
 		private static bool IsAssignable(PropertyDeclarationSyntax property)
 		{
-			return property.Initializer != null || property.AccessorList.Accessors.Any(IsPublicSetter);
+			return property.Initializer != null || (property.AccessorList != null && property.AccessorList.Accessors.Any(IsPublicSetter));
 		}
 
 		private static bool IsPublicSetter(AccessorDeclarationSyntax accessor)

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/SetPropertiesInAnyOrderAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/SetPropertiesInAnyOrderAnalyzerTest.cs
@@ -51,6 +51,7 @@ namespace PropertiesinOrderTests {
 namespace PropertiesinOrderTests {
     public class Number {
         public int One => 1;
+        public int Two => 2;
     }
 }";
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/SetPropertiesInAnyOrderAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/SetPropertiesInAnyOrderAnalyzerTest.cs
@@ -47,6 +47,13 @@ namespace PropertiesinOrderTests {
     }
 }";
 
+		private const string CorrectReadOnlyArrow = @"
+namespace PropertiesinOrderTests {
+    public class Number {
+        public int One => 1;
+    }
+}";
+
 		private const string WrongInAssignment = @"
 namespace PropertiesinOrderTests {
     public class Number {
@@ -67,7 +74,9 @@ namespace PropertiesinOrderTests {
 		 DataRow(CorrectAutoProperties, DisplayName = nameof(CorrectAutoProperties)),
 		 DataRow(CorrectInitializer, DisplayName = nameof(CorrectInitializer)),
 		 DataRow(CorrectNoSetter, DisplayName = nameof(CorrectNoSetter)),
-		 DataRow(CorrectPrivateSetter, DisplayName = nameof(CorrectPrivateSetter))]
+		 DataRow(CorrectPrivateSetter, DisplayName = nameof(CorrectPrivateSetter)),
+		 DataRow(CorrectReadOnlyArrow, DisplayName = nameof(CorrectReadOnlyArrow))
+		]
 		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task WhenTestCodeIsValidNoDiagnosticIsTriggeredAsync(string testCode)
 		{


### PR DESCRIPTION
I guess this fixes #681 

@bcollamore could you please check this is the syntax on which the Analyzer crashes ?