### PR TITLE
feat: add PH2161 PreferAssertHasCount and extend PH2160 auto-setup Dispose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+
+### Features
+
+* Add PH2161 PreferAssertHasCount analyzer and CodeFix: rewrites `Assert.AreEqual(x.Count, y.Count)` to `Assert.HasCount(x.Count, y)`
+* Extend PH2160 CodeFix with an alternative that inserts `mock.Protected().Setup("Dispose", ItExpr.IsAny<bool>()).CallBase();` when no `preferred_disposable_mock_type` is configured
+
+
+
 ## [2.1.0](https://github.com/philips-software/roslyn-analyzers/compare/v2.0.0...v2.1.0) (2026-04-23)
 
 

--- a/Documentation/Diagnostics/PH2161.md
+++ b/Documentation/Diagnostics/PH2161.md
@@ -1,0 +1,43 @@
+# PH2161: Prefer Assert.HasCount over Assert.AreEqual(x.Count, y.Count)
+
+| Property | Value  |
+|--|--|
+| Package | [Philips.CodeAnalysis.MsTestAnalyzers](https://www.nuget.org/packages/Philips.CodeAnalysis.MsTestAnalyzers) |
+| Diagnostic ID | PH2161 |
+| Category  | [MsTest](../MsTest.md) |
+| Analyzer | [PreferAssertHasCountAnalyzer](https://github.com/philips-software/roslyn-analyzers/blob/main/Philips.CodeAnalysis.MsTestAnalyzers/PreferAssertHasCountAnalyzer.cs) |
+| CodeFix  | Yes |
+| Severity | Info |
+| Enabled By Default | Yes |
+
+## Introduction
+
+This analyzer flags calls of the form `Assert.AreEqual(a.Count, b.Count)` and suggests using `Assert.HasCount(a.Count, b)` instead. Microsoft's MSTEST0037 does not flag this pattern because neither argument is a literal.
+
+## Reason
+
+`Assert.HasCount` produces a clearer failure message than comparing two integer counts, because it surfaces the actual collection contents in the diagnostic output.
+
+## How to fix violations
+
+Use `Assert.HasCount(expected.Count, actual)` and drop the `.Count` from the second argument. The CodeFix does this automatically.
+
+## Examples
+
+### Incorrect
+
+```csharp
+Assert.AreEqual(expected.Count, actual.Count);
+```
+
+### Correct
+
+```csharp
+Assert.HasCount(expected.Count, actual);
+```
+
+## Suppression
+
+```csharp
+[SuppressMessage("Philips.CodeAnalysis.MsTestAnalyzers", "PH2161:Prefer Assert.HasCount over Assert.AreEqual(x.Count, y.Count)", Justification = "Reviewed.")]
+```

--- a/Philips.CodeAnalysis.Common/DiagnosticId.cs
+++ b/Philips.CodeAnalysis.Common/DiagnosticId.cs
@@ -145,6 +145,7 @@ namespace Philips.CodeAnalysis.Common
 		AvoidUnlicensedPackages = 2155,
 		AvoidPkcsPaddingWithRsaEncryption = 2158,
 		AvoidUnnecessaryAttributeParentheses = 2159,
-		MockDisposableObjectsShouldSetupDispose = 2160
+		MockDisposableObjectsShouldSetupDispose = 2160,
+		PreferAssertHasCount = 2161
 	}
 }

--- a/Philips.CodeAnalysis.MoqAnalyzers/MockDisposableClassesShouldSetupDisposeCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MoqAnalyzers/MockDisposableClassesShouldSetupDisposeCodeFixProvider.cs
@@ -2,32 +2,77 @@
 
 using System.Collections.Immutable;
 using System.Composition;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Text;
 using Philips.CodeAnalysis.Common;
 
 namespace Philips.CodeAnalysis.MoqAnalyzers
 {
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MockDisposableClassesShouldSetupDisposeCodeFixProvider)), Shared]
-	public class MockDisposableClassesShouldSetupDisposeCodeFixProvider : SingleDiagnosticCodeFixProvider<ExpressionSyntax>
+	public class MockDisposableClassesShouldSetupDisposeCodeFixProvider : CodeFixProvider
 	{
-		protected override string Title => "Use configured disposable mock type";
+		private const string PreferredTypeTitle = "Use configured disposable mock type";
+		private const string ProtectedSetupTitle = "Insert Protected().Setup Dispose CallBase (local variables only; field/property initializers are not modified)";
+		private const string MoqProtectedNamespace = "Moq.Protected";
 
-		protected override DiagnosticId DiagnosticId => DiagnosticId.MockDisposableObjectsShouldSetupDispose;
+		public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DiagnosticId.MockDisposableObjectsShouldSetupDispose.ToId());
 
