### PR TITLE
chore: Fix performance pipeline

### DIFF
--- a/Philips.CodeAnalysis.AnalyzerPerformance/Philips.CodeAnalysis.AnalyzerPerformance.csproj
+++ b/Philips.CodeAnalysis.AnalyzerPerformance/Philips.CodeAnalysis.AnalyzerPerformance.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.820" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.206" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Apparently, msbuild version is updated in the runners