### PR TITLE
docs: Fixing small typo in documentation of PH2021

### DIFF
--- a/Documentation/Diagnostics/PH2021.md
+++ b/Documentation/Diagnostics/PH2021.md
@@ -3,7 +3,7 @@
 | Property | Value  |
 |--|--|
 | Package | [Philips.CodeAnalysis.MaintainabilityAnalyzers](https://www.nuget.org/packages/Philips.CodeAnalysis.MaintainabilityAnalyzers) |
-| Diagnostic ID | PH2022 |
+| Diagnostic ID | PH2021 |
 | Category  | [Readability](../Readability.md) |
 | Analyzer | [AvoidInlineNewAnalyzer](https://github.com/philips-software/roslyn-analyzers/blob/main/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/AvoidInlineNewAnalyzer.cs)
 | CodeFix  | No |


### PR DESCRIPTION
The documentation of PH2021 referenced the Diagnostic ID as PH2022. 
This is clearly a typo. See e.g. [here](https://github.com/philips-software/roslyn-analyzers/blob/45b8b2f6b8c6496972652dd7c89d377560fa2df3/Philips.CodeAnalysis.Common/DiagnosticId.cs#L28)