-		protected override async Task<Document> ApplyFix(Document document, ExpressionSyntax node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
+		public override FixAllProvider GetFixAllProvider()
 		{
-			var configuredTypeName = GetPreferredDisposableMockType(properties);
-			if (string.IsNullOrWhiteSpace(configuredTypeName))
+			return WellKnownFixAllProviders.BatchFixer;
+		}
+
+		public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+		{
+			SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+			if (root == null)
 			{
-				return document;
+				return;
 			}
 
+			Diagnostic diagnostic = context.Diagnostics.First();
+			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
+
+			SyntaxToken token = root.FindToken(diagnosticSpan.Start);
+			ExpressionSyntax node = token.Parent?.AncestorsAndSelf().OfType<ExpressionSyntax>()
+				.FirstOrDefault(e => e is ObjectCreationExpressionSyntax or ImplicitObjectCreationExpressionSyntax);
+
+			if (node == null)
+			{
+				return;
+			}
+
+			var configuredTypeName = GetPreferredDisposableMockType(diagnostic.Properties);
+
+			if (!string.IsNullOrWhiteSpace(configuredTypeName))
+			{
+				context.RegisterCodeFix(
+					CodeAction.Create(
+						title: PreferredTypeTitle,
+						createChangedDocument: c => ApplyPreferredTypeFix(context.Document, node, configuredTypeName, c),
+						equivalenceKey: PreferredTypeTitle),
+					diagnostic);
+			}
+
+			// Always offer the Protected().Setup("Dispose", ...).CallBase() alternative.
+			context.RegisterCodeFix(
+				CodeAction.Create(
+					title: ProtectedSetupTitle,
+					createChangedDocument: c => ApplyProtectedSetupFix(context.Document, node, c),
+					equivalenceKey: ProtectedSetupTitle),
+				diagnostic);
+		}
+
+		private static async Task<Document> ApplyPreferredTypeFix(Document document, ExpressionSyntax node, string configuredTypeName, CancellationToken cancellationToken)
+		{
 			SyntaxNode rootNode = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 			if (rootNode == null)
 			{
@@ -83,6 +128,145 @@ namespace Philips.CodeAnalysis.MoqAnalyzers
 			}
 
 			return document;
+		}
+
+		private static async Task<Document> ApplyProtectedSetupFix(Document document, ExpressionSyntax node, CancellationToken cancellationToken)
+		{
+			SyntaxNode rootNode = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+			if (rootNode == null)
+			{
+				return document;
+			}
+
+			ExpressionSyntax currentNode = FindCurrentNode<ExpressionSyntax>(rootNode, node);
+			if (currentNode == null)
+			{
+				return document;
+			}
+
+			// Identify the mock identifier from either local variable declaration or assignment.
+			(string mockIdentifier, StatementSyntax containingStatement) result = GetMockIdentifierAndStatement(currentNode);
+			var mockIdentifier = result.mockIdentifier;
+			StatementSyntax containingStatement = result.containingStatement;
+			if (mockIdentifier == null || containingStatement == null)
+			{
+				// Skip field/property initializers: too complex to safely insert in a constructor/TestInitialize.
+				return document;
+			}
+
+			StatementSyntax setupStatement = BuildProtectedSetupStatement(mockIdentifier)
+				.WithAdditionalAnnotations(Formatter.Annotation);
+
+			if (containingStatement.Parent is not BlockSyntax block)
+			{
+				return document;
+			}
+
+			SyntaxList<StatementSyntax> statements = block.Statements;
+			var index = statements.IndexOf(containingStatement);
+			if (index < 0)
+			{
+				return document;
+			}
+
+			SyntaxList<StatementSyntax> newStatements = statements.Insert(index + 1, setupStatement);
+			BlockSyntax newBlock = block.WithStatements(newStatements);
+
+			SyntaxNode newRoot = rootNode.ReplaceNode(block, newBlock);
+
+			// Ensure Moq.Protected using directive is present for ItExpr.
+			newRoot = EnsureUsingDirective(newRoot, MoqProtectedNamespace);
+
+			return document.WithSyntaxRoot(newRoot);
+		}
+
+		private static (string mockIdentifier, StatementSyntax containingStatement) GetMockIdentifierAndStatement(ExpressionSyntax currentNode)
+		{
+			if (currentNode.Parent is EqualsValueClauseSyntax equalsValueClause &&
+				equalsValueClause.Parent is VariableDeclaratorSyntax variableDeclarator &&
+				variableDeclarator.Parent is VariableDeclarationSyntax variableDeclaration &&
+				variableDeclaration.Parent is LocalDeclarationStatementSyntax localDeclaration)
+			{
+				return (variableDeclarator.Identifier.ValueText, localDeclaration);
+			}
+
+			if (currentNode.Parent is AssignmentExpressionSyntax assignment &&
+				assignment.Parent is ExpressionStatementSyntax expressionStatement &&
+				assignment.Left is IdentifierNameSyntax identifierName)
+			{
+				return (identifierName.Identifier.ValueText, expressionStatement);
+			}
+
+			if (currentNode.Parent is AssignmentExpressionSyntax assignmentMember &&
+				assignmentMember.Parent is ExpressionStatementSyntax expressionStatement2 &&
+				assignmentMember.Left is MemberAccessExpressionSyntax memberAccess)
+			{
+				return (memberAccess.ToString(), expressionStatement2);
+			}
+
+			return (null, null);
+		}
+
+		private static ExpressionStatementSyntax BuildProtectedSetupStatement(string mockIdentifier)
+		{
+			// mockIdentifier.Protected().Setup("Dispose", ItExpr.IsAny<bool>()).CallBase();
+			ExpressionSyntax mockExpression = SyntaxFactory.ParseExpression(mockIdentifier);
+
+			InvocationExpressionSyntax protectedInvocation = SyntaxFactory.InvocationExpression(
+				SyntaxFactory.MemberAccessExpression(
+					SyntaxKind.SimpleMemberAccessExpression,
+					mockExpression,
+					SyntaxFactory.IdentifierName("Protected")));
+
+			ArgumentListSyntax setupArgs = SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(new[]
+			{
+				SyntaxFactory.Argument(SyntaxFactory.LiteralExpression(
+					SyntaxKind.StringLiteralExpression,
+					SyntaxFactory.Literal("Dispose"))),
+				SyntaxFactory.Argument(SyntaxFactory.InvocationExpression(
+					SyntaxFactory.MemberAccessExpression(
+						SyntaxKind.SimpleMemberAccessExpression,
+						SyntaxFactory.IdentifierName("ItExpr"),
+						SyntaxFactory.GenericName(SyntaxFactory.Identifier("IsAny"))
+							.WithTypeArgumentList(SyntaxFactory.TypeArgumentList(
+								SyntaxFactory.SingletonSeparatedList<TypeSyntax>(
+									SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.BoolKeyword))))))))
+			}));
+
+			InvocationExpressionSyntax setupInvocation = SyntaxFactory.InvocationExpression(
+				SyntaxFactory.MemberAccessExpression(
+					SyntaxKind.SimpleMemberAccessExpression,
+					protectedInvocation,
+					SyntaxFactory.IdentifierName("Setup")),
+				setupArgs);
+
+			InvocationExpressionSyntax callBaseInvocation = SyntaxFactory.InvocationExpression(
+				SyntaxFactory.MemberAccessExpression(
+					SyntaxKind.SimpleMemberAccessExpression,
+					setupInvocation,
+					SyntaxFactory.IdentifierName("CallBase")),
+				SyntaxFactory.ArgumentList());
+
+			return SyntaxFactory.ExpressionStatement(callBaseInvocation);
+		}
+
+		private static SyntaxNode EnsureUsingDirective(SyntaxNode root, string namespaceName)
+		{
+			if (root is not CompilationUnitSyntax compilationUnit)
+			{
+				return root;
+			}
+
+			var alreadyExists = compilationUnit.Usings.Any(u => u.Name != null && u.Name.ToString() == namespaceName);
+			if (alreadyExists)
+			{
+				return root;
+			}
+
+			UsingDirectiveSyntax newUsing = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceName))
+				.WithAdditionalAnnotations(Formatter.Annotation);
+
+			return compilationUnit.AddUsings(newUsing);
 		}
 
 		private static TNode FindCurrentNode<TNode>(SyntaxNode rootNode, SyntaxNode originalNode)

