### PR TITLE
fix: bail on nested regions

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceRegionsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceRegionsAnalyzer.cs
@@ -52,7 +52,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 
 		private static readonly DiagnosticDescriptor EnforceMemberLocation = new(DiagnosticId.EnforceRegions.ToId(), EnforceRegionTitle,
 			EnforceRegionMessageFormat, EnforceRegionCategory, DiagnosticSeverity.Error, isEnabledByDefault: true, description: EnforceRegionDescription);
-		private static readonly DiagnosticDescriptor EnforceNonDupliateRegion = new(DiagnosticId.EnforceNonDuplicateRegion.ToId(),
+		private static readonly DiagnosticDescriptor EnforceNonDuplicateRegion = new(DiagnosticId.EnforceNonDuplicateRegion.ToId(),
 			EnforceNonDuplicateRegionTitle, EnforceNonDuplicateRegionMessageFormat, EnforceNonDuplicateRegionCategory,
 			DiagnosticSeverity.Error, isEnabledByDefault: true, description: EnforceNonDuplicateRegionDescription);
 		private static readonly DiagnosticDescriptor NonCheckedMember = new(DiagnosticId.NonCheckedRegionMember.ToId(),
@@ -62,7 +62,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 			AvoidEmptyRegionMessageFormat, AvoidEmptyRegionCategory, DiagnosticSeverity.Error, isEnabledByDefault: true, description: AvoidEmptyRegionDescription);
 
 
-		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(EnforceMemberLocation, EnforceNonDupliateRegion, NonCheckedMember, AvoidEmpty);
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(EnforceMemberLocation, EnforceNonDuplicateRegion, NonCheckedMember, AvoidEmpty);
 
 		protected override void InitializeCompilation(CompilationStartAnalysisContext context)
 		{
@@ -89,6 +89,11 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 			}
 			// In obscure cases, the pair may start with #endregion due to mismatches
 			if (regions[0].Kind() == SyntaxKind.EndRegionDirectiveTrivia)
+			{
+				return;
+			}
+			// In nested cases, just exit
+			if (regions[1].Kind() == SyntaxKind.RegionDirectiveTrivia)
 			{
 				return;
 			}
@@ -150,7 +155,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 				if (regionLocations.Remove(regionName))
 				{
 					Location memberLocation = region.DirectiveNameToken.GetLocation();
-					CreateDiagnostic(memberLocation, context, regionName, EnforceNonDupliateRegion);
+					CreateDiagnostic(memberLocation, context, regionName, EnforceNonDuplicateRegion);
 				}
 				else
 				{

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/XmlDocumentationShouldAddValueAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/XmlDocumentationShouldAddValueAnalyzerTest.cs
@@ -57,6 +57,31 @@ public class Foo
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
+		public async Task DefaultWhiteSpaceWithBaseTest()
+		{
+			var content = $@"
+		/// <summary>
+		/// 
+		/// </summary>
+		public DoubleList(int capacity)
+			: base(capacity)
+		{{
+		}}
+";
+
+			var newContent = $@"
+		public DoubleList(int capacity)
+			: base(capacity)
+		{{
+		}}
+";
+
+			await VerifyDiagnostic(content, DiagnosticId.EmptyXmlComments).ConfigureAwait(false);
+			await VerifyFix(content, newContent);
+		}
+
+		[TestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task EmptyClassTestAsync()
 		{
 			var content = $@"
@@ -537,7 +562,7 @@ public class TestClass
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
-		public async Task ConstructorTestAsync()
+		public async Task ConstructorTest()
 		{
 			var content = $@"
 public class Foo
@@ -550,8 +575,48 @@ public class Foo
 	}}
 }}
 ";
+			var newContent = $@"
+public class Foo
+{{
+	public Foo()
+	{{
+	}}
+}}
+";
 
 			await VerifyDiagnostic(content, DiagnosticId.XmlDocumentationShouldAddValue).ConfigureAwait(false);
+			await VerifyFix(content, newContent);
 		}
+
+		[TestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public async Task ConstructorWithBaseTest()
+		{
+			var content = $@"
+public class Foo : BaseClass
+{{
+	/// <summary>
+	/// Constructor
+	/// </summary>
+	public Foo()
+		: base()
+	{{
+	}}
+}}
+";
+			var newContent = $@"
+public class Foo : BaseClass
+{{
+	public Foo()
+		: base()
+	{{
+	}}
+}}
+";
+
+			await VerifyDiagnostic(content, DiagnosticId.XmlDocumentationShouldAddValue).ConfigureAwait(false);
+			await VerifyFix(content, newContent);
+		}
+
 	}
 }

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/EnforceRegionsTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/EnforceRegionsTest.cs
@@ -289,7 +289,7 @@ class Foo
 		[DataTestMethod]
 		[DataRow(@"Non-Public Properties/Methods")]
 		[TestCategory(TestDefinitions.UnitTests)]
-		public async Task DupliateRegionTest(string given)
+		public async Task DuplicateRegionTest(string given)
 		{
 			var baseline = @"
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -309,6 +309,24 @@ class Foo
 }}";
 			var givenText = string.Format(baseline, given);
 			await VerifyDiagnostic(givenText, DiagnosticId.EnforceNonDuplicateRegion, regex: EnforceRegionsAnalyzer.EnforceNonDuplicateRegionMessageFormat, line: 8, column: 3).ConfigureAwait(false);
+		}
+
+		[TestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public async Task NestedRegionsTest()
+		{
+			var givenText = @"
+namespace MyNamespace {{
+	#region Dictionaries
+	#region Lists
+	public class ObjectList {{ }}
+	#endregion
+	public class StringToActionDictionary {{ }}
+	#endregion
+
+}}
+";
+			await VerifySuccessfulCompilation(givenText).ConfigureAwait(false);
 		}
 
 		private async Task VerifyError(string baseline, string given, bool isError, int line = 6, int column = 2)


### PR DESCRIPTION
Analyzer that scans regions does not work well with nested regions. Gracefully bail out in this scenario.