### PR TITLE
fix: Limit the length of strings to inspect 

### DIFF
--- a/Documentation/Diagnostics/PH2080.md
+++ b/Documentation/Diagnostics/PH2080.md
@@ -12,11 +12,15 @@
 
 ## Introduction
 
-Avoid hardcoded absolute paths, as they are bound the change without notice. For performance reasons, only the first 1000 charcters of a string literal are inspected.
+Avoid hardcoded absolute paths, as they are bound the change without notice. For performance reasons, only the first 259 charcters of a string literal are inspected.
 
 ## How to solve
 
-Use configuration instead, for example using `App.config`.
+Use configuration instead, for example using `App.config`. 
+
+## Remarks
+
+Only Windows absolute or UNC paths are reported. Formatted like: "c:\\temp\example.xml" or "\\server\share\example.xml"
 
 ## Example
 

--- a/Documentation/Diagnostics/PH2080.md
+++ b/Documentation/Diagnostics/PH2080.md
@@ -12,7 +12,7 @@
 
 ## Introduction
 
-Avoid hardcoded absolute paths, as they are bound the change without notice. For performance reasons, only the first 1000 charcters of s stirng literal are inspected.
+Avoid hardcoded absolute paths, as they are bound the change without notice. For performance reasons, only the first 1000 charcters of a string literal are inspected.
 
 ## How to solve
 

--- a/Documentation/Diagnostics/PH2080.md
+++ b/Documentation/Diagnostics/PH2080.md
@@ -12,7 +12,7 @@
 
 ## Introduction
 
