### PR TITLE
fix: Report PH2071 diagnostics inline for IDE support

### DIFF
--- a/Philips.CodeAnalysis.DuplicateCodeAnalyzer/AvoidDuplicateCodeAnalyzer.cs
+++ b/Philips.CodeAnalysis.DuplicateCodeAnalyzer/AvoidDuplicateCodeAnalyzer.cs
@@ -107,7 +107,7 @@ namespace Philips.CodeAnalysis.DuplicateCodeAnalyzer
 		private sealed class CompilationAnalyzer
 		{
 			private readonly DuplicateDetector _library = new();
-			private readonly List<Diagnostic> _diagnostics = [];
+			private readonly Diagnostic _configurationError;
 			private readonly int _duplicateTokenThreshold;
 			private readonly Helper _helper;
 			private readonly bool _shouldGenerateExceptionsFile;
@@ -118,10 +118,7 @@ namespace Philips.CodeAnalysis.DuplicateCodeAnalyzer
 				_duplicateTokenThreshold = duplicateTokenThreshold;
 				_helper = helper;
 				_shouldGenerateExceptionsFile = shouldGenerateExceptionsFile;
-				if (configurationError != null)
-				{
-					_diagnostics.Add(configurationError);
-				}
+				_configurationError = configurationError;
 			}
 
 			private string ToPrettyReference(FileLinePositionSpan fileSpan)
@@ -163,7 +160,7 @@ namespace Philips.CodeAnalysis.DuplicateCodeAnalyzer
 							{
 								Location location = evidence.LocationEnvelope.Contents();
 								Location existingEvidenceLocation = existingEvidence.LocationEnvelope.Contents();
-								CreateDuplicateDiagnostic(location, existingEvidenceLocation, token, methodDeclarationSyntax);
+								ReportDuplicateDiagnostic(obj, location, existingEvidenceLocation, token, methodDeclarationSyntax);
 
 								// Don't pile on.  Move on to the next method.
 								return;
@@ -173,11 +170,11 @@ namespace Philips.CodeAnalysis.DuplicateCodeAnalyzer
 				}
 				catch (Exception ex)
 				{
-					CreateExceptionDiagnostic(ex, obj);
+					ReportExceptionDiagnostic(obj, ex);
 				}
 			}
 
-			private void CreateDuplicateDiagnostic(Location location, Location existingEvidenceLocation, SyntaxToken token, MethodDeclarationSyntax methodDeclarationSyntax)
+			private void ReportDuplicateDiagnostic(SyntaxNodeAnalysisContext context, Location location, Location existingEvidenceLocation, SyntaxToken token, MethodDeclarationSyntax methodDeclarationSyntax)
 			{
 				// We found a duplicate, but if it's partially duplicated with itself, ignore it.
 				if (!location.SourceSpan.IntersectsWith(existingEvidenceLocation.SourceSpan))
@@ -186,7 +183,7 @@ namespace Philips.CodeAnalysis.DuplicateCodeAnalyzer
 					FileLinePositionSpan existingEvidenceLineSpan = existingEvidenceLocation.GetLineSpan();
 					var reference = ToPrettyReference(existingEvidenceLineSpan);
 
-					_diagnostics.Add(Diagnostic.Create(Rule, location, new List<Location>() { existingEvidenceLocation }, reference, shapeDetails));
+					context.ReportDiagnostic(Diagnostic.Create(Rule, location, new List<Location>() { existingEvidenceLocation }, reference, shapeDetails));
 
 					if (_shouldGenerateExceptionsFile)
 					{
@@ -195,7 +192,7 @@ namespace Philips.CodeAnalysis.DuplicateCodeAnalyzer
 				}
 			}
 