--- a/Philips.CodeAnalysis.MsTestAnalyzers/Philips.CodeAnalysis.MsTestAnalyzers.md
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/Philips.CodeAnalysis.MsTestAnalyzers.md
@@ -38,5 +38,6 @@
 | [PH2059](../Documentation/Diagnostics/PH2059.md)  | Public Method should be TestMethod                   | Public methods inside a TestClass should either be a test method or non-public. | ✅ **Use [MSTEST0029](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0029)** |
 | [PH2076](../Documentation/Diagnostics/PH2076.md)  | Assert.Fail alternatives                             | Assert.Fail should not be used if an alternative is more appropriate | ⚠️ **Consider [MSTEST0025](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0025)** |
 | [PH2095](../Documentation/Diagnostics/PH2095.md)  | TestMethods must return void/Task for async methods  | TestMethods must return Task if they are async methods, or void if not | ⚠️ **Consider [MSTEST0003](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0003)** |
+| [PH2161](../Documentation/Diagnostics/PH2161.md)  | Prefer Assert.HasCount over Assert.AreEqual(x.Count, y.Count) | Assert.HasCount produces clearer failure messages than comparing two .Count values; MSTEST0037 does not cover this pattern. | 📌 **Keep** (Unique) |
 
 

--- a/Philips.CodeAnalysis.MsTestAnalyzers/PreferAssertHasCountAnalyzer.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/PreferAssertHasCountAnalyzer.cs
@@ -1,0 +1,83 @@
+﻿// © 2026 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Philips.CodeAnalysis.Common;
+
+namespace Philips.CodeAnalysis.MsTestAnalyzers
+{
+	/// <summary>
+	/// Flags <c>Assert.AreEqual(a.Count, b.Count)</c> patterns that Microsoft's MSTEST0037 does not cover,
+	/// recommending <c>Assert.HasCount(a.Count, b)</c> instead.
+	/// </summary>
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class PreferAssertHasCountAnalyzer : AssertMethodCallDiagnosticAnalyzer
+	{
+		private const string Title = @"Prefer Assert.HasCount over Assert.AreEqual(x.Count, y.Count)";
+		private const string MessageFormat = @"Prefer Assert.HasCount(expected.Count, actual) over Assert.AreEqual on two .Count expressions";
+		private const string Description = @"When both arguments to Assert.AreEqual end in .Count, Assert.HasCount provides a clearer failure message.";
+		private const string Category = Categories.MsTest;
+		private const string CountMemberName = "Count";
+
+		private static readonly DiagnosticDescriptor Rule = new(
+			DiagnosticId.PreferAssertHasCount.ToId(),
+			Title,
+			MessageFormat,
+			Category,
+			DiagnosticSeverity.Info,
+			isEnabledByDefault: true,
+			description: Description,
+			helpLinkUri: DiagnosticId.PreferAssertHasCount.ToHelpLinkUrl());
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		protected override IEnumerable<Diagnostic> Analyze(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocationExpressionSyntax, MemberAccessExpressionSyntax memberAccessExpression)
+		{
+			var memberName = memberAccessExpression.Name switch
+			{
+				GenericNameSyntax generic => generic.Identifier.ToString(),
+				SimpleNameSyntax name => name.ToString()
+			};
+
+			if (memberName != StringConstants.AreEqualMethodName)
+			{
+				return Array.Empty<Diagnostic>();
+			}
+
+			SymbolInfo symbolInfo = context.SemanticModel.GetSymbolInfo(memberAccessExpression);
+			ISymbol symbol = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
+			if ((symbol is not IMethodSymbol memberSymbol) || !memberSymbol.ToString().StartsWith(StringConstants.AssertFullyQualifiedName))
+			{
+				return Array.Empty<Diagnostic>();
+			}
+
+			ArgumentListSyntax argumentList = invocationExpressionSyntax.ArgumentList;
+			if (argumentList == null || argumentList.Arguments.Count < 2)
+			{
+				return Array.Empty<Diagnostic>();
+			}
+
+			if (!IsCountMemberAccess(argumentList.Arguments[0].Expression) ||
+				!IsCountMemberAccess(argumentList.Arguments[1].Expression))
+			{
+				return Array.Empty<Diagnostic>();
+			}
+
+			Location location = invocationExpressionSyntax.GetLocation();
+			var diagnostic = Diagnostic.Create(Rule, location);
+			return new[] { diagnostic };
+		}
+
+		private static bool IsCountMemberAccess(ExpressionSyntax expression)
+		{
+			return expression is MemberAccessExpressionSyntax memberAccess &&
+				memberAccess.Name.Identifier.ValueText == CountMemberName;
+		}
+	}
+}

