### PR TITLE
fix: Support partial versions

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/EnforceFileVersionIsSameAsPackageVersionAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/EnforceFileVersionIsSameAsPackageVersionAnalyzer.cs
@@ -63,12 +63,9 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 		private Version SetRevisionToZeroIfMissing(Version version)
 		{
-			Version sanitizedVersion = version;
-			if (version.Revision < 0)
-			{
-				sanitizedVersion = new Version(version.Major, version.Minor, version.Build, 0);
-			}
-			return sanitizedVersion;
+			var build = Math.Max(0, version.Build);
+			var revision = Math.Max(0, version.Revision);
+			return new Version(version.Major, version.Minor, build, revision);
 		}
 
 		private string RemoveVersionSuffix(string version)

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/EnforceFileVersionIsSameAsPackageVersionAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/EnforceFileVersionIsSameAsPackageVersionAnalyzerTest.cs
@@ -28,8 +28,9 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		[DataRow("1.0.0", "1.0.0-ci.1", false)]
 		[DataRow("1.1.2", "1.1.2+417ce", false)]
 		[DataRow("1.1.2", "1.1.2-beta+417ce", false)]
+		[DataRow("1.1", "1.1", false)]
 		[TestCategory(TestDefinitions.UnitTests)]
-		public async Task FileVersionMustBeSameAsPackageVersionAsync(string fileVersion, string packageVersion, bool hasDiagnostic)
+		public async Task FileVersionMustBeSameAsPackageVersion(string fileVersion, string packageVersion, bool hasDiagnostic)
 		{
 			var code = $@"
 using System;
@@ -60,7 +61,7 @@ class FooClass
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
-		public async Task NoDiagnosticWhenNoPackageVersionAsync()
+		public async Task NoDiagnosticWhenNoPackageVersion()
 		{
 			var code = $@"
 using System;
@@ -83,7 +84,7 @@ class FooClass
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
-		public async Task NoDiagnosticWhenNoFileVersionOrPackageVersionAsync()
+		public async Task NoDiagnosticWhenNoFileVersionOrPackageVersion()
 		{
 			var code = $@"
 using System;


### PR DESCRIPTION
Only `Major` and `Minor` version fields are required now, while `Build` and `Revision` are optional.