-			private void CreateExceptionDiagnostic(Exception ex, SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
+			private void ReportExceptionDiagnostic(SyntaxNodeAnalysisContext context, Exception ex)
 			{
 				StringBuilder builder = new();
 				var lines = ex.StackTrace.Split(separator, StringSplitOptions.RemoveEmptyEntries);
@@ -215,15 +212,15 @@ namespace Philips.CodeAnalysis.DuplicateCodeAnalyzer
 					result = ex.StackTrace.Replace(Environment.NewLine, " ## ");
 				}
 
-				Location location = syntaxNodeAnalysisContext.Node.GetLocation();
-				_diagnostics.Add(Diagnostic.Create(UnhandledExceptionRule, location, result, ex.Message));
+				Location location = context.Node.GetLocation();
+				context.ReportDiagnostic(Diagnostic.Create(UnhandledExceptionRule, location, result, ex.Message));
 			}
 
 			public void EndCompilationAction(CompilationAnalysisContext context)
 			{
-				foreach (Diagnostic diagnostic in _diagnostics)
+				if (_configurationError != null)
 				{
-					context.ReportDiagnostic(diagnostic);
+					context.ReportDiagnostic(_configurationError);
 				}
 			}
 

--- a/Philips.CodeAnalysis.DuplicateCodeAnalyzer/AvoidDuplicateCodeAnalyzer.cs
+++ b/Philips.CodeAnalysis.DuplicateCodeAnalyzer/AvoidDuplicateCodeAnalyzer.cs
@@ -170,7 +170,7 @@ namespace Philips.CodeAnalysis.DuplicateCodeAnalyzer
 				}
 				catch (Exception ex)
 				{
-					ReportExceptionDiagnostic(obj, ex);
+					CreateExceptionDiagnostic(ex, obj);
 				}
 			}
 
@@ -192,7 +192,7 @@ namespace Philips.CodeAnalysis.DuplicateCodeAnalyzer
 				}
 			}
 
-			private void ReportExceptionDiagnostic(SyntaxNodeAnalysisContext context, Exception ex)
+			private void CreateExceptionDiagnostic(Exception ex, SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
 			{
 				StringBuilder builder = new();
 				var lines = ex.StackTrace.Split(separator, StringSplitOptions.RemoveEmptyEntries);
@@ -212,8 +212,8 @@ namespace Philips.CodeAnalysis.DuplicateCodeAnalyzer
 					result = ex.StackTrace.Replace(Environment.NewLine, " ## ");
 				}
 
-				Location location = context.Node.GetLocation();
-				context.ReportDiagnostic(Diagnostic.Create(UnhandledExceptionRule, location, result, ex.Message));
+				Location location = syntaxNodeAnalysisContext.Node.GetLocation();
+				syntaxNodeAnalysisContext.ReportDiagnostic(Diagnostic.Create(UnhandledExceptionRule, location, result, ex.Message));
 			}
 
 			public void EndCompilationAction(CompilationAnalysisContext context)

--- a/Philips.CodeAnalysis.Test/DuplicateCode/AvoidDuplicateCodeAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/DuplicateCode/AvoidDuplicateCodeAnalyzerTest.cs
@@ -395,6 +395,49 @@ namespace MyNamespace
 	}
 
 	[TestClass]
+	public class AvoidDuplicateCodeInvalidTokenCountTest : DiagnosticVerifier
+	{
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
+		{
+			return new AvoidDuplicateCodeAnalyzer() { DefaultDuplicateTokenThreshold = 100 };
+		}
+
+		protected override ImmutableDictionary<string, string> GetAdditionalAnalyzerConfigOptions()
+		{
+			return base.GetAdditionalAnalyzerConfigOptions()
+				.Add($@"dotnet_code_quality.{AvoidDuplicateCodeAnalyzer.Rule.Id}.token_count", @"abc");
+		}
+
+		[TestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public async Task AvoidDuplicateCodeReportsInvalidTokenCountAsync()
+		{
+			var source = @"
+namespace MyNamespace
+{{
+  class FooClass
+  {{
+    public void Foo()
+    {{
+	  object obj = new object();
+    }}
+  }}
+}}
+";
+
+			await VerifyDiagnostic(source,
+				new DiagnosticResult()
+				{
+					Id = AvoidDuplicateCodeAnalyzer.Rule.Id,
+					Message = new Regex(".+invalid.+"),
+					Severity = DiagnosticSeverity.Error,
+					Locations = [],
+				}
+			).ConfigureAwait(false);
+		}
+	}
+
+	[TestClass]
 	public class AvoidDuplicateCodeGenerateExceptionsFileTest : AvoidDuplicateCodeAnalyzerTest
 	{
 		private const string GeneratedFileName = @"DuplicateCode.Allowed.GENERATED.txt";

--- a/Philips.CodeAnalysis.Test/DuplicateCode/AvoidDuplicateCodeAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/DuplicateCode/AvoidDuplicateCodeAnalyzerTest.cs
@@ -1,6 +1,7 @@
 ﻿// © 2019 Koninklijke Philips N.V. See License.md in the project root for license information.
 
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -390,6 +391,74 @@ namespace MyNamespace
 					}
 				}
 			).ConfigureAwait(false);