-Avoid hardcoded absolute paths, as they are bound the change without notice. 
+Avoid hardcoded absolute paths, as they are bound the change without notice. For performance reasons, only the first 1000 charcters of s stirng literal are inspected.
 
 ## How to solve
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoHardCodedPathsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoHardCodedPathsAnalyzerTest.cs
@@ -20,7 +20,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
-		public async Task CatchesHardCodedAbsoluteWindowsPathsAsync()
+		public async Task CatchesHardCodedAbsoluteWindowsPaths()
 		{
 			const string template = @"
 using System;
@@ -38,7 +38,7 @@ class Foo
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
-		public async Task CatchesHardCodedAbsoluteWindowsPathWithDoubleSlashAsync()
+		public async Task CatchesHardCodedAbsoluteWindowsPathWithDoubleSlash()
 		{
 			const string template = @"
 using System;
@@ -57,7 +57,7 @@ class Foo
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
-		public async Task CatchesHardCodedPathsRegardlessOfCaseAsync()
+		public async Task CatchesHardCodedPathsRegardlessOfCase()
 		{
 			const string template = @"
 using System;
@@ -75,7 +75,7 @@ class Foo
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
-		public async Task CatchesHardCodedPaths2Async()
+		public async Task CatchesHardCodedPaths2()
 		{
 			const string template = @"
 using System;
@@ -104,7 +104,7 @@ class Foo
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
-		public async Task CatchesHardCodedPathsWithSpaceAsync()
+		public async Task CatchesHardCodedPathsWithSpace()
 		{
 			const string template = @"
 using System;
@@ -123,7 +123,26 @@ class Foo
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
-		public async Task CatchesHardCodedPathsWithSpecialCharactersAsync()
+		public async Task CatchesHardCodedPathsInLongStringLiterals()
+		{
+			const string template = @"
+using System;
+class Foo
+{
+	public void Test()
+	{
+		string path = @""c:\users\test in a veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery long string literal"";
+	}
+}
+";
+
+			await VerifyDiagnostic(template, DiagnosticId.NoHardcodedPaths).ConfigureAwait(false);
+
+		}
+
+		[TestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public async Task CatchesHardCodedPathsWithSpecialCharacters()
 		{
 			const string template = @"
 using System;
@@ -143,7 +162,7 @@ class Foo
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
-		public async Task DoesNotCatchNormalStringAsync()
+		public async Task DoesNotCatchNormalString()
 		{
 			const string template = @"
 using System;
@@ -162,7 +181,7 @@ class Foo
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
-		public async Task DoesNotCatchShortStringAsync()
+		public async Task DoesNotCatchShortString()
 		{
 			const string template = @"
 using System;
@@ -180,7 +199,7 @@ class Foo
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
-		public async Task DoesNotCatchEmptyStringAsync()
+		public async Task DoesNotCatchEmptyString()
 		{
 			const string template = @"
 using System;
@@ -198,7 +217,7 @@ class Foo
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
-		public async Task DoesNotCatchRelativePathAsync()
+		public async Task DoesNotCatchRelativePath()
 		{
 			const string template = @"
 using system;
@@ -215,7 +234,7 @@ class foo
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
-		public async Task DoesNotCatchPathsInCommentsAsync()
+		public async Task DoesNotCatchPathsInComments()
 		{
 			const string template = @"
 using System;
@@ -236,7 +255,7 @@ class Foo
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
-		public async Task DoesNotCatchPathsInTestCodeAsync()
+		public async Task DoesNotCatchPathsInTestCode()
 		{
 			const string template = @"
 using System;

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoHardCodedPathsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoHardCodedPathsAnalyzerTest.cs
@@ -75,6 +75,24 @@ class Foo
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
+		public async Task CatchesHardCodedPathsAsUnc()
+		{
+			const string template = @"
+using System;
+class Foo
+{
+	public void Test()
+	{
+		string path = @""\\server\share\BIN\EXAMPLE.XML"";
+	}
+}
+";
+			await VerifyDiagnostic(template, DiagnosticId.NoHardcodedPaths).ConfigureAwait(false);
+
+		}
+
+		[TestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task CatchesHardCodedPaths2()
 		{
 			const string template = @"
@@ -131,7 +149,7 @@ class Foo
 {
 	public void Test()
 	{
-		string path = @""c:\users\test in a veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery long string literal"";
+		string path = @""c:\users\test in a veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery long string literal"";
 	}
 }
 ";

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoHardCodedPathsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoHardCodedPathsAnalyzerTest.cs
@@ -33,7 +33,6 @@ class Foo
 }
 ";
 			await VerifyDiagnostic(template, DiagnosticId.NoHardcodedPaths).ConfigureAwait(false);
-
 		}
 
 		[TestMethod]
@@ -51,7 +50,6 @@ class Foo
 }
 ";
 			await VerifyDiagnostic(template, DiagnosticId.NoHardcodedPaths).ConfigureAwait(false);
-
 		}
 
 
@@ -70,7 +68,6 @@ class Foo
 }
 ";
 			await VerifyDiagnostic(template, DiagnosticId.NoHardcodedPaths).ConfigureAwait(false);
-
 		}
 
 		[TestMethod]
@@ -88,7 +85,6 @@ class Foo
 }
 ";
 			await VerifyDiagnostic(template, DiagnosticId.NoHardcodedPaths).ConfigureAwait(false);
-
 		}
 
 		[TestMethod]
@@ -117,7 +113,6 @@ class Foo
 }
 ";
 			await VerifyDiagnostic(template, DiagnosticId.NoHardcodedPaths).ConfigureAwait(false);
-
 		}
 
 		[TestMethod]
@@ -136,7 +131,6 @@ class Foo
 ";
 
 			await VerifyDiagnostic(template, DiagnosticId.NoHardcodedPaths).ConfigureAwait(false);
-
 		}
 
 		[TestMethod]
@@ -155,7 +149,6 @@ class Foo
 ";
 
 			await VerifyDiagnostic(template, DiagnosticId.NoHardcodedPaths).ConfigureAwait(false);
-
 		}
 
 		[TestMethod]
@@ -174,7 +167,6 @@ class Foo
 ";
 
 			await VerifyDiagnostic(template, DiagnosticId.NoHardcodedPaths).ConfigureAwait(false);
-
 		}
 
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoHardCodedPathsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoHardCodedPathsAnalyzerTest.cs
@@ -93,7 +93,7 @@ class Foo
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
-		public async Task CatchesHardCodedPaths2()
+		public async Task CatchesHardCodedPathsAsAbsolute()
 		{
 			const string template = @"
 using System;


### PR DESCRIPTION
Set the limit to 1000, hard coded, to prevent the analysis taking too much time.

Created #735 to prevent creating long string literals in the first place.