### PR TITLE
fix: Empty region false positives

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceRegionsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceRegionsAnalyzer.cs
@@ -78,9 +78,17 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 			visitor.Visit(typeDeclaration);
 
 			IReadOnlyList<DirectiveTriviaSyntax> regions = visitor.Regions;
-
+			if (regions.Count == 0)
+			{
+				return;
+			}
 			// Region directives should come in pairs
-			if (regions.Count == 1)
+			if (regions.Count % 2 == 1)
+			{
+				return;
+			}
+			// In obscure cases, the pair may start with #endregion due to mismatches
+			if (regions[0].Kind() == SyntaxKind.EndRegionDirectiveTrivia)
 			{
 				return;
 			}
@@ -181,6 +189,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 		{
 			Dictionary<string, LocationRangeModel> regionLocations = [];
 			var regionStartName = string.Empty;
+
 			for (var i = 0; i < regions.Count; i++)
 			{
 				DirectiveTriviaSyntax region = regions[i];

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/EnforceRegionsTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/EnforceRegionsTest.cs
@@ -199,13 +199,51 @@ class Foo
 		{
 			var givenText = @"
 class C {{
-  #region Some Small Region
-
-  #endregion
+	#region Dictionaries
+	#endregion
 }}
 ";
-			await VerifyDiagnostic(givenText, DiagnosticId.AvoidEmptyRegions, regex: EnforceRegionsAnalyzer.AvoidEmptyRegionMessageFormat, line: 3, column: 4).ConfigureAwait(false);
+			await VerifyDiagnostic(givenText, DiagnosticId.AvoidEmptyRegions).ConfigureAwait(false);
 		}
+
+
+		[TestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public async Task AvoidEmptyRegionFalsePositive1()
+		{
+			// 2 Analyses/sets triggered, but first #endregion is with second set (which now has 3 items)
+			var givenText = @"
+namespace MyNamespace {{
+	#region Dictionaries
+	public class StringToActionDictionary {{ }}
+	#endregion
+
+	#region Lists
+	public class ObjectList {{ }}
+	#endregion
+}}
+";
+			await VerifySuccessfulCompilation(givenText).ConfigureAwait(false);
+		}
+
+		[TestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public async Task AvoidEmptyRegionFalsePositive2()
+		{
+			// 2 Analyses/sets triggered, but first #endregion is with second set (which should have 3 items (not good), but
+			// last #endregion is excluded, so perceived as a pair, starting with an #endregion.
+			var givenText = @"
+	#region Dictionaries
+	public class StringToActionDictionary {{ }}
+	#endregion
+
+	#region Lists
+	public class ObjectList {{ }}
+	#endregion
+";
+			await VerifySuccessfulCompilation(givenText).ConfigureAwait(false);
+		}
+
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]


### PR DESCRIPTION
The EnforceRegion analyzers work by inspecting the trivia associated with a class declaration. If there are multiple class declarations in the same file, region pairs may not align together, and the analyzer becomes confused. Added some sanity checks to exit gracefully in these situations (rather than strengthening the analyzer for these unusual conditions).