--- a/Philips.CodeAnalysis.MsTestAnalyzers/PreferAssertHasCountCodeFixProvider.cs
+++ b/Philips.CodeAnalysis.MsTestAnalyzers/PreferAssertHasCountCodeFixProvider.cs
@@ -1,0 +1,79 @@
+﻿// © 2026 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Philips.CodeAnalysis.Common;
+using Document = Microsoft.CodeAnalysis.Document;
+
+namespace Philips.CodeAnalysis.MsTestAnalyzers
+{
+	/// <summary>
+	/// Rewrites <c>Assert.AreEqual(expected.Count, actual.Count)</c> to
+	/// <c>Assert.HasCount(expected.Count, actual)</c>.
+	/// </summary>
+	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(PreferAssertHasCountCodeFixProvider)), Shared]
+	public class PreferAssertHasCountCodeFixProvider : SingleDiagnosticCodeFixProvider<InvocationExpressionSyntax>
+	{
+		private const string HasCountMethodName = "HasCount";
+
+		protected override string Title => "Use Assert.HasCount";
+
+		protected override DiagnosticId DiagnosticId => DiagnosticId.PreferAssertHasCount;
+
+		protected override async Task<Document> ApplyFix(Document document, InvocationExpressionSyntax node, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
+		{
+			SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+			if (root == null || node == null)
+			{
+				return document;
+			}
+
+			if (node.Expression is not MemberAccessExpressionSyntax memberAccess)
+			{
+				return document;
+			}
+
+			ArgumentListSyntax argumentList = node.ArgumentList;
+			if (argumentList == null || argumentList.Arguments.Count < 2)
+			{
+				return document;
+			}
+
+			if (argumentList.Arguments[1].Expression is not MemberAccessExpressionSyntax secondMemberAccess)
+			{
+				return document;
+			}
+
+			MemberAccessExpressionSyntax newMemberAccess = memberAccess.WithName(
+				SyntaxFactory.IdentifierName(HasCountMethodName).WithTriviaFrom(memberAccess.Name));
+
+			ArgumentSyntax firstArgument = argumentList.Arguments[0];
+			ArgumentSyntax secondArgument = argumentList.Arguments[1];
+
+			ExpressionSyntax strippedCollection = secondMemberAccess.Expression.WithTriviaFrom(secondMemberAccess);
+			ArgumentSyntax newSecondArgument = secondArgument.WithExpression(strippedCollection);
+
+			var newArguments = new List<ArgumentSyntax> { firstArgument, newSecondArgument };
+			for (var i = 2; i < argumentList.Arguments.Count; i++)
+			{
+				newArguments.Add(argumentList.Arguments[i]);
+			}
+
+			ArgumentListSyntax newArgumentList = argumentList.WithArguments(SyntaxFactory.SeparatedList(newArguments));
+
+			InvocationExpressionSyntax newInvocation = node
+				.WithExpression(newMemberAccess)
+				.WithArgumentList(newArgumentList);
+
+			SyntaxNode newRoot = root.ReplaceNode(node, newInvocation);
+			return document.WithSyntaxRoot(newRoot);
+		}
+	}
+}

