### PR TITLE
fix: Diagnostic on empty regions

### DIFF
--- a/Documentation/Diagnostics/PH2141.md
+++ b/Documentation/Diagnostics/PH2141.md
@@ -3,7 +3,7 @@
 | Property | Value  |
 |--|--|
 | Package | [Philips.CodeAnalysis.MaintainabilityAnalyzers](https://www.nuget.org/packages/Philips.CodeAnalysis.MaintainabilityAnalyzers) |
-| Diagnostic ID | PH2140 |
+| Diagnostic ID | PH2141 |
 | Category  | [Readability](../Readability.md) |
 | Analyzer | [EnforceRegionsAnalyzer](https://github.com/philips-software/roslyn-analyzers/blob/main/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceRegionsAnalyzer.cs)
 | CodeFix  | No |
@@ -12,7 +12,7 @@
 
 ## Introduction
 
-Avoid writing rfegions with no code inside.
+Avoid writing regions with no code inside.
 
 ## How to solve
 

--- a/Documentation/Diagnostics/PH2141.md
+++ b/Documentation/Diagnostics/PH2141.md
@@ -1,0 +1,51 @@
+# PH2141: Avoid Empty Regions
+
+| Property | Value  |
+|--|--|
+| Package | [Philips.CodeAnalysis.MaintainabilityAnalyzers](https://www.nuget.org/packages/Philips.CodeAnalysis.MaintainabilityAnalyzers) |
+| Diagnostic ID | PH2140 |
+| Category  | [Readability](../Readability.md) |
+| Analyzer | [EnforceRegionsAnalyzer](https://github.com/philips-software/roslyn-analyzers/blob/main/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceRegionsAnalyzer.cs)
+| CodeFix  | No |
+| Severity | Error |
+| Enabled By Default | Yes |
+
+## Introduction
+
+Avoid writing rfegions with no code inside.
+
+## How to solve
+
+Remove the empty region.
+
+## Example
+
+Code that triggers a diagnostic:
+``` cs
+class BadExample
+{
+    #region Put some stuff here later
+    #endregion
+}
+
+```
+
+And the replacement code:
+``` cs
+class GoodExample
+{
+    #region Public Interface
+
+    public void GoodMethod()
+    {
+        return;
+    }
+
+    #endregion
+}
+
+```
+
+## Configuration
+
+This analyzer does not offer any special configuration. The general ways of [suppressing](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/suppress-warnings) diagnostics apply.

--- a/Philips.CodeAnalysis.Common/DiagnosticId.cs
+++ b/Philips.CodeAnalysis.Common/DiagnosticId.cs
@@ -134,5 +134,6 @@ namespace Philips.CodeAnalysis.Common
 		AvoidVoidReturn = 2138,
 		EnableDocumentationCreation = 2139,
 		AvoidExcludeFromCodeCoverage = 2140,
+		AvoidEmptyRegions = 2141,
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/LocationRangeModel.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/LocationRangeModel.cs
@@ -1,14 +1,19 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
+using Microsoft.CodeAnalysis;
+
 namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 {
 	public class LocationRangeModel
 	{
-		public LocationRangeModel(int startLine, int endLine)
+		public LocationRangeModel(Location location, int startLine, int endLine)
 		{
+			Location = location;
 			StartLine = startLine;
 			EndLine = endLine;
 		}
+
+		public Location Location { get; }
 
 		public int StartLine { get; }
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.csproj
@@ -122,6 +122,7 @@
 	    * Introduce PH2136: Avoid duplicate strings.
       * Introduce PH2139: Enable documentation creation.
       * Introduce PH2140: Avoid ExcludeFromCodeCoverage attribute.
+      * Introduce PH2141: Avoid Empty Regions.
     </PackageReleaseNotes>
     <Copyright>© 2019-2023 Koninklijke Philips N.V.</Copyright>
     <PackageTags>CSharp Maintainability Roslyn CodeAnalysis analyzers Philips</PackageTags>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Philips.CodeAnalysis.MaintainabilityAnalyzers.md
@@ -90,3 +90,4 @@
 | [PH2138](../Documentation/Diagnostics/PH2138.md)  | Avoid void returns                           | Methods that return void are mysterious. |
 | [PH2139](../Documentation/Diagnostics/PH2139.md)  | Enable documentation creation                | Add XML documentation generation to the project file, to be able to see Diagnostics for XML documentation. |
 | [PH2140](../Documentation/Diagnostics/PH2140.md)  | Avoid ExcludeFromCodeCoverage attribute      | Avoid the usage of the 'ExcludeFromCodeCoverage' attribute. |
+| [PH2141](../Documentation/Diagnostics/PH2141.md)  | Avoid Empty Regions                          | Avoid writing regions that have no code inside. |

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceRegionsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceRegionsAnalyzer.cs
@@ -240,15 +240,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 		/// </summary>
 		private static void CheckEmptyRegion(LocationRangeModel locationRange, IReadOnlyList<MemberDeclarationSyntax> members, SyntaxNodeAnalysisContext context)
 		{
-			var foundMemberInside = false;
-			foreach (MemberDeclarationSyntax member in members)
-			{
-				if (MemberPresentInRegion(member, locationRange))
-				{
-					foundMemberInside = true;
-					break;
-				}
-			}
+			var foundMemberInside = members.Any(m => MemberPresentInRegion(m, locationRange));
 
 			if (!foundMemberInside)
 			{

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceRegionsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceRegionsAnalyzer.cs
@@ -139,22 +139,19 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 					return;
 				}
 
-				if (RegionChecks.ContainsKey(regionName))
+				if (regionLocations.Remove(regionName))
 				{
-					if (regionLocations.Remove(regionName))
-					{
-						Location memberLocation = region.DirectiveNameToken.GetLocation();
-						CreateDiagnostic(memberLocation, context, regionName, EnforceNonDupliateRegion);
-					}
-					else
-					{
-						Location location = region.GetLocation();
-						Location memberLocation = region.DirectiveNameToken.GetLocation();
-						var lineNumber = GetMemberLineNumber(location);
+					Location memberLocation = region.DirectiveNameToken.GetLocation();
+					CreateDiagnostic(memberLocation, context, regionName, EnforceNonDupliateRegion);
+				}
+				else
+				{
+					Location location = region.GetLocation();
+					Location memberLocation = region.DirectiveNameToken.GetLocation();
+					var lineNumber = GetMemberLineNumber(location);
 
-						regionLocations.Add(regionName, new LocationRangeModel(memberLocation, lineNumber, lineNumber));
-						regionStartName = regionName;
-					}
+					regionLocations.Add(regionName, new LocationRangeModel(memberLocation, lineNumber, lineNumber));
+					regionStartName = regionName;
 				}
 			}
 			else
@@ -183,7 +180,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 		private static IReadOnlyDictionary<string, LocationRangeModel> PopulateRegionLocations(IReadOnlyList<DirectiveTriviaSyntax> regions, SyntaxNodeAnalysisContext context)
 		{
 			Dictionary<string, LocationRangeModel> regionLocations = new();
-			var regionStartName = "";
+			var regionStartName = string.Empty;
 			for (var i = 0; i < regions.Count; i++)
 			{
 				DirectiveTriviaSyntax region = regions[i];

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ProhibitDynamicKeywordAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ProhibitDynamicKeywordAnalyzerTest.cs
@@ -13,10 +13,6 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 	[TestClass]
 	public class ProhibitDynamicKeywordAnalyzerTest : DiagnosticVerifier
 	{
-		#region Non-Public Data Members
-
-		#endregion
-
 		#region Non-Public Properties/Methods
 
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/EnforceRegionsTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/EnforceRegionsTest.cs
@@ -201,7 +201,7 @@ class Foo
 		{
 			var givenText = @"
 class C {{
-  #region Non-Public Data Members
+  #region Some Small Region
 
   #endregion
 }}
@@ -209,6 +209,22 @@ class C {{
 			await VerifyDiagnostic(givenText, DiagnosticId.AvoidEmptyRegions, regex: EnforceRegionsAnalyzer.AvoidEmptyRegionMessageFormat, line: 3, column: 4).ConfigureAwait(false);
 		}
 
+		[TestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public async Task AvoidRegionInsideMethod()
+		{
+			var givenText = @"
+class C {{
+  public void LongMethod() {{
+    private int i = 0;
+    #region Inside Method
+    i++;
+    #endregion
+  }}
+}}
+";
+			await VerifySuccessfulCompilation(givenText);
+		}
 
 		[DataTestMethod]
 		[DataRow(@"#region Constants", false)]

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/EnforceRegionsTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/EnforceRegionsTest.cs
@@ -195,6 +195,21 @@ class Foo
 			await VerifyError(baseline, given, isError, 6, 2).ConfigureAwait(false);
 		}
 
+		[TestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public async Task AvoidEmptyRegion()
+		{
+			var givenText = @"
+class C {{
+  #region Non-Public Data Members
+
+  #endregion
+}}
+";
+			await VerifyDiagnostic(givenText, DiagnosticId.AvoidEmptyRegions, regex: EnforceRegionsAnalyzer.AvoidEmptyRegionMessageFormat, line: 3, column: 4).ConfigureAwait(false);
+		}
+
+
 		[DataTestMethod]
 		[DataRow(@"#region Constants", false)]
 		[DataRow(@"#region Public Properties/Methods", false)]

--- a/Philips.CodeAnalysis.Test/Moq/MockObjectsMustCallExistingConstructorsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Moq/MockObjectsMustCallExistingConstructorsAnalyzerTest.cs
@@ -16,10 +16,6 @@ namespace Philips.CodeAnalysis.Test.Moq
 	[TestClass]
 	public class MockObjectsMustCallExistingConstructorsAnalyzerTest : DiagnosticVerifier
 	{
-		#region Non-Public Data Members
-
-		#endregion
-
 		#region Non-Public Properties/Methods
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{

--- a/Philips.CodeAnalysis.Test/MsTest/AssertAreEqualLiteralAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AssertAreEqualLiteralAnalyzerTest.cs
@@ -14,10 +14,6 @@ namespace Philips.CodeAnalysis.Test.MsTest
 	[TestClass]
 	public class AssertAreEqualLiteralAnalyzerTest : AssertCodeFixVerifier
 	{
-		#region Non-Public Data Members
-
-		#endregion
-
 		#region Non-Public Properties/Methods
 
 		protected override DiagnosticResult GetExpectedDiagnostic(int expectedLineNumberErrorOffset = 0, int expectedColumnErrorOffset = 0)

--- a/Philips.CodeAnalysis.Test/MsTest/AssertFailAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AssertFailAnalyzerTest.cs
@@ -13,10 +13,6 @@ namespace Philips.CodeAnalysis.Test.MsTest
 	[TestClass]
 	public class AssertFailAnalyzerTest : AssertDiagnosticVerifier
 	{
-		#region Non-Public Data Members
-
-		#endregion
-
 		#region Non-Public Properties/Methods
 
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()

--- a/Philips.CodeAnalysis.Test/MsTest/AssertIsTrueLiteralAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AssertIsTrueLiteralAnalyzerTest.cs
@@ -14,10 +14,6 @@ namespace Philips.CodeAnalysis.Test.MsTest
 	[TestClass]
 	public class AssertIsTrueLiteralAnalyzerTest : AssertDiagnosticVerifier
 	{
-		#region Non-Public Data Members
-
-		#endregion
-
 		#region Non-Public Properties/Methods
 
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()

--- a/Philips.CodeAnalysis.Test/MsTest/AvoidAssertConditionalAccessAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AvoidAssertConditionalAccessAnalyzerTest.cs
@@ -15,10 +15,6 @@ namespace Philips.CodeAnalysis.Test.MsTest
 	[TestClass]
 	public class AvoidAssertConditionalAccessAnalyzerTest : AssertDiagnosticVerifier
 	{
-		#region Non-Public Data Members
-
-		#endregion
-
 		#region Non-Public Properties/Methods
 
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()

--- a/Philips.CodeAnalysis.Test/MsTest/DataTestMethodsHaveDataRowsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/DataTestMethodsHaveDataRowsAnalyzerTest.cs
@@ -16,10 +16,6 @@ namespace Philips.CodeAnalysis.Test.MsTest
 	[TestClass]
 	public class DataTestMethodsHaveDataRowsAnalyzerTest : DiagnosticVerifier
 	{
-		#region Non-Public Data Members
-
-		#endregion
-
 		#region Non-Public Properties/Methods
 
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodsMustBeInTestClassAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodsMustBeInTestClassAnalyzerTest.cs
@@ -14,10 +14,6 @@ namespace Philips.CodeAnalysis.Test.MsTest
 	[TestClass]
 	public class TestMethodsMustBeInTestClassAnalyzerTest : DiagnosticVerifier
 	{
-		#region Non-Public Data Members
-
-		#endregion
-
 		#region Non-Public Properties/Methods
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodsShouldHaveUniqueNamesAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodsShouldHaveUniqueNamesAnalyzerTest.cs
@@ -15,10 +15,6 @@ namespace Philips.CodeAnalysis.Test.MsTest
 	[TestClass]
 	public class TestMethodsShouldHaveUniqueNamesAnalyzerTest : DiagnosticVerifier
 	{
-		#region Non-Public Data Members
-
-		#endregion
-
 		#region Non-Public Properties/Methods
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
 		{

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodsShouldHaveValidReturnTypesAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodsShouldHaveValidReturnTypesAnalyzerTest.cs
@@ -13,10 +13,6 @@ namespace Philips.CodeAnalysis.Test.MsTest
 	[TestClass]
 	public class TestMethodsShouldHaveValidReturnTypesAnalyzerTest : DiagnosticVerifier
 	{
-		#region Non-Public Data Members
-
-		#endregion
-
 		#region Non-Public Properties/Methods
 
 		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()


### PR DESCRIPTION
Empty is defined here, as no `TypeDeclaration` or `MemberDeclaration` inside the region.

Please note that regions inside methods are allowed now.