### PR TITLE
fix: Fix all .NET 7 analyzer errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -66,7 +66,7 @@ csharp_preferred_modifier_order = public,private,protected,internal,static,exter
 dotnet_naming_symbols.parameters.applicable_kinds = parameter
 dotnet_naming_style.camel_case.capitalization = camel_case
 dotnet_naming_rule.parameter_must_be_camel_case.symbols  = parameters
-dotnet_naming_rule.parameter_must_be_camel_case.style    = camel_case
+dotnet_naming_rule.parameter_must_be_camel_case.style = camel_case
 dotnet_naming_rule.parameter_must_be_camel_case.severity = error
 
 
@@ -88,6 +88,10 @@ dotnet_diagnostic.CA1847.severity = none
 
 # Do not facilitate static methods
 dotnet_diagnostic.CA1822.severity = none
+
+# Requested overload not present in .NET standard
+dotnet_diagnostic.CA1866.severity = none
+dotnet_diagnostic.CA1862.severity = none
 
 dotnet_diagnostic.CA1724.severity = error
 dotnet_diagnostic.CA1825.severity = error
@@ -201,4 +205,54 @@ dotnet_code_quality.PH2015.allowed_test_categories = TestDefinitions.UnitTests
 dotnet_code_quality.PH2028.company_name = Koninklijke Philips N.V.
 dotnet_code_quality.PH2075.assembly_version = 1.0.3.0
 dotnet_code_quality.PH2079.namespace_prefix = Philips.CodeAnalysis
+csharp_using_directive_placement = outside_namespace:silent
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_prefer_braces = true:silent
+csharp_style_namespace_declarations = block_scoped:silent
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = true:silent
+csharp_style_prefer_primary_constructors = true:suggestion
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_throw_expression = true:suggestion
+csharp_style_prefer_null_check_over_type_check = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_style_prefer_utf8_string_literals = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
 
+
+[*.{cs,vb}]
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_prefer_collection_expression = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = false:silent
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_namespace_match_folder = true:suggestion
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+indent_size = 4
+end_of_line = crlf

--- a/Philips.CodeAnalysis.Common/AdditionalFilesHelper.cs
+++ b/Philips.CodeAnalysis.Common/AdditionalFilesHelper.cs
@@ -32,7 +32,7 @@ namespace Philips.CodeAnalysis.Common
 		public virtual HashSet<string> InitializeExceptions(string exceptionsFile, string diagnosticId)
 		{
 			ExceptionsOptions = LoadExceptionsOptions(diagnosticId);
-			HashSet<string> exceptions = new();
+			HashSet<string> exceptions = [];
 			if (ExceptionsOptions.ShouldUseExceptionsFile)
 			{
 				exceptions = LoadExceptions(exceptionsFile);
@@ -54,12 +54,12 @@ namespace Philips.CodeAnalysis.Common
 				}
 			}
 