+		}
+	}
+
+	[TestClass]
+	public class AvoidDuplicateCodeGenerateExceptionsFileTest : AvoidDuplicateCodeAnalyzerTest
+	{
+		private const string GeneratedFileName = @"DuplicateCode.Allowed.GENERATED.txt";
+
+		protected override ImmutableDictionary<string, string> GetAdditionalAnalyzerConfigOptions()
+		{
+			return base.GetAdditionalAnalyzerConfigOptions()
+				.Add($@"dotnet_code_quality.{AvoidDuplicateCodeAnalyzer.Rule.Id}.generate_exceptions_file", @"true");
+		}
+
+		[TestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public async Task AvoidDuplicateCodeGeneratesExceptionsFileAsync()
+		{
+			// Ensure clean state
+			if (File.Exists(GeneratedFileName))
+			{
+				File.Delete(GeneratedFileName);
+			}
+
+			var source = @"
+namespace MyNamespace
+{{
+  class FooClass
+  {{
+    public void Foo()
+    {{
+	  object obj = new object(); object obj2 = new object(); object obj3 = new object();
+    }}
+    public void Bar()
+    {{
+	  object obj = new object(); object obj2 = new object(); object obj3 = new object();
+    }}
+  }}
+}}
+";
+
+			try
+			{
+				await VerifyDiagnostic(source,
+					new DiagnosticResult()
+					{
+						Id = AvoidDuplicateCodeAnalyzer.Rule.Id,
+						Message = new Regex("Duplicate shape found.+"),
+						Severity = DiagnosticSeverity.Error,
+						Locations = new[]
+						{
+							new DiagnosticResultLocation("Test0.cs", null, null),
+							new DiagnosticResultLocation("Test0.cs", null, null),
+						}
+					}
+				).ConfigureAwait(false);
+
+				Assert.IsTrue(File.Exists(GeneratedFileName), $"Expected {GeneratedFileName} to be generated when generate_exceptions_file is enabled.");
+				var content = File.ReadAllText(GeneratedFileName);
+				Assert.Contains("Bar", content);
+			}
+			finally
+			{
+				if (File.Exists(GeneratedFileName))
+				{
+					File.Delete(GeneratedFileName);
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Report duplicate code diagnostics directly from `SyntaxNodeAction` context instead of deferring to `CompilationEndAction`, enabling real-time inline error squiggles in IDEs
- Fixes a latent thread-safety bug where the shared `_diagnostics` list was written to from concurrent `SyntaxNodeAction` callbacks without synchronization
- Configuration errors (invalid `.editorconfig` token_count) still report via `CompilationEndAction`

## Test plan
- [x] All 17 existing `DuplicateCode` tests pass
- [x] New: `AvoidDuplicateCodeGeneratesExceptionsFileAsync` — covers `_shouldGenerateExceptionsFile` branch in `ReportDuplicateDiagnostic`
- [x] New: `AvoidDuplicateCodeReportsInvalidTokenCountAsync` — covers config error reporting through `EndCompilationAction`

NEW:
<img width="1257" height="645" alt="image" src="https://github.com/user-attachments/assets/786a5c57-9f3c-4f5f-a094-d92a281292e8" />

OLD (disappeared when clicked, just showed in build output and failed)
<img width="1202" height="505" alt="image" src="https://github.com/user-attachments/assets/75179d8f-3462-429e-b387-94b0e182b049" />

## Remaining uncovered code

The only uncovered new line is `syntaxNodeAnalysisContext.ReportDiagnostic(...)` inside `CreateExceptionDiagnostic` — the defensive catch-all for unexpected internal exceptions during syntax analysis. This requires contriving a failure inside Roslyn's syntax traversal, which is not a realistic scenario to unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)