--- a/Philips.CodeAnalysis.Test/Moq/MockDisposableClassesShouldSetupDisposeCodeFixProviderTest.cs
+++ b/Philips.CodeAnalysis.Test/Moq/MockDisposableClassesShouldSetupDisposeCodeFixProviderTest.cs
@@ -327,6 +327,35 @@ namespace MyNamespace
 
 		[TestMethod]
 		[TestCategory(TestDefinitions.UnitTests)]
+		public async Task ProtectedSetupFixIsAlwaysOfferedAsSecondOptionAsync()
+		{
+			const string template = @"
+		using Moq;
+
+		class Foo
+		{
+			public void Test()
+			{
+				Mock<DisposableClass> mock = new Mock<DisposableClass>();
+			}
+		}";
+			const string expected = @"
+		using Moq;
+		using Moq.Protected;
+
+		class Foo
+		{
+			public void Test()
+			{
+				Mock<DisposableClass> mock = new Mock<DisposableClass>();
+				mock.Protected().Setup(""Dispose"", ItExpr.IsAny<bool>()).CallBase();
+			}
+		}";
+			await VerifyFix(template, expected, codeFixIndex: 1, shouldAllowNewCompilerDiagnostics: true).ConfigureAwait(false);
+		}
+
+		[TestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
 		public async Task AutoPropertyInitializerMockTypeIsReplacedAsync()
 		{
 			const string template = @"
@@ -344,6 +373,96 @@ namespace MyNamespace
 					public MyNamespace.DisposableObjectMock<DisposableClass> Dependency { get; } = new MyNamespace.DisposableObjectMock<DisposableClass>();
 				}";
 			await VerifyFix(template, expected, null, shouldAllowNewCompilerDiagnostics: true).ConfigureAwait(false);
+		}
+	}
+
+	[TestClass]
+	public class MockDisposableClassesShouldSetupDisposeCodeFixProviderNoPreferredTypeTest : CodeFixVerifier
+	{
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
+		{
+			return new MockDisposableClassesShouldSetupDisposeAnalyzer();
+		}
+
+		protected override CodeFixProvider GetCodeFixProvider()
+		{
+			return new MockDisposableClassesShouldSetupDisposeCodeFixProvider();
+		}
+
+		protected override ImmutableArray<MetadataReference> GetMetadataReferences()
+		{
+			var mockReference = typeof(Mock<>).Assembly.Location;
+			MetadataReference reference = MetadataReference.CreateFromFile(mockReference);
+			return base.GetMetadataReferences().Add(reference);
+		}
+
+		protected override ImmutableArray<(string name, string content)> GetAdditionalSourceCode()
+		{
+			return base.GetAdditionalSourceCode()
+				.Add(("DisposableClass.cs", @"
+using System;
+
+class DisposableClass : IDisposable
+{
+	public void Dispose()
+	{
+		Dispose(true);
+		GC.SuppressFinalize(this);
+	}
+
+	protected virtual void Dispose(bool disposing)
+	{
+	}
+}"));
+		}
+
+		protected override void AssertFixAllProvider(FixAllProvider fixAllProvider)
+		{
+			Assert.IsTrue(fixAllProvider.GetSupportedFixAllScopes().Contains(FixAllScope.Document));
+		}
+
+		[TestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public async Task ProtectedSetupInsertedAfterMockDeclarationAsync()
+		{
+			const string template = @"
+		using Moq;
+
+		class Foo
+		{
+			public void Test()
+			{
+				Mock<DisposableClass> mock = new Mock<DisposableClass>();
+			}
+		}";
+			const string expected = @"
+		using Moq;
+		using Moq.Protected;
+
+		class Foo
+		{
+			public void Test()
+			{
+				Mock<DisposableClass> mock = new Mock<DisposableClass>();
+				mock.Protected().Setup(""Dispose"", ItExpr.IsAny<bool>()).CallBase();
+			}
+		}";
+			await VerifyFix(template, expected, null, shouldAllowNewCompilerDiagnostics: true).ConfigureAwait(false);
+		}
+
+		[TestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public async Task ProtectedSetupSkipsFieldInitializerAsync()
+		{
+			const string template = @"
+		using Moq;
+
+		class Foo
+		{
+			private readonly Mock<DisposableClass> _mock = new Mock<DisposableClass>();
+		}";
+			// Field initializers are not modified by the Protected-setup fix; expect no changes.
+			await VerifyFix(template, template, null, shouldAllowNewCompilerDiagnostics: true).ConfigureAwait(false);
 		}
 	}
 }

--- a/Philips.CodeAnalysis.Test/MsTest/PreferAssertHasCountAnalyzerTest.cs
+++ b/Philips.CodeAnalysis.Test/MsTest/PreferAssertHasCountAnalyzerTest.cs
@@ -1,0 +1,112 @@
+﻿// © 2026 Koninklijke Philips N.V. See License.md in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Philips.CodeAnalysis.Common;
+using Philips.CodeAnalysis.MsTestAnalyzers;
+using Philips.CodeAnalysis.Test.Helpers;
+using Philips.CodeAnalysis.Test.Verifiers;
+
+namespace Philips.CodeAnalysis.Test.MsTest
+{
+	[TestClass]
+	public class PreferAssertHasCountAnalyzerTest : AssertCodeFixVerifier
+	{
+		protected override DiagnosticResult GetExpectedDiagnostic(int expectedLineNumberErrorOffset = 0, int expectedColumnErrorOffset = 0)
+		{
+			return new DiagnosticResult()
+			{
+				Id = DiagnosticId.PreferAssertHasCount.ToId(),
+				Location = new DiagnosticResultLocation("Test0.cs", null, null),
+				Severity = Microsoft.CodeAnalysis.DiagnosticSeverity.Info,
+			};
+		}
+
+		protected override DiagnosticAnalyzer GetDiagnosticAnalyzer()
+		{
+			return new PreferAssertHasCountAnalyzer();
+		}
+
+		protected override CodeFixProvider GetCodeFixProvider()
+		{
+			return new PreferAssertHasCountCodeFixProvider();
+		}
+
+		[TestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public async Task FlagsAreEqualWithTwoCountArguments()
+		{
+			var body = @"
+var expected = new System.Collections.Generic.List<int>();
+var actual = new System.Collections.Generic.List<int>();
+Assert.AreEqual(expected.Count, actual.Count);
+";
+			var expected = @"
+var expected = new System.Collections.Generic.List<int>();
+var actual = new System.Collections.Generic.List<int>();
+Assert.HasCount(expected.Count, actual);
+";
+			await VerifyChange(body, expected, shouldAllowNewCompilerDiagnostics: true).ConfigureAwait(false);
+		}
+
+		[TestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public async Task FlagsAreEqualWithNestedCountArguments()
+		{
+			var body = @"
+var a = new { Foo = new System.Collections.Generic.List<int>() };
+var b = new { Bar = new System.Collections.Generic.List<int>() };
+Assert.AreEqual(a.Foo.Count, b.Bar.Count);
+";
+			var expected = @"
+var a = new { Foo = new System.Collections.Generic.List<int>() };
+var b = new { Bar = new System.Collections.Generic.List<int>() };
+Assert.HasCount(a.Foo.Count, b.Bar);
+";
+			await VerifyChange(body, expected, shouldAllowNewCompilerDiagnostics: true).ConfigureAwait(false);
+		}
+
+		[TestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public async Task DoesNotFlagWhenSecondArgumentIsNotCountMemberAccess()
+		{
+			var body = @"
+var expected = new System.Collections.Generic.List<int>();
+int actualCount = 0;
+Assert.AreEqual(expected.Count, actualCount);
+";
+			await VerifyNoError(body).ConfigureAwait(false);
+		}
+
+		[TestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public async Task DoesNotFlagWhenFirstArgumentIsNotCountMemberAccess()
+		{
+			var body = @"
+int expectedCount = 0;
+var actual = new System.Collections.Generic.List<int>();
+Assert.AreEqual(expectedCount, actual.Count);
+";
+			await VerifyNoError(body).ConfigureAwait(false);
+		}
+
+		[TestMethod]
+		[TestCategory(TestDefinitions.UnitTests)]
+		public async Task PreservesTrailingMessageArgument()
+		{
+			var body = @"
+var expected = new System.Collections.Generic.List<int>();
+var actual = new System.Collections.Generic.List<int>();
+Assert.AreEqual(expected.Count, actual.Count, ""message"");
+";
+			var fixedBody = @"
+var expected = new System.Collections.Generic.List<int>();
+var actual = new System.Collections.Generic.List<int>();
+Assert.HasCount(expected.Count, actual, ""message"");
+";
+			await VerifyChange(body, fixedBody, shouldAllowNewCompilerDiagnostics: true).ConfigureAwait(false);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **PH2161 PreferAssertHasCount** (new): analyzer + code fix that rewrites `Assert.AreEqual(x.Count, y.Count)` to `Assert.HasCount(x.Count, y)`. Microsoft's MSTEST0037 does not flag this pattern because neither argument is a literal. Category: `Philips MsTest`; severity: Info; enabled by default. Preserves any trailing message argument.
- **PH2160 code fix extension**: adds an always-available alternative action that inserts `mock.Protected().Setup(""Dispose"", ItExpr.IsAny<bool>()).CallBase();` immediately after the `Mock<T>` declaration (and adds `using Moq.Protected;` when missing). The existing "Use configured disposable mock type" fix remains the first option when `preferred_disposable_mock_type` is configured. Field and property initializers are intentionally not modified by the new fix (limitation noted in the fix title).

Files added: `Philips.CodeAnalysis.MsTestAnalyzers/PreferAssertHasCountAnalyzer.cs`, `Philips.CodeAnalysis.MsTestAnalyzers/PreferAssertHasCountCodeFixProvider.cs`, `Documentation/Diagnostics/PH2161.md`, `Philips.CodeAnalysis.Test/MsTest/PreferAssertHasCountAnalyzerTest.cs`.

Files modified: `CHANGELOG.md` (new Unreleased section), `Philips.CodeAnalysis.Common/DiagnosticId.cs` (new `PreferAssertHasCount = 2161`), `Philips.CodeAnalysis.MoqAnalyzers/MockDisposableClassesShouldSetupDisposeCodeFixProvider.cs`, `Philips.CodeAnalysis.MsTestAnalyzers/Philips.CodeAnalysis.MsTestAnalyzers.md`, `Philips.CodeAnalysis.Test/Moq/MockDisposableClassesShouldSetupDisposeCodeFixProviderTest.cs`.

## Test plan

- [x] `dotnet build Philips.CodeAnalysis.sln` — succeeds with no warnings
- [x] `dotnet test Philips.CodeAnalysis.sln` — all 2329 tests pass
- [x] New `PreferAssertHasCountAnalyzerTest` covers: basic rewrite, nested `a.Foo.Count`, not-a-.Count second arg (no diagnostic), not-a-.Count first arg (no diagnostic), and message preservation
- [x] New `MockDisposableClassesShouldSetupDisposeCodeFixProviderNoPreferredTypeTest` covers: Protected+Setup+CallBase insertion for local variable case, field initializer skip
- [x] Existing PH2160 tests still pass with the reordered / new code fix actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)