### PR TITLE
feat: Migrate to CodeAnalysis 4.4, ending support for VS2019

### DIFF
--- a/Directory.Build.Analyzer.props
+++ b/Directory.Build.Analyzer.props
@@ -33,11 +33,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
     <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.34.2" PrivateAssets="all" ExcludeAssets="build" />

--- a/Philips.CodeAnalysis.Benchmark/Philips.CodeAnalysis.Benchmark.csproj
+++ b/Philips.CodeAnalysis.Benchmark/Philips.CodeAnalysis.Benchmark.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Philips.CodeAnalysis.Common/Philips.CodeAnalysis.Common.csproj
+++ b/Philips.CodeAnalysis.Common/Philips.CodeAnalysis.Common.csproj
@@ -7,7 +7,7 @@
     <AssemblyVersion>1.0.3.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.6" />
   </ItemGroup>
 </Project>

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/XmlDocumentationCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Documentation/XmlDocumentationCodeFixProvider.cs
@@ -27,7 +27,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Documentation
 			SyntaxNode newRoot = root;
 			foreach (SyntaxTrivia trivia in node.GetLeadingTrivia())
 			{
-				if (trivia.Kind() == SyntaxKind.SingleLineDocumentationCommentTrivia)
+				if (trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia))
 				{
 					newRoot = newRoot.ReplaceTrivia(trivia, SyntaxTriviaList.Empty);
 				}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidAsyncVoidAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidAsyncVoidAnalyzer.cs
@@ -42,7 +42,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 		{
 			var lambdaExpressionSyntax = (LambdaExpressionSyntax)context.Node;
 
-			if (lambdaExpressionSyntax.AsyncKeyword.Kind() != SyntaxKind.AsyncKeyword)
+			if (!lambdaExpressionSyntax.AsyncKeyword.IsKind(SyntaxKind.AsyncKeyword))
 			{
 				return;
 			}
@@ -70,7 +70,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 				return;
 			}
 
-			if (methodDeclaration.ReturnType is not PredefinedTypeSyntax predefinedTypeSyntax || predefinedTypeSyntax.Keyword.Kind() != SyntaxKind.VoidKeyword)
+			if (methodDeclaration.ReturnType is not PredefinedTypeSyntax predefinedTypeSyntax || !predefinedTypeSyntax.Keyword.IsKind(SyntaxKind.VoidKeyword))
 			{
 				return;
 			}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidPublicMemberVariableAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidPublicMemberVariableAnalyzer.cs
@@ -24,7 +24,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 	{
 		public override void Analyze()
 		{
-			if (Node.Parent.Kind() == SyntaxKind.StructDeclaration)
+			if (Node.Parent.IsKind(SyntaxKind.StructDeclaration))
 			{
 				return;
 			}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidStaticClassesAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidStaticClassesAnalyzer.cs
@@ -103,7 +103,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 				}
 			}
 
-			Location location = classDeclarationSyntax.Modifiers.First(t => t.Kind() == SyntaxKind.StaticKeyword).GetLocation();
+			Location location = classDeclarationSyntax.Modifiers.First(t => t.IsKind(SyntaxKind.StaticKeyword)).GetLocation();
 			var diagnostic = Diagnostic.Create(AvoidStaticClassesAnalyzer.Rule, location);
 			context.ReportDiagnostic(diagnostic);
 		}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidStaticMethodAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/AvoidStaticMethodAnalyzer.cs
@@ -83,7 +83,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 				return;
 			}
 
