### PR TITLE
fix: enforce regions false positives

### DIFF
--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceRegionsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/EnforceRegionsAnalyzer.cs
@@ -87,15 +87,17 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 			{
 				return;
 			}
-			// In obscure cases, the pair may start with #endregion due to mismatches
-			if (regions[0].Kind() == SyntaxKind.EndRegionDirectiveTrivia)
+
+			// If pair is malformed (eg. #region followed by #region), bail out
+			for (var i = 0; i < regions.Count; i += 2)
 			{
-				return;
-			}
-			// In nested cases, just exit
-			if (regions[1].Kind() == SyntaxKind.RegionDirectiveTrivia)
-			{
-				return;
+				DirectiveTriviaSyntax start = regions[i];
+				DirectiveTriviaSyntax end = regions[i + 1];
+
+				if (start.IsKind(SyntaxKind.EndRegionDirectiveTrivia) || end.IsKind(SyntaxKind.RegionDirectiveTrivia))
+				{
+					return;
+				}
 			}
 
 			Dictionary<string, LocationRangeModel> regionLocations = PopulateRegionLocations(regions, context);

--- a/Philips.CodeAnalysis.Test/Maintainability/Readability/EnforceRegionsRemoveEmptyRegionAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Readability/EnforceRegionsRemoveEmptyRegionAnalyzerTest.cs
@@ -69,6 +69,31 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Readability
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
+		public async Task NestedRegionDoesNotTriggerEmptyRegion()
+		{
+			const string input = @"
+	public class MyClass
+	{
+		#region R1
+		private void Foo1() { }
+		#endregion
+
+		#region R2
+
+		#region R3
+		private void Foo2() { }
+		#endregion
+
+		#endregion
+	}
+";
+			await VerifySuccessfulCompilation(input).ConfigureAwait(false);
+		}
+
+
+
+		[TestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task RegionWithContentDoesNotTriggerDiagnostic()
 		{
 			const string input = @"public class Foo


### PR DESCRIPTION
Highly nested #regions still confuse the analyzer, because the analyzer is only safety checking the first region pair it encounters, and assumes subsequent regions are what it expects.