-			return new HashSet<string>();
+			return [];
 		}
 
 		public virtual HashSet<string> Convert(SourceText text)
 		{
-			HashSet<string> result = new();
+			HashSet<string> result = [];
 			foreach (TextLine line in text.Lines)
 			{
 				_ = result.Add(line.ToString());
@@ -106,7 +106,7 @@ namespace Philips.CodeAnalysis.Common
 		/// <returns></returns>
 		public virtual IReadOnlyList<string> GetValuesFromEditorConfig(string diagnosticId, string settingKey)
 		{
-			List<string> values = new();
+			List<string> values = [];
 			var value = GetValueFromEditorConfig(diagnosticId, settingKey);
 
 			foreach (var v in value.Split(','))

--- a/Philips.CodeAnalysis.Common/AllowedSymbols.cs
+++ b/Philips.CodeAnalysis.Common/AllowedSymbols.cs
@@ -28,10 +28,10 @@ namespace Philips.CodeAnalysis.Common
 		internal AllowedSymbols(Compilation compilation)
 		{
 			_compilation = compilation;
-			_allowedMethods = new HashSet<IMethodSymbol>();
-			_allowedTypes = new HashSet<ITypeSymbol>();
-			_allowedNamespaces = new HashSet<INamespaceSymbol>();
-			_allowedLines = new HashSet<string>();
+			_allowedMethods = [];
+			_allowedTypes = [];
+			_allowedNamespaces = [];
+			_allowedLines = [];
 		}
 
 		/// <summary>

--- a/Philips.CodeAnalysis.Common/ConstructorSyntaxHelper.cs
+++ b/Philips.CodeAnalysis.Common/ConstructorSyntaxHelper.cs
@@ -17,8 +17,8 @@ namespace Philips.CodeAnalysis.Common
 
 		public IReadOnlyDictionary<ConstructorDeclarationSyntax, ConstructorDeclarationSyntax> CreateMapping(SyntaxNodeAnalysisContext context, ConstructorDeclarationSyntax[] constructors)
 		{
-			Dictionary<ConstructorDeclarationSyntax, ISymbol> deferredCtor = new();
-			Dictionary<ISymbol, ConstructorDeclarationSyntax> symbolToCtor = new();
+			Dictionary<ConstructorDeclarationSyntax, ISymbol> deferredCtor = [];
+			Dictionary<ISymbol, ConstructorDeclarationSyntax> symbolToCtor = [];
 
 			foreach (ConstructorDeclarationSyntax ctor in constructors)
 			{
@@ -35,7 +35,7 @@ namespace Philips.CodeAnalysis.Common
 				}
 			}
 
-			Dictionary<ConstructorDeclarationSyntax, ConstructorDeclarationSyntax> result = new();
+			Dictionary<ConstructorDeclarationSyntax, ConstructorDeclarationSyntax> result = [];
 			foreach (ConstructorDeclarationSyntax ctor in constructors)
 			{
 				if (deferredCtor.TryGetValue(ctor, out ISymbol otherCtor) && otherCtor != null)
@@ -49,9 +49,9 @@ namespace Philips.CodeAnalysis.Common
 
 		public IReadOnlyList<ConstructorDeclarationSyntax> GetCtorChain(IReadOnlyDictionary<ConstructorDeclarationSyntax, ConstructorDeclarationSyntax> mapping, ConstructorDeclarationSyntax ctor)
 		{
-			List<ConstructorDeclarationSyntax> chain = new() { ctor };
+			List<ConstructorDeclarationSyntax> chain = [ctor];
 
-			HashSet<ConstructorDeclarationSyntax> seenConstructors = new();
+			HashSet<ConstructorDeclarationSyntax> seenConstructors = [];
 			while (true)
 			{
 				if (!mapping.TryGetValue(ctor, out ctor))

--- a/Philips.CodeAnalysis.Common/DocumentationHelper.cs
+++ b/Philips.CodeAnalysis.Common/DocumentationHelper.cs
@@ -11,7 +11,7 @@ namespace Philips.CodeAnalysis.Common
 	public class DocumentationHelper
 	{
 		private const string ExceptionElementName = "exception";
-		private readonly List<XmlElementSyntax> _xmlElements = new();
+		private readonly List<XmlElementSyntax> _xmlElements = [];
 
 		public static SyntaxNode FindAncestorThatCanHaveDocumentation(SyntaxNode node)
 		{

--- a/Philips.CodeAnalysis.Common/Inspection/CallTreeIteratorDeepestFirst.cs
+++ b/Philips.CodeAnalysis.Common/Inspection/CallTreeIteratorDeepestFirst.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.Common.Inspection
 		public CallTreeIteratorDeepestFirst(CallTreeNode root)
 		{
 			_root = root;
-			_visited = new HashSet<CallTreeNode>();
+			_visited = [];
 			Reset();
 		}
 

--- a/Philips.CodeAnalysis.Common/Inspection/CallTreeNode.cs
+++ b/Philips.CodeAnalysis.Common/Inspection/CallTreeNode.cs
@@ -14,11 +14,11 @@ namespace Philips.CodeAnalysis.Common.Inspection
 		private const int VirtualCallOpcode = 0x6F;
 		private const int NewObjectCallOpcode = 0x73;
 		private readonly List<CallTreeNode> _children;
-		private static readonly Dictionary<string, CallTreeNode> Cache = new();
+		private static readonly Dictionary<string, CallTreeNode> Cache = [];
 
 		public CallTreeNode(MethodDefinition method, CallTreeNode parent)
 		{
-			_children = new();
+			_children = [];
 			Method = method;
 			Parent = parent;
 		}

--- a/Philips.CodeAnalysis.Common/NamespacesHelper.cs
+++ b/Philips.CodeAnalysis.Common/NamespacesHelper.cs
@@ -17,7 +17,7 @@ namespace Philips.CodeAnalysis.Common
 		public bool IsNamespaceExempt(string myNamespace)
 		{
 			// https://developercommunity.visualstudio.com/t/error-cs0518-predefined-type-systemruntimecompiler/1244809
-			List<string> exceptions = new() { "System.Runtime.CompilerServices" };
+			List<string> exceptions = ["System.Runtime.CompilerServices"];
 			return exceptions.Contains(myNamespace);
 		}
 

--- a/Philips.CodeAnalysis.DuplicateCodeAnalyzer/AvoidDuplicateCodeAnalyzer.cs
+++ b/Philips.CodeAnalysis.DuplicateCodeAnalyzer/AvoidDuplicateCodeAnalyzer.cs
@@ -107,10 +107,11 @@ namespace Philips.CodeAnalysis.DuplicateCodeAnalyzer
 		private sealed class CompilationAnalyzer
 		{
 			private readonly DuplicateDetector _library = new();
-			private readonly List<Diagnostic> _diagnostics = new();
+			private readonly List<Diagnostic> _diagnostics = [];
 			private readonly int _duplicateTokenThreshold;
 			private readonly Helper _helper;
 			private readonly bool _shouldGenerateExceptionsFile;
+			private static readonly char[] separator = new[] { ':' };
 
 			public CompilationAnalyzer(int duplicateTokenThreshold, Helper helper, bool shouldGenerateExceptionsFile, Diagnostic configurationError)
 			{
@@ -199,7 +200,7 @@ namespace Philips.CodeAnalysis.DuplicateCodeAnalyzer
 			private void CreateExceptionDiagnostic(Exception ex, SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
 			{
 				StringBuilder builder = new();
-				var lines = ex.StackTrace.Split(new[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
+				var lines = ex.StackTrace.Split(separator, StringSplitOptions.RemoveEmptyEntries);
 				foreach (var line in lines)
 				{
 					if (line.StartsWith("line") && line.Length >= 8)
@@ -230,7 +231,7 @@ namespace Philips.CodeAnalysis.DuplicateCodeAnalyzer
 
 			private string GetShapeDetails(SyntaxToken token)
 			{
-				List<SyntaxToken> tokens = new();
+				List<SyntaxToken> tokens = [];
 				SyntaxToken currentToken = token;
 				for (var i = 0; i < _duplicateTokenThreshold; i++)
 				{
@@ -414,7 +415,7 @@ namespace Philips.CodeAnalysis.DuplicateCodeAnalyzer
 
 	public class DuplicateDetector
 	{
-		private readonly Dictionary<int, List<Evidence>> _library = new();
+		private readonly Dictionary<int, List<Evidence>> _library = [];
 		private readonly object _lock = new();
 
 		public Evidence Register(int key, Evidence value)
@@ -436,10 +437,7 @@ namespace Philips.CodeAnalysis.DuplicateCodeAnalyzer
 				}
 
 				// New key
-				existingValues = new List<Evidence>
-				{
-					value
-				};
+				existingValues = [value];
 				_library.Add(key, existingValues);
 				return null;
 			}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/DocumentUnhandledExceptionsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/DocumentUnhandledExceptionsAnalyzer.cs
@@ -38,7 +38,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 
 			IEnumerable<InvocationExpressionSyntax> invocations = Node.DescendantNodes().OfType<InvocationExpressionSyntax>();
 			ExceptionWalker walker = new();
-			List<string> unhandledExceptions = new();
+			List<string> unhandledExceptions = [];
 			foreach (InvocationExpressionSyntax invocation in invocations)
 			{
 				IEnumerable<string> newExceptions = walker.UnhandledFromInvocation(invocation, aliases, Context.SemanticModel);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/ExceptionWalker.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/ExceptionWalker.cs
@@ -75,7 +75,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 			IEnumerable<string> lastOpenExceptions = Array.Empty<string>();
 			foreach (CallTreeNode node in iterator)
 			{
-				HashSet<string> openExceptions = new();
+				HashSet<string> openExceptions = [];
 				if (TrySkipMethod(node, out MethodBody body) || TryGetFromCache(node, ref lastOpenExceptions))
 				{
 					continue;
@@ -173,7 +173,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 
 		private string GetFullName(ISymbol symbol)
 		{
-			List<string> namespaces = new();
+			List<string> namespaces = [];
 			INamespaceSymbol ns = symbol.ContainingNamespace;
 			while (ns != null && !string.IsNullOrEmpty(ns.Name))
 			{

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/XmlDocumentationShouldAddValueAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/XmlDocumentationShouldAddValueAnalyzer.cs
@@ -36,6 +36,8 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(EmptyRule, ValueRule);
 
+		private static readonly char[] separator = new[] { ' ' };
+
 		protected override void InitializeCompilation(CompilationStartAnalysisContext context)
 		{
 			var line = Helper.ForAdditionalFiles.GetValueFromEditorConfig(ValueRule.Id, @"additional_useless_words");
@@ -174,7 +176,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 		private static IEnumerable<string> SplitInWords(string input)
 		{
 			var pruned = input.Replace(',', ' ').Replace('.', ' ').ToLowerInvariant();
-			return pruned.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).Select(w => w.TrimEnd('s'));
+			return pruned.Split(separator, StringSplitOptions.RemoveEmptyEntries).Select(w => w.TrimEnd('s'));
 		}
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidArrayListCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidArrayListCodeFixProvider.cs
@@ -65,7 +65,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		/// Types of the Generic Arguments, which themselves may be generic types
 		/// </param>
 		/// <returns>An instance of TypeSyntax from the Roslyn Model</returns>
-		private static TypeSyntax CreateGenericTypeSyntax(string identifier, params TypeSyntax[] arguments)
+		private static GenericNameSyntax CreateGenericTypeSyntax(string identifier, params TypeSyntax[] arguments)
 		{
 			System.Collections.Generic.IEnumerable<TypeSyntax> args = arguments.Select(
 				x =>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidInvocationAsArgumentCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidInvocationAsArgumentCodeFixProvider.cs
@@ -107,7 +107,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 			}
 			else
 			{
-				List<SyntaxNode> newNodes = new() { formattedLocalDeclarationSyntax, newFullExistingExpressionSyntax };
+				List<SyntaxNode> newNodes = [formattedLocalDeclarationSyntax, newFullExistingExpressionSyntax];
 				rootNode = rootNode.ReplaceNode(fullExistingExpressionSyntax, newNodes);
 			}
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidStaticClassesCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidStaticClassesCodeFixProvider.cs
@@ -38,7 +38,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 		private SourceText AddLineToSourceText(SourceText sourceText, string line)
 		{
-			List<string> list = new();
+			List<string> list = [];
 			foreach (TextLine textLine in sourceText.Lines)
 			{
 				list.Add(textLine.ToString());

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidTryParseWithoutCultureAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidTryParseWithoutCultureAnalyzer.cs
@@ -25,11 +25,11 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 	public class AvoidTryParseWithoutCultureSyntaxNodeAction : SyntaxNodeAction<InvocationExpressionSyntax>
 	{
 		private const string TryParseMethodName = @"TryParse";
-		private static readonly HashSet<string> CultureParameterTypes = new()
-		{
+		private static readonly HashSet<string> CultureParameterTypes =
+		[
 			@"IFormatProvider",
 			@"CultureInfo"
-		};
+		];
 
 		public override void Analyze()
 		{

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/CallExtensionMethodsAsInstanceMethodsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/CallExtensionMethodsAsInstanceMethodsAnalyzer.cs
@@ -63,7 +63,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 		private bool HasMultipleCallables(int position, SemanticModel semanticModel, ImmutableArray<ISymbol> statics, IMethodSymbol currentMethod)
 		{
-			HashSet<ISymbol> didCheck = new();
+			HashSet<ISymbol> didCheck = [];
 			Queue<ISymbol> toCheck = new(statics);
 
 			var count = 0;

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/ReturnImmutableCollectionsCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/ReturnImmutableCollectionsCodeFixProvider.cs
@@ -22,7 +22,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		private const string ReadonlyDictionary = "IReadOnlyDictionary";
 		private const string ReadonlyList = "IReadOnlyList";
 
-		private static readonly IReadOnlyDictionary<string, string> CollectionsMap = new Dictionary<string, string>()
+		private static readonly Dictionary<string, string> CollectionsMap = new()
 		{
 			{StringConstants.List, ReadonlyList},
 			{StringConstants.QueueClassName, ReadonlyCollection},

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/NoSpaceInFilenameAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/NoSpaceInFilenameAnalyzer.cs
@@ -56,7 +56,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 			}
 
 			var filePath = context.Tree.FilePath;
-			if (filePath.IndexOf(' ') != -1)
+			if (filePath.Contains(" "))
 			{
 				var location = Location.Create(context.Tree, TextSpan.FromBounds(0, 0));
 				var diagnostic = Diagnostic.Create(Rule, location, filePath);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/PositiveNamingAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/PositiveNamingAnalyzer.cs
@@ -28,7 +28,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 		{
 			var additionalWords = Helper.ForAdditionalFiles.GetValueFromEditorConfig(Rule.Id, @"negative_words");
 			var words = additionalWords.Split(',');
-			if (words.Any())
+			if (words.Length != 0)
 			{
 				IEnumerable<string> filteredWords = words.Where(x => !string.IsNullOrWhiteSpace(x)).Select(w => w.Trim());
 				NegativeWords.AddRange(filteredWords);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidInlineNewAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidInlineNewAnalyzer.cs
@@ -22,7 +22,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 
 	public class AvoidInlineNewSyntaxNodeAction : SyntaxNodeAction<ObjectCreationExpressionSyntax>
 	{
-		private static readonly HashSet<string> AllowedMethods = new() { StringConstants.ToStringMethodName, StringConstants.ToListMethodName, StringConstants.ToArrayMethodName, "AsSpan" };
+		private static readonly HashSet<string> AllowedMethods = [StringConstants.ToStringMethodName, StringConstants.ToListMethodName, StringConstants.ToArrayMethodName, "AsSpan"];
 
 		public override void Analyze()
 		{

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidMultipleLambdasOnSingleLineAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidMultipleLambdasOnSingleLineAnalyzer.cs
@@ -57,9 +57,9 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 			context.ReportDiagnostic(Diagnostic.Create(Rule, loc));
 		}
 
-		private static IEnumerable<LambdaExpressionSyntax> FindOtherLambdasOnSameLine(LambdaExpressionSyntax ourLambda, IEnumerable<LambdaExpressionSyntax> lambdas)
+		private static List<LambdaExpressionSyntax> FindOtherLambdasOnSameLine(LambdaExpressionSyntax ourLambda, IEnumerable<LambdaExpressionSyntax> lambdas)
 		{
-			List<LambdaExpressionSyntax> result = new();
+			List<LambdaExpressionSyntax> result = [];
 			var theLine = ourLambda.GetLocation().GetLineSpan().StartLinePosition.Line;
 			foreach (LambdaExpressionSyntax lambda in lambdas)
 			{

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceRegionsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceRegionsAnalyzer.cs
@@ -159,9 +159,9 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 		/// <param name="regions">Regions found in the file</param>
 		/// <param name="context">Tha Analysis context</param>
 		/// <returns>Dictionary of region name and LocationRangeModel object</returns>
-		private static IReadOnlyDictionary<string, LocationRangeModel> PopulateRegionLocations(IReadOnlyList<DirectiveTriviaSyntax> regions, SyntaxNodeAnalysisContext context)
+		private static Dictionary<string, LocationRangeModel> PopulateRegionLocations(IReadOnlyList<DirectiveTriviaSyntax> regions, SyntaxNodeAnalysisContext context)
 		{
-			Dictionary<string, LocationRangeModel> regionLocations = new();
+			Dictionary<string, LocationRangeModel> regionLocations = [];
 			var regionStartName = "";
 			for (var i = 0; i < regions.Count; i++)
 			{
@@ -177,7 +177,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 		/// <param name="members">List of members</param>
 		/// <param name="locationRange">LocationRangeModel object</param>
 		/// <returns>List of members belonging to the given region</returns>
-		private static IReadOnlyList<MemberDeclarationSyntax> GetMembersOfRegion(SyntaxList<MemberDeclarationSyntax> members, LocationRangeModel locationRange)
+		private static List<MemberDeclarationSyntax> GetMembersOfRegion(SyntaxList<MemberDeclarationSyntax> members, LocationRangeModel locationRange)
 		{
 			return members.Where(member => MemberPresentInRegion(member, locationRange)).ToList();
 		}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/RegionVisitor.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/RegionVisitor.cs
@@ -9,7 +9,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers
 {
 	public class RegionVisitor : CSharpSyntaxWalker
 	{
-		private readonly List<DirectiveTriviaSyntax> _regions = new();
+		private readonly List<DirectiveTriviaSyntax> _regions = [];
 
 		public RegionVisitor() : base(SyntaxWalkerDepth.StructuredTrivia)
 		{ }

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AssertIsTrueCodeFixProvider.cs
@@ -108,7 +108,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			return document.WithSyntaxRoot(root);
 		}
 
-		private StatementSyntax CreateAssert(ExpressionSyntax test, bool isIsTrue, ArgumentSyntax[] additionalArguments)
+		private ExpressionStatementSyntax CreateAssert(ExpressionSyntax test, bool isIsTrue, ArgumentSyntax[] additionalArguments)
 		{
 			SeparatedSyntaxList<ArgumentSyntax> newArguments = new();
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestAttributeDiagnosticAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestAttributeDiagnosticAnalyzer.cs
@@ -58,7 +58,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 				return;
 			}
 
-			HashSet<INamedTypeSymbol> presentAttributes = new();
+			HashSet<INamedTypeSymbol> presentAttributes = [];
 			foreach (INamedTypeSymbol attribute in methodSymbol.GetAttributes().Select(attribute => attribute.AttributeClass))
 			{
 				if (definitions.NonTestMethods.Contains(attribute))

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestHasTimeoutAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestHasTimeoutAnalyzer.cs
@@ -35,7 +35,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 		private sealed class TestHasTimeout : TestMethodImplementation
 		{
 			private readonly object _lock1 = new();
-			private readonly Dictionary<string, ImmutableList<string>> _configuredTimeouts = new();
+			private readonly Dictionary<string, ImmutableList<string>> _configuredTimeouts = [];
 
 			public TestHasTimeout(MsTestAttributeDefinitions definitions, Helper helper) : base(definitions, helper)
 			{
@@ -79,7 +79,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 					ImmutableDictionary<string, string> additionalData = ImmutableDictionary<string, string>.Empty;
 
 					//it doesn't have a timeout.  To help the fixer, see if it has a category...
-					if (hasCategory && TryExtractAttributeArgument(context, categoryArgumentSyntax, out _, out string categoryForDiagnostic) && TryGetAllowedTimeouts(categoryForDiagnostic, out ImmutableList<string> allowed) && allowed.Any())
+					if (hasCategory && TryExtractAttributeArgument(context, categoryArgumentSyntax, out _, out string categoryForDiagnostic) && TryGetAllowedTimeouts(categoryForDiagnostic, out ImmutableList<string> allowed) && !allowed.IsEmpty)
 					{
 						var firstAllowedTimeout = allowed.First();
 						additionalData = additionalData.Add(DefaultTimeoutKey, firstAllowedTimeout);
@@ -110,7 +110,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 				{
 					ImmutableDictionary<string, string> additionalData = ImmutableDictionary<string, string>.Empty;
 
-					if (TryGetAllowedTimeouts(category, out ImmutableList<string> allowed) && allowed.Any())
+					if (TryGetAllowedTimeouts(category, out ImmutableList<string> allowed) && !allowed.IsEmpty)
 					{
 						var firstAllowed = allowed.First();
 						additionalData = additionalData.Add(DefaultTimeoutKey, firstAllowed);
@@ -153,7 +153,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 				if (!timeouts.Contains(argumentString))
 				{
-					List<string> timeoutStrings = new();
+					List<string> timeoutStrings = [];
 					foreach (var timeoutString in timeouts)
 					{
 						timeoutStrings.Add($"\"{timeoutString}\"");

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsMustHaveTheCorrectNumberOfArgumentsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsMustHaveTheCorrectNumberOfArgumentsAnalyzer.cs
@@ -75,7 +75,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			{
 				hasAnyCustomDataSources = false;
 				hasAnyDynamicData = false;
-				dataRowParameters = new();
+				dataRowParameters = [];
 				foreach (AttributeSyntax attribute in methodDeclaration.AttributeLists.SelectMany(x => x.Attributes))
 				{
 					if (Helper.ForAttributes.IsDataRowAttribute(attribute, context))

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsShouldHaveUniqueNamesAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodsShouldHaveUniqueNamesAnalyzer.cs
@@ -26,7 +26,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 		protected override void OnTestClass(SyntaxNodeAnalysisContext context, ClassDeclarationSyntax classDeclaration)
 		{
-			HashSet<MethodDeclarationSyntax> testMethods = new();
+			HashSet<MethodDeclarationSyntax> testMethods = [];
 			foreach (MemberDeclarationSyntax member in classDeclaration.Members)
 			{
 				if (member is not MethodDeclarationSyntax method || !Helper.ForTests.IsTestMethod(method, context))
@@ -37,7 +37,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 				_ = testMethods.Add(method);
 			}
 
-			HashSet<string> seenNames = new();
+			HashSet<string> seenNames = [];
 			foreach (SyntaxToken methodIdentifier in testMethods
 						 .Select(method => method.Identifier)
 						 .Where(id => !seenNames.Add(id.ToString())))

--- a/Philips.CodeAnalysis.Test/Common/AdditionalFilesHelperTest.cs
+++ b/Philips.CodeAnalysis.Test/Common/AdditionalFilesHelperTest.cs
@@ -110,7 +110,7 @@ namespace Philips.CodeAnalysis.Test.Common
 			return new AnalyzerOptions(additionalTexts, new TestAnalyzerConfigOptionsProvider(settings));
 		}
 
-		private static Compilation CreateCompilation()
+		private static CSharpCompilation CreateCompilation()
 		{
 			var dummyText = SourceText.From("");
 			SyntaxTree tree = SyntaxFactory.ParseSyntaxTree(dummyText);

--- a/Philips.CodeAnalysis.Test/Common/AnalyzerPerformanceRecordTest.cs
+++ b/Philips.CodeAnalysis.Test/Common/AnalyzerPerformanceRecordTest.cs
@@ -56,8 +56,8 @@ namespace Philips.CodeAnalysis.Test.Common
 			// Arrange
 			var list = new List<AnalyzerPerformanceRecord>(2)
 			{
-				new AnalyzerPerformanceRecord() { Time = 42 },
-				new AnalyzerPerformanceRecord() { Time = 2 }
+				new() { Time = 42 },
+				new() { Time = 2 }
 			};
 
 			// Act

--- a/Philips.CodeAnalysis.Test/DuplicateCode/AvoidDuplicateCodeAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/DuplicateCode/AvoidDuplicateCodeAnalyzerTest.cs
@@ -1,6 +1,5 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -269,22 +268,22 @@ Foo.WhitelistedFunction";
 		public void DuplicateDictionaryTest()
 		{
 			var dictionary = new DuplicateDetector();
-			var e1 = new Evidence(null, new List<int>() { 10 }, 10);
+			var e1 = new Evidence(null, [10], 10);
 
 			Evidence existing = dictionary.Register(1, e1);
 			Assert.IsNull(existing);
 
-			var e2 = new Evidence(null, new List<int>() { 20 }, 20);
+			var e2 = new Evidence(null, [20], 20);
 
 			existing = dictionary.Register(2, e2);
 			Assert.IsNull(existing);
 
-			var e3 = new Evidence(null, new List<int>() { 30 }, 30);
+			var e3 = new Evidence(null, [30], 30);
 
 			existing = dictionary.Register(2, e3);
 			Assert.IsNull(existing);
 
-			var e4 = new Evidence(null, new List<int>() { 30 }, 30);
+			var e4 = new Evidence(null, [30], 30);
 
 			existing = dictionary.Register(2, e4);
 			Assert.IsNotNull(existing);

--- a/Philips.CodeAnalysis.Test/Helpers/TestAnalyzerConfigOptionsProvider.cs
+++ b/Philips.CodeAnalysis.Test/Helpers/TestAnalyzerConfigOptionsProvider.cs
@@ -13,7 +13,7 @@ namespace Philips.CodeAnalysis.Test.Helpers
 
 		public TestAnalyzerConfigOptions(Dictionary<string, string> settings)
 		{
-			_settings = settings ?? new Dictionary<string, string>();
+			_settings = settings ?? [];
 		}
 
 		public override bool TryGetValue(string key, [NotNullWhen(true)] out string value)

--- a/Philips.CodeAnalysis.Test/Helpers/TestTextLoader.cs
+++ b/Philips.CodeAnalysis.Test/Helpers/TestTextLoader.cs
@@ -10,7 +10,7 @@ namespace Philips.CodeAnalysis.Test.Helpers
 {
 	public class TestTextLoader : TextLoader
 	{
-		private readonly Dictionary<DocumentId, string> _textDocuments = new();
+		private readonly Dictionary<DocumentId, string> _textDocuments = [];
 
 		public void Register(DocumentId documentId, string content)
 		{

--- a/Philips.CodeAnalysis.Test/Moq/MockRaiseArgumentsMustMatchEventAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Moq/MockRaiseArgumentsMustMatchEventAnalyzerTest.cs
@@ -208,7 +208,7 @@ public static class Bar
 }}
 ";
 
-			List<DiagnosticResult> diagnosticResults = new();
+			List<DiagnosticResult> diagnosticResults = [];
 
 			for (var i = 0; i < errorCount; i++)
 			{

--- a/Philips.CodeAnalysis.Test/MsTest/TestMethodsMustHaveTheCorrectNumberOfArgumentsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestMethodsMustHaveTheCorrectNumberOfArgumentsAnalyzerTest.cs
@@ -171,7 +171,7 @@ public class Tests
 
 			if (dataRowParameters >= 0)
 			{
-				List<string> dataRowParametersStrings = new();
+				List<string> dataRowParametersStrings = [];
 				for (var i = 0; i < dataRowParameters; i++)
 				{
 					dataRowParametersStrings.Add(i.ToString());

--- a/Philips.CodeAnalysis.Test/Verifiers/CodeFixVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/CodeFixVerifier.cs
@@ -20,6 +20,8 @@ namespace Philips.CodeAnalysis.Test.Verifiers
 	/// </summary>
 	public abstract partial class CodeFixVerifier : DiagnosticVerifier
 	{
+		private static readonly char[] NewLineCharacters = new[] { '\n', '\r' };
+
 		/// <summary>
 		/// Returns the codefix being tested (C#) - to be implemented in non-abstract class
 		/// </summary>
@@ -96,7 +98,7 @@ namespace Philips.CodeAnalysis.Test.Verifiers
 				var context = new CodeFixContext(document, firstDiagnostic, (a, d) => actions.Add(a), CancellationToken.None);
 				codeFixProvider.RegisterCodeFixesAsync(context).Wait();
 
-				if (!actions.Any())
+				if (actions.Count == 0)
 				{
 					break;
 				}
@@ -151,8 +153,8 @@ namespace Philips.CodeAnalysis.Test.Verifiers
 
 			// After applying all of the code fixes, compare the resulting string to the inputted one
 			var actualSource = await GetStringFromDocument(document).ConfigureAwait(false);
-			var actualSourceLines = actualSource.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
-			var expectedSourceLines = expectedSource.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
+			var actualSourceLines = actualSource.Split(NewLineCharacters, StringSplitOptions.RemoveEmptyEntries);
+			var expectedSourceLines = expectedSource.Split(NewLineCharacters, StringSplitOptions.RemoveEmptyEntries);
 			Assert.AreEqual(expectedSourceLines.Length, actualSourceLines.Length, @"The result's line code differs from the expected result's line code.");
 			for (var i = 0; i < actualSourceLines.Length; i++)
 			{

--- a/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.Helper.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.Helper.cs
@@ -149,7 +149,7 @@ namespace Philips.CodeAnalysis.Test.Verifiers
 				CompilationOptions options = compilation.Options.WithSpecificDiagnosticOptions(specificOptions);
 				Compilation modified = compilation.WithOptions(options);
 
-				List<AdditionalText> additionalTextsBuilder = new();
+				List<AdditionalText> additionalTextsBuilder = [];
 				foreach (TextDocument textDocument in project.AdditionalDocuments)
 				{
 					SourceText contents = await textDocument.GetTextAsync().ConfigureAwait(false);
@@ -174,7 +174,7 @@ namespace Philips.CodeAnalysis.Test.Verifiers
 
 		private async Task<IReadOnlyList<Diagnostic>> CollectOurDiagnostics(ImmutableArray<Diagnostic> diags, IEnumerable<Document> documents)
 		{
-			List<Diagnostic> diagnostics = new();
+			List<Diagnostic> diagnostics = [];
 			foreach (Diagnostic diag in diags)
 			{
 				if (diag.Location == Location.None || diag.Location.IsInMetadata)
@@ -201,7 +201,7 @@ namespace Philips.CodeAnalysis.Test.Verifiers
 		/// </summary>
 		/// <param name="diagnostics">The list of Diagnostics to be sorted</param>
 		/// <returns>An IEnumerable containing the Diagnostics in order of Location</returns>
-		private static IEnumerable<Diagnostic> SortDiagnostics(IEnumerable<Diagnostic> diagnostics)
+		private static Diagnostic[] SortDiagnostics(IEnumerable<Diagnostic> diagnostics)
 		{
 			return diagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToArray();
 		}
@@ -216,7 +216,7 @@ namespace Philips.CodeAnalysis.Test.Verifiers
 		/// <param name="filenamePrefix">The name of the source file, without the extension</param>
 		/// <param name="assemblyName">The name of the resulting assembly of the compilation, without the extension</param>
 		/// <returns>A Tuple containing the Documents produced from the sources and their TextSpans if relevant</returns>
-		private IEnumerable<Document> GetDocuments(string[] sources, string filenamePrefix, string assemblyName)
+		private Document[] GetDocuments(string[] sources, string filenamePrefix, string assemblyName)
 		{
 			Project project = CreateProject(sources, filenamePrefix, assemblyName);
 			Document[] documents = project.Documents.ToArray();
@@ -252,7 +252,7 @@ namespace Philips.CodeAnalysis.Test.Verifiers
 
 		protected virtual ImmutableArray<DocumentInfo> GetAdditionalDocumentInfos(ProjectId projectId)
 		{
-			List<DocumentInfo> list = new();
+			List<DocumentInfo> list = [];
 			ImmutableArray<(string name, string content)> details = GetAdditionalTexts();
 			TestTextLoader textLoader = new();
 			foreach ((var name, var content) in details)


### PR DESCRIPTION
Our CI pipeline got upgraded to a newer version of .NET 7 This also adds some extra Analyser rules.