-			Location location = Node.Modifiers.First(t => t.Kind() == SyntaxKind.StaticKeyword).GetLocation();
+			Location location = Node.Modifiers.First(t => t.IsKind(SyntaxKind.StaticKeyword)).GetLocation();
 			ReportDiagnostic(location);
 		}
 

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/MergeIfStatementsAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Maintainability/MergeIfStatementsAnalyzer.cs
@@ -74,7 +74,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Maintainability
 
 		private bool IfConditionHasLogicalAnd(IfStatementSyntax ifStatement)
 		{
-			return ifStatement.Condition.DescendantTokens().Any((token) => { return token.Kind() == SyntaxKind.BarBarToken; });
+			return ifStatement.Condition.DescendantTokens().Any((token) => { return token.IsKind(SyntaxKind.BarBarToken); });
 		}
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/EnforceBoolNamingConventionAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/EnforceBoolNamingConventionAnalyzer.cs
@@ -232,12 +232,12 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 
 		private bool IsFieldPublic(FieldDeclarationSyntax fieldDeclaration)
 		{
-			return fieldDeclaration.Modifiers.Any(x => x.Kind() == SyntaxKind.PublicKeyword);
+			return fieldDeclaration.Modifiers.Any(x => x.IsKind(SyntaxKind.PublicKeyword));
 		}
 
 		private bool IsFieldConst(FieldDeclarationSyntax fieldDeclaration)
 		{
-			return fieldDeclaration.Modifiers.Any(x => x.Kind() == SyntaxKind.ConstKeyword);
+			return fieldDeclaration.Modifiers.Any(x => x.IsKind(SyntaxKind.ConstKeyword));
 		}
 	}
 }

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/VariableNamingConventionAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Naming/VariableNamingConventionAnalyzer.cs
@@ -92,7 +92,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Naming
 						{
 							var fieldDeclaration = (FieldDeclarationSyntax)variableDeclaration.Parent;
 
-							if (fieldDeclaration.Modifiers.Any(x => x.Kind() == SyntaxKind.PublicKeyword))
+							if (fieldDeclaration.Modifiers.Any(x => x.IsKind(SyntaxKind.PublicKeyword)))
 							{
 								continue;
 							}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/PreferNamedTuplesAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/PreferNamedTuplesAnalyzer.cs
@@ -28,7 +28,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 		{
 			foreach (TupleElementSyntax element in Node.Elements)
 			{
-				if (element.Identifier.Kind() == SyntaxKind.None)
+				if (element.Identifier.IsKind(SyntaxKind.None))
 				{
 					Location location = element.GetLocation();
 					ReportDiagnostic(location);

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/PreventUnnecessaryRangeChecksAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/Readability/PreventUnnecessaryRangeChecksAnalyzer.cs
@@ -102,7 +102,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.Readability
 				return false;
 			}
 
-			if (literal.Token.Kind() != SyntaxKind.NumericLiteralToken)
+			if (!literal.Token.IsKind(SyntaxKind.NumericLiteralToken))
 			{
 				return false;
 			}

--- a/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/DereferenceNullAnalyzer.cs
+++ b/Philips.CodeAnalysis.MaintainabilityAnalyzers/RuntimeFailure/DereferenceNullAnalyzer.cs
@@ -66,7 +66,7 @@ namespace Philips.CodeAnalysis.MaintainabilityAnalyzers.RuntimeFailure
 		{
 			var binaryExpressionSyntax = syntaxNode as BinaryExpressionSyntax;
 			return
-				(binaryExpressionSyntax == null || binaryExpressionSyntax.OperatorToken.Kind() == SyntaxKind.AsKeyword) &&
+				(binaryExpressionSyntax == null || binaryExpressionSyntax.OperatorToken.IsKind(SyntaxKind.AsKeyword)) &&
 				binaryExpressionSyntax != null &&
 				binaryExpressionSyntax.Parent is EqualsValueClauseSyntax equalsValueClauseSyntax &&
 				equalsValueClauseSyntax.Parent is VariableDeclaratorSyntax;

--- a/Philips.CodeAnalysis.MsTestAnalyzers/AvoidAssertConditionalAccessAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/AvoidAssertConditionalAccessAnalyzer.cs
@@ -50,7 +50,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 		private static bool InConditionalAccess(ArgumentSyntax argument)
 		{
-			return argument.DescendantNodes().Any(x => x.Kind() == SyntaxKind.ConditionalAccessExpression);
+			return argument.DescendantNodes().Any(x => x.IsKind(SyntaxKind.ConditionalAccessExpression));
 		}
 	}
 }

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodNameAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodNameAnalyzer.cs
@@ -35,7 +35,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			SyntaxNode methodNode = Node.Parent;
 
 			// Confirm this is actually a method...
-			if (methodNode.Kind() != SyntaxKind.MethodDeclaration)
+			if (!methodNode.IsKind(SyntaxKind.MethodDeclaration))
 			{
 				return;
 			}
@@ -43,7 +43,7 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 			var invalidPrefix = string.Empty;
 			foreach (SyntaxToken token in methodNode.ChildTokens())
 			{
-				if (token.Kind() == SyntaxKind.IdentifierToken)
+				if (token.IsKind(SyntaxKind.IdentifierToken))
 				{
 					if (token.ValueText.StartsWith(StringConstants.TestAttributeName))
 					{

--- a/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodNameCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/TestMethodNameCodeFixProvider.cs
@@ -39,14 +39,24 @@ namespace Philips.CodeAnalysis.MsTestAnalyzers
 
 			name += StringConstants.TestAttributeName;
 
-			// Get the symbol representing the type to be renamed.
+			// Get the symbol representing the method to be renamed.
 			SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken);
 			IMethodSymbol typeSymbol = semanticModel.GetDeclaredSymbol(node, cancellationToken);
 
-			// Produce a new solution that has all references to that type renamed, including the declaration.
-			Solution originalSolution = document.Project.Solution;
-			Microsoft.CodeAnalysis.Options.OptionSet optionSet = originalSolution.Workspace.Options;
-			Solution newSolution = await Renamer.RenameSymbolAsync(document.Project.Solution, typeSymbol, name, optionSet, cancellationToken).ConfigureAwait(false);
+			SymbolRenameOptions renameOptions = new()
+			{
+				RenameOverloads = false,
+				RenameInStrings = false,
+				RenameInComments = false,
+				RenameFile = false,
+			};
+
+			Solution newSolution = await Renamer.RenameSymbolAsync(
+				document.Project.Solution,
+				typeSymbol,
+				renameOptions,
+				name,
+				cancellationToken).ConfigureAwait(false);
 
 			// Return the new solution with the now-uppercase type name.
 			return newSolution;

--- a/Philips.CodeAnalysis.Test/Helpers/TestAnalyzerConfigOptionsProvider.cs
+++ b/Philips.CodeAnalysis.Test/Helpers/TestAnalyzerConfigOptionsProvider.cs
@@ -31,6 +31,8 @@ namespace Philips.CodeAnalysis.Test.Helpers
 			_options = new TestAnalyzerConfigOptions(settings);
 		}
 
+		public override AnalyzerConfigOptions GlobalOptions => _options;
+
 		public override AnalyzerConfigOptions GetOptions(SyntaxTree tree)
 		{
 			return _options;
@@ -41,5 +43,4 @@ namespace Philips.CodeAnalysis.Test.Helpers
 			return _options;
 		}
 	}
-
 }

--- a/Philips.CodeAnalysis.Test/Maintainability/Documentation/XmlDocumentationShouldAddValueAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Documentation/XmlDocumentationShouldAddValueAnalyzerTest.cs
@@ -60,6 +60,8 @@ public class Foo
 		public async Task DefaultWhiteSpaceWithBaseTest()
 		{
 			var content = $@"
+public class DoubleList : BaseList
+{{
 		/// <summary>
 		/// 
 		/// </summary>
@@ -67,13 +69,17 @@ public class Foo
 			: base(capacity)
 		{{
 		}}
+}}
 ";
 
 			var newContent = $@"
+public class DoubleList : BaseList
+{{
 		public DoubleList(int capacity)
 			: base(capacity)
 		{{
 		}}
+}}
 ";
 
 			await VerifyDiagnostic(content, DiagnosticId.EmptyXmlComments).ConfigureAwait(false);

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoRegionsInMethodAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/NoRegionsInMethodAnalyzerTest.cs
@@ -21,42 +21,42 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task NoRegionNoMethodTestAsync()
 		{
-			await VerifySuccessfulCompilation(@"Class C{C(){}}").ConfigureAwait(false);
+			await VerifySuccessfulCompilation(@"class C{C(){}}").ConfigureAwait(false);
 		}
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task NoRegionTestAsync()
 		{
-			await VerifySuccessfulCompilation(@"Class C{C(){}public void foo(){}}").ConfigureAwait(false);
+			await VerifySuccessfulCompilation(@"class C{C(){}public void foo(){}}").ConfigureAwait(false);
 		}
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task EmptyClassWithRegionTestAsync()
 		{
-			await VerifySuccessfulCompilation(@"Class C{	#region testRegion	#endregion	}").ConfigureAwait(false);
+			await VerifySuccessfulCompilation(@"class C{	#region testRegion	#endregion	}").ConfigureAwait(false);
 		}
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task RegionOutsideMethodTestAsync()
 		{
-			await VerifySuccessfulCompilation(@"Class C{#region testRegion	public void foo() {int x = 2; }	#endregion}").ConfigureAwait(false);
+			await VerifySuccessfulCompilation(@"class C{#region testRegion	public void foo() {int x = 2; }	#endregion}").ConfigureAwait(false);
 		}
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task RegionStartsAndEndsInMethodTestAsync()
 		{
-			await VerifyDiagnostic(@"Class C{	public void foo(){#region testRegion int x = 2;	#endregion }}").ConfigureAwait(false);
+			await VerifyDiagnostic(@"class C{	public void foo(){#region testRegion int x = 2;	#endregion }}").ConfigureAwait(false);
 		}
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task RegionStartsInMethodTestAsync()
 		{
-			await VerifyDiagnostic(@"Class C{ public void foo(){ #region testRegion int x = 2;}	#endregion
+			await VerifyDiagnostic(@"class C{ public void foo(){ #region testRegion int x = 2;}	#endregion
 
 	}").ConfigureAwait(false);
 		}
@@ -65,7 +65,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task RegionEndsInMethodTestAsync()
 		{
-			await VerifyDiagnostic(@"Class C{
+			await VerifyDiagnostic(@"class C{
 	#region testRegion
 	public void foo(){
 		int x = 2;
@@ -78,7 +78,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task RegionCoversMultipleMethodsTestAsync()
 		{
-			await VerifySuccessfulCompilation(@"Class C{	#region testRegion	public void foo(){	return;	} public void bar(){	}	#endregion	}").ConfigureAwait(false);
+			await VerifySuccessfulCompilation(@"class C{	#region testRegion	public void foo(){	return;	} public void bar(){	}	#endregion	}").ConfigureAwait(false);
 		}
 
 		[TestMethod]
@@ -92,7 +92,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task UnnamedRegionTestAsync()
 		{
-			await VerifySuccessfulCompilation(@"Class C{	#region #endregion	public void foo(){	return; }public void bar(){}	}").ConfigureAwait(false);
+			await VerifySuccessfulCompilation(@"class C{	#region #endregion	public void foo(){	return; }public void bar(){}	}").ConfigureAwait(false);
 		}
 
 		[TestMethod]
@@ -100,7 +100,7 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 		public async Task RegionStartsInOneMethodEndsInAnotherTestAsync()
 		{
 			await VerifyDiagnostic(@"
-Class C{
+class C{
 	#region 
 	public void foo(){
 		return;
@@ -118,7 +118,7 @@ Class C{
 		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task MalformedCodeTestAsync()
 		{
-			await VerifySuccessfulCompilation(@"Class C{	#region 	public void foo(){		return;	}	#endregion	public void bar(){	}	").ConfigureAwait(false);
+			await VerifySuccessfulCompilation(@"class C{	#region 	public void foo(){		return;	}	#endregion	public void bar(){	}	").ConfigureAwait(false);
 		}
 
 		[TestMethod]

--- a/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ProhibitDynamicKeywordAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/Maintainability/Maintainability/ProhibitDynamicKeywordAnalyzerTest.cs
@@ -24,12 +24,12 @@ namespace Philips.CodeAnalysis.Test.Maintainability.Maintainability
 
 		#region Public Interface
 
-		[DataRow(@"void TestMethod() { dynamic i = 5; }")]
-		[DataRow(@"dynamic TestMethod() { return 5; }")]
-		[DataRow(@"void TestMethod(dynamic i) { return 5; }")]
-		[DataRow(@"void TestMethod() { List<dynamic> list = null; }")]
-		[DataRow(@"void TestMethod() { var t = (dynamic)4; }")]
-		[DataRow(@"dynamic TestProperty { get; }")]
+		[DataRow(@"class C { void TestMethod() { dynamic i = 5; } }")]
+		[DataRow(@"class C { dynamic TestMethod() { return 5; } }")]
+		[DataRow(@"class C { void TestMethod(dynamic i) { return 5; } }")]
+		[DataRow(@"class C { void TestMethod() { List<dynamic> list = null; } }")]
+		[DataRow(@"class C { void TestMethod() { var t = (dynamic)4; } }")]
+		[DataRow(@"class C { dynamic TestProperty { get; } }")]
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task DynamicTypeShouldTriggerDiagnostic(string testCode)

--- a/Philips.CodeAnalysis.Test/Philips.CodeAnalysis.Test.csproj
+++ b/Philips.CodeAnalysis.Test/Philips.CodeAnalysis.Test.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.10.4" />

--- a/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.Helper.cs
+++ b/Philips.CodeAnalysis.Test/Verifiers/DiagnosticVerifier.Helper.cs
@@ -97,6 +97,8 @@ namespace Philips.CodeAnalysis.Test.Verifiers
 				_configOptions = new TestAnalyzerConfigOptions(options);
 			}
 
+			public override AnalyzerConfigOptions GlobalOptions => _configOptions;
+
 			public override AnalyzerConfigOptions GetOptions(SyntaxTree tree)
 			{
 				return _configOptions;

--- a/README.md
+++ b/README.md
@@ -28,18 +28,14 @@ Published packages include .snupkg and SourceLink. This allows symbol loading, s
 
 For symbols and stack traces, launch a second instance of Visual Studio, attach the debugger to your primary development instance, and Load Symbols via Debug -> Windows -> Modules, and right-clicking on the Analyzer.
 
-## Visual Studio 2019/2022 Support
+## Visual Studio Supported versions
 
-These packages reference Microsoft.CodeAnalysis version 3.6, which shipped with Visual Studio 2019 16.6.
+Visual Studio 2019 support was dropped in version 2.0.0 of these packages.
+The current minimum support version is Visual Studio 2022 17.4.
 
 ## MCP Server for Development
 
 A Model Context Protocol (MCP) server is available to automate common development tasks such as dogfooding builds, strict building, file navigation, and test execution. See [tools/mcp/MCP_SERVER.md](./tools/mcp/MCP_SERVER.md) for details.
-
-Quick start:
-```bash
-./tools/mcp/start_mcp_server.sh
-```
 
 ## CI/CD
 [Learn more](./cicd.md) about the CI/CD pipeline.


### PR DESCRIPTION
BREAKING CHANGE: End support for VS2019.