### PR TITLE
Opt-in to solution-level analyzers

### DIFF
--- a/Documentation/Diagnostics/PH2072.md
+++ b/Documentation/Diagnostics/PH2072.md
@@ -17,3 +17,4 @@ Disabled by default. As of VS 16.3, [Analyzers can now see settings](https://dev
 ## Configuration
 
 This analyzer does not offer any special configuration. The general ways of [suppressing](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/suppress-warnings) diagnostics apply.
+Solution-level analyzers are disabled by default. To configure, consider using a [.globalconfig](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files#global-analyzerconfig) file.

--- a/Documentation/Diagnostics/PH2079.md
+++ b/Documentation/Diagnostics/PH2079.md
@@ -51,3 +51,5 @@ namespace MyOrg.MyProduct
 Specify the first part of your namespace in the `.editorconfig` file under: dotnet_code_quality.PH2079.namespace_prefix = [OrganizationName].[ProductName] 
 
 The general ways of [suppressing](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/suppress-warnings) diagnostics apply.
+
+Also see: https://github.com/philips-software/roslyn-analyzers/discussions/141

--- a/Documentation/Diagnostics/PH2099.md
+++ b/Documentation/Diagnostics/PH2099.md
@@ -8,7 +8,7 @@
 | Analyzer | [EnforceFileVersionIsSameAsPackageVersionAnalyzer](https://github.com/philips-software/roslyn-analyzers/blob/main/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/EnforceFileVersionIsSameAsPackageVersionAnalyzer.cs)
 | CodeFix  | No |
 | Severity | Error |
-| Enabled By Default | Yes |
+| Enabled By Default | No |
 
 ## Introduction
 
@@ -49,3 +49,4 @@ And the replacement code:
 ## Configuration
 
 This analyzer does not offer any special configuration. The general ways of [suppressing](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/suppress-warnings) diagnostics apply.
+Solution-level analyzers are disabled by default. To configure, consider using a [.globalconfig](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files#global-analyzerconfig) file.

--- a/Philips.CodeAnalysis.Common/SolutionAnalyzer.cs
+++ b/Philips.CodeAnalysis.Common/SolutionAnalyzer.cs
@@ -14,8 +14,18 @@ namespace Philips.CodeAnalysis.Common
 		public DiagnosticId Id { get; }
 		protected DiagnosticDescriptor Rule { get; }
 
+		/// <summary>
+		/// SolutionAnalyzers typically require .globalconfig file, which may require more cognitive load, limiting adoption; therefore, opt-in rather than Opt-out.
+		/// </summary>
+		/// <param name="id"></param>
+		/// <param name="title"></param>
+		/// <param name="messageFormat"></param>
+		/// <param name="description"></param>
+		/// <param name="category"></param>
+		/// <param name="severity"></param>
+		/// <param name="isEnabled"></param>
 		protected SolutionAnalyzer(DiagnosticId id, string title, string messageFormat, string description, string category,
-											DiagnosticSeverity severity = DiagnosticSeverity.Error, bool isEnabled = true)
+											DiagnosticSeverity severity = DiagnosticSeverity.Error, bool isEnabled = false)
 		{
 			Id = id;
 			var helpLink = id.ToHelpLinkUrl();

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/EnforceEditorConfigAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/EnforceEditorConfigAnalyzer.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		private const string Description = @".editorconfig files help enforce and configure Analyzers";
 
 		public EnforceEditorConfigAnalyzer()
-			: base(DiagnosticId.EnforceEditorConfig, Title, MessageFormat, Description, Categories.Maintainability, isEnabled: false)
+			: base(DiagnosticId.EnforceEditorConfig, Title, MessageFormat, Description, Categories.Maintainability)
 		{ }
 
 		public override void Initialize(AnalysisContext context)


### PR DESCRIPTION
Configuring solution-level analyzers on older versions of Visual Studio and/or TargetFrameworks with .globalconfig may not always be possible. Opt-in to these analyzers instead; otherwise, users of older versions may be unable to use these packages.