### PR TITLE
refactor: CodeFixVerifier more strict with newlines

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/PreventUnnecessaryRangeChecksCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/PreventUnnecessaryRangeChecksCodeFixProvider.cs
@@ -1,13 +1,11 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
-using System;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Text;
@@ -50,10 +48,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 			{
 				replaceNode = replaceNode.WithLeadingTrivia(leadingTrivia);
 			}
-			SyntaxTrivia newLine = SyntaxFactory.SyntaxTrivia(SyntaxKind.WhitespaceTrivia, Environment.NewLine);
-
-			SyntaxTriviaList trivia = trailingTrivia.Insert(0, newLine);
-			replaceNode = replaceNode.WithTrailingTrivia(trivia);
+			replaceNode = replaceNode.WithTrailingTrivia(trailingTrivia);
 
 			root = root.ReplaceNode(node, replaceNode).WithAdditionalAnnotations(Formatter.Annotation);
 

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/DocumentThrownExceptionsAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/DocumentThrownExceptionsAnalyzerTest.cs
@@ -163,6 +163,7 @@ public class Foo
 {
     /// <summary> Helpful text. </summary>
     /// <exception>
+
     /// <exception cref=""ArgumentException""></exception>
     public void MethodA()
     {
@@ -172,54 +173,54 @@ public class Foo
 ";
 
 		private const string WrongEmptyCref = @"
-public class Foo
-{
-    /// <summary> Helpful text. </summary>
-    /// <exception cref=""""></exception>
-    public void MethodA()
-    {
-        throw new ArgumentException(""Error"");
-    }
-}
-";
+		public class Foo
+		{
+			/// <summary> Helpful text. </summary>
+			/// <exception cref=""""></exception>
+			public void MethodA()
+			{
+				throw new ArgumentException(""Error"");
+			}
+		}
+		";
 
 		private const string FixedEmptyCref = @"
-public class Foo
-{
-    /// <summary> Helpful text. </summary>
-    /// <exception cref=""""></exception>
-    /// <exception cref=""ArgumentException""></exception>
-    public void MethodA()
-    {
-        throw new ArgumentException(""Error"");
-    }
-}
-";
+		public class Foo
+		{
+			/// <summary> Helpful text. </summary>
+			/// <exception cref=""""></exception>
+			/// <exception cref=""ArgumentException""></exception>
+			public void MethodA()
+			{
+				throw new ArgumentException(""Error"");
+			}
+		}
+		";
 
 		private const string WrongType = @"
-public class Foo
-{
-    /// <summary> Helpful text. </summary>
-    /// <exception cref=""InvalidOperationException""></exception>
-    public void MethodA()
-    {
-        throw new ArgumentException(""Error"");
-    }
-}
-";
+		public class Foo
+		{
+			/// <summary> Helpful text. </summary>
+			/// <exception cref=""InvalidOperationException""></exception>
+			public void MethodA()
+			{
+				throw new ArgumentException(""Error"");
+			}
+		}
+		";
 
 		private const string FixedWrongType = @"
-public class Foo
-{
-    /// <summary> Helpful text. </summary>
-    /// <exception cref=""InvalidOperationException""></exception>
-	/// <exception cref=""ArgumentException""></exception>
-    public void MethodA()
-    {
-        throw new ArgumentException(""Error"");
-    }
-}
-";
+		public class Foo
+		{
+			/// <summary> Helpful text. </summary>
+			/// <exception cref=""InvalidOperationException""></exception>
+			/// <exception cref=""ArgumentException""></exception>
+			public void MethodA()
+			{
+				throw new ArgumentException(""Error"");
+			}
+		}
+		";
 
 		private const string WrongInProperty = @"
 public class Foo

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidEmptyTypeInitializerAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/AvoidEmptyTypeInitializerAnalyzerTest.cs
@@ -56,8 +56,6 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		}
 
 		[DataRow("  /// <summary />")]
-		[DataRow(@"  /** <summary>
-  </summary> */")]
 		[DataTestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task AvoidEmptyTypeInitializerStaticWithFix(string summaryComment)
@@ -72,7 +70,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 			var classContent = string.Format(template, string.Format(@"{0}
 static Foo() {{ }}", summaryComment));
 
-			var expected = string.Format(template, "  \r\n");
+			var expected = string.Format(template, string.Empty);
 
 			await VerifyFix(classContent, expected).ConfigureAwait(false);
 		}

--- a/Philips.CodeAnalysis.Test/MsTest/AssertIsTrueAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/AssertIsTrueAnalyzerTest.cs
@@ -67,7 +67,7 @@ namespace Philips.CodeAnalysis.Test.MsTest
 		}
 
 		[DataTestMethod]
-		[DataRow("Assert.IsTrue(true && true)", "Assert.IsTrue(true);\n      Assert.IsTrue(true)")]
+		[DataRow("Assert.IsTrue(true && true)", "Assert.IsTrue(true);\r\n      Assert.IsTrue(true)")]
 		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task CanBreakDownCompoundStatements(string given, string expected)
 		{
@@ -75,8 +75,8 @@ namespace Philips.CodeAnalysis.Test.MsTest
 		}
 
 		[DataTestMethod]
-		[DataRow("Assert.IsTrue(true && true, \"blah\")", "Assert.IsTrue(true, \"blah\");\n      Assert.IsTrue(true, \"blah\")")]
-		[DataRow("Assert.IsTrue(true && true, \"blah{0}\", 1)", "Assert.IsTrue(true, \"blah{0}\", 1);\n      Assert.IsTrue(true, \"blah{0}\", 1)")]
+		[DataRow("Assert.IsTrue(true && true, \"blah\")", "Assert.IsTrue(true, \"blah\");\r\n      Assert.IsTrue(true, \"blah\")")]
+		[DataRow("Assert.IsTrue(true && true, \"blah{0}\", 1)", "Assert.IsTrue(true, \"blah{0}\", 1);\r\n      Assert.IsTrue(true, \"blah{0}\", 1)")]
 		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task PreserveCompoundMessages(string given, string expected)
 		{

--- a/Philips.CodeAnalysis.Test/MsTest/TestHasTimeoutAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/TestHasTimeoutAnalyzerTest.cs
@@ -45,11 +45,11 @@ class TestDefinitions
 		}
 
 		[DataTestMethod]
-		[DataRow("[STATestMethod]", "[STATestMethod]\n    [Timeout(1000)]")]
-		[DataRow("[TestMethod]", "[TestMethod]\n    [Timeout(1000)]")]
-		[DataRow("[TestMethod, Owner(\"\")]", "[TestMethod, Owner(\"\")]\n    [Timeout(1000)]")]
-		[DataRow("[DataTestMethod]", "[DataTestMethod]\n    [Timeout(1000)]")]
-		[DataRow("[TestMethod, TestCategory(TestDefinitions.UnitTests)]", "[TestMethod, TestCategory(TestDefinitions.UnitTests)]\n    [Timeout(TestTimeouts.CiAppropriate)]")]
+		[DataRow("[STATestMethod]", "[STATestMethod]\r\n    [Timeout(1000)]")]
+		[DataRow("[TestMethod]", "[TestMethod]\r\n    [Timeout(1000)]")]
+		[DataRow("[TestMethod, Owner(\"\")]", "[TestMethod, Owner(\"\")]\r\n    [Timeout(1000)]")]
+		[DataRow("[DataTestMethod]", "[DataTestMethod]\r\n    [Timeout(1000)]")]
+		[DataRow("[TestMethod, TestCategory(TestDefinitions.UnitTests)]", "[TestMethod, TestCategory(TestDefinitions.UnitTests)]\r\n    [Timeout(TestTimeouts.CiAppropriate)]")]
 		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task TimeoutAttributeNotPresent(string methodAttributes, string expectedMethodAttributes)
 		{
@@ -57,8 +57,8 @@ class TestDefinitions
 		}
 
 		[DataTestMethod]
-		[DataRow("[STATestMethod]", "[STATestMethod]\n    [Timeout(1000)]")]
-		[DataRow("[TestMethod]", "[TestMethod]\n    [Timeout(1000)]")]
+		[DataRow("[STATestMethod]", "[STATestMethod]\r\n    [Timeout(1000)]")]
+		[DataRow("[TestMethod]", "[TestMethod]\r\n    [Timeout(1000)]")]
 		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task TimeoutAttributeNotPresentNoCategory(string methodAttributes, string expectedMethodAttributes)
 		{
@@ -66,8 +66,8 @@ class TestDefinitions
 		}
 
 		[DataTestMethod]
-		[DataRow("[STATestMethod, TestCategory(\"foo\")]", "[STATestMethod, TestCategory(\"foo\")]\n    [Timeout(1000)]")]
-		[DataRow("[TestMethod, TestCategory(\"foo\")]", "[TestMethod, TestCategory(\"foo\")]\n    [Timeout(1000)]")]
+		[DataRow("[STATestMethod, TestCategory(\"foo\")]", "[STATestMethod, TestCategory(\"foo\")]\r\n    [Timeout(1000)]")]
+		[DataRow("[TestMethod, TestCategory(\"foo\")]", "[TestMethod, TestCategory(\"foo\")]\r\n    [Timeout(1000)]")]
 		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task TimeoutAttributeNotPresentUnknownCategory(string methodAttributes, string expectedMethodAttributes)
 		{

--- a/Philips.CodeAnalysis.Test/Verifiers/CodeFixVerifier.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/CodeFixVerifier.cs
@@ -20,8 +20,6 @@ namespace Philips.CodeAnalysis.Test.Verifiers
 	/// </summary>
 	public abstract partial class CodeFixVerifier : DiagnosticVerifier
 	{
-		private static readonly char[] NewLineCharacters = new[] { '\n', '\r' };
-
 		/// <summary>
 		/// Returns the codefix being tested (C#) - to be implemented in non-abstract class
 		/// </summary>
@@ -153,8 +151,8 @@ namespace Philips.CodeAnalysis.Test.Verifiers
 
 			// After applying all of the code fixes, compare the resulting string to the inputted one
 			var actualSource = await GetStringFromDocument(document).ConfigureAwait(false);
-			var actualSourceLines = actualSource.Split(NewLineCharacters, StringSplitOptions.RemoveEmptyEntries);
-			var expectedSourceLines = expectedSource.Split(NewLineCharacters, StringSplitOptions.RemoveEmptyEntries);
+			var actualSourceLines = actualSource.Split(Environment.NewLine);
+			var expectedSourceLines = expectedSource.Split(Environment.NewLine);
 			Assert.AreEqual(expectedSourceLines.Length, actualSourceLines.Length, @"The result's line code differs from the expected result's line code.");
 			for (var i = 0; i < actualSourceLines.Length; i++)
 			{


### PR DESCRIPTION
As part of a recent commit, it was discovered that our CodeFixVerifier wasn't handling newlines well. This tightens that up and updates Tests and Analyzers that failed as a result of the stricter newline handling. 2 Analyzers (DocumentThrownExceptionAnalyzers and AvoidEmptyTypeInitializer) would appear to benefit from some improvements, but that's beyond the